### PR TITLE
Separate console features and fix N64 address bug

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -172,6 +172,11 @@ static int g_n64_optionc = 0;
 static int g_n64_collecting = 0;
 static int g_n64_cache_ready = 0;
 static int g_n64_needs_recollect = 0;
+static int g_n64_resolve_pass = 0;
+static int g_n64_resolve_cooldown = 0;
+static void *g_n64_rdram_direct = NULL;
+static uint8_t *g_n64_progress_buf = NULL;
+static size_t   g_n64_progress_size = 0;
 static uint32_t g_n64_last_resp_frame = 0;
 static uint32_t g_n64_game_frames = 0;
 static uint32_t g_n64_poll_logged = 0;
@@ -778,42 +783,52 @@ static uint32_t ra_read_memory(uint32_t address, uint8_t *buffer,
 			}
 			memset(buffer, 0, num_bytes);
 			return num_bytes;
-		case 2: // RC_CONSOLE_NINTENDO_64 (N64)
-			// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is
-			// little-endian within 32-bit words.  XOR 3 on the low 2 bits
-			// converts between the two byte orders.
-			if (g_n64_optionc) {
-				if (g_n64_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(((address + i) ^ 3));
-				}
-				if (g_n64_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, ((address + i) ^ 3));
+			case 2: // RC_CONSOLE_NINTENDO_64 (N64)
+				// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is
+				// little-endian within 32-bit words.  XOR 3 on the low 2 bits
+				// converts between the two byte orders.
+				if (g_n64_optionc) {
+					if (g_n64_collecting) {
+						for (uint32_t i = 0; i < num_bytes; i++)
+							ra_snes_addrlist_add(((address + i) ^ 3));
+					}
+					// Always prefer direct RDRAM reads for consistency
+					// (avoids mixing stale FPGA cache with live RDRAM values)
+					if (g_n64_rdram_direct) {
+						const uint8_t *rdram = (const uint8_t *)g_n64_rdram_direct;
+						for (uint32_t i = 0; i < num_bytes; i++) {
+							uint32_t ddr_addr = (address + i) ^ 3;
+							buffer[i] = (ddr_addr < 0x800000) ? rdram[ddr_addr] : 0;
+						}
+						return num_bytes;
+					}
+					if (g_n64_cache_ready) {
+						for (uint32_t i = 0; i < num_bytes; i++)
+							buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, ((address + i) ^ 3));
+						return num_bytes;
+					}
+					memset(buffer, 0, num_bytes);
 					return num_bytes;
 				}
 				memset(buffer, 0, num_bytes);
 				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-		case 11: // RC_CONSOLE_MASTER_SYSTEM
-		case 15: // RC_CONSOLE_GAME_GEAR
-			if (g_sms_optionc) {
-				if (g_sms_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_sms_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
+			case 11: // RC_CONSOLE_MASTER_SYSTEM
+			case 15: // RC_CONSOLE_GAME_GEAR
+				if (g_sms_optionc) {
+					if (g_sms_collecting) {
+						for (uint32_t i = 0; i < num_bytes; i++)
+							ra_snes_addrlist_add(address + i);
+					}
+					if (g_sms_cache_ready) {
+						for (uint32_t i = 0; i < num_bytes; i++)
+							buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
+						return num_bytes;
+					}
+					memset(buffer, 0, num_bytes);
 					return num_bytes;
 				}
 				memset(buffer, 0, num_bytes);
 				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
 		case 5:  // RC_CONSOLE_GAMEBOY_ADVANCE
 			if (g_gba_optionc) {
 				if (g_gba_collecting) {
@@ -1211,7 +1226,7 @@ void achievements_init(void)
 	signal(SIGFPE,  ra_crash_handler);
 
 	RA_LOG("=== RetroAchievements for MiSTer ===");
-	RA_LOG("Build: OptionC v21-n64xor3arm (2026-04-14)");
+	RA_LOG("Build: OptionC v28-b4 (2026-04-18)");
 	RA_LOG("Phase 3 — Full pipeline: HTTP + login + achievements");
 
 	const char *core = user_io_get_core_name(1);
@@ -1387,6 +1402,11 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 	g_n64_collecting = 0;
 	g_n64_cache_ready = 0;
 	g_n64_needs_recollect = 0;
+	g_n64_resolve_pass = 0;
+	g_n64_resolve_cooldown = 0;
+	if (g_n64_rdram_direct) { shmem_unmap(g_n64_rdram_direct, 0x800000); g_n64_rdram_direct = NULL; }
+	if (g_n64_progress_buf) { free(g_n64_progress_buf); g_n64_progress_buf = NULL; }
+	g_n64_progress_size = 0;
 	g_n64_last_resp_frame = 0;
 	g_n64_game_frames = 0;
 	g_n64_poll_logged = 0;
@@ -2016,15 +2036,36 @@ void achievements_poll(void)
 	// N64: Option C — selective address reading
 	// ================================================================
 	if (g_client && g_game_loaded && ra_get_console_id() == 2 && g_n64_optionc) {
+		// Ensure direct RDRAM mapping is available for fallback reads
+		if (!g_n64_rdram_direct) {
+			g_n64_rdram_direct = shmem_map(0x30000000, 0x800000);
+			if (g_n64_rdram_direct)
+				RA_LOG("N64 OptionC: Direct RDRAM mapped for fallback reads");
+			else
+				RA_LOG("N64 OptionC: WARNING - failed to map RDRAM for fallback!");
+		}
 		if (ra_snes_addrlist_count() == 0 && !g_n64_cache_ready) {
 			// Phase 1: Bootstrap — collect addresses with zero values
+			// Save rcheevos state before collection to prevent delta corruption
+			size_t psize = rc_client_progress_size(g_client);
+			if (psize > g_n64_progress_size) {
+				free(g_n64_progress_buf);
+				g_n64_progress_buf = (uint8_t *)malloc(psize);
+				g_n64_progress_size = psize;
+			}
+			if (g_n64_progress_buf)
+				rc_client_serialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
 			g_n64_collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(g_client);
 			g_n64_collecting = 0;
+			// Restore state (undo delta/hit changes from zero-value reads)
+			if (g_n64_progress_buf)
+				rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
 			int changed = ra_snes_addrlist_end_collect(g_ra_map);
 			if (changed) {
 				g_n64_needs_recollect = 1; // schedule pointer-resolution pass
+				g_n64_resolve_pass = 0;
 				RA_LOG("N64 OptionC: Bootstrap collection done, %d addrs written to DDRAM",
 					ra_snes_addrlist_count());
 			} else {
@@ -2034,30 +2075,52 @@ void achievements_poll(void)
 			// Phase 2/4: Wait for FPGA cache
 			if (ra_snes_addrlist_is_ready(g_ra_map)) {
 				g_n64_cache_ready = 1;
-				g_n64_last_resp_frame = 0;
-				g_n64_game_frames = 0;
-				g_n64_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_n64_cache_time);
 				if (g_n64_needs_recollect) {
 					RA_LOG("N64 OptionC: Cache active (pre-recollect). Will resolve pointers.");
 				} else {
-					RA_LOG("N64 OptionC: Cache active! FPGA response matched request.");
+					if (g_n64_game_frames == 0) {
+						// First activation after bootstrap
+						g_n64_last_resp_frame = 0;
+						g_n64_poll_logged = 0;
+						clock_gettime(CLOCK_MONOTONIC, &g_n64_cache_time);
+						RA_LOG("N64 OptionC: Cache active! FPGA response matched request.");
+					} else {
+						RA_LOG("N64 OptionC: Resolution complete, resuming (%d addrs)",
+							ra_snes_addrlist_count());
+					}
+					// Restore rcheevos state saved before resolution began
+					if (g_n64_progress_buf)
+						rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
+					g_n64_resolve_cooldown = 30;
+					RA_LOG("N64 OptionC: State restored via Phase 2, cooldown=30");
 				}
 			}
 		} else if (g_n64_needs_recollect) {
-			// Phase 3: Pointer-resolution re-collection
-			g_n64_needs_recollect = 0;
+			// Phase 3: Iterative pointer-resolution (multi-pass for AddAddress chains)
+			g_n64_resolve_pass++;
 			g_n64_collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(g_client);
 			g_n64_collecting = 0;
 			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("N64 OptionC: Pointer-resolve re-collection done, %d addrs (was different!)",
-					ra_snes_addrlist_count());
-				g_n64_cache_ready = 0; // wait for new FPGA data with correct addresses
+			if (changed && g_n64_resolve_pass < 4) {
+				RA_LOG("N64 OptionC: Pass %d found new addrs, %d total - re-resolving",
+					g_n64_resolve_pass, ra_snes_addrlist_count());
+				g_n64_cache_ready = 0; // wait for FPGA to respond with new addresses
 			} else {
-				RA_LOG("N64 OptionC: Pointer-resolve complete, no address changes");
+				RA_LOG("N64 OptionC: Pointer-resolution %s after %d passes, %d addrs",
+					changed ? "done (max passes)" : "stable",
+					g_n64_resolve_pass, ra_snes_addrlist_count());
+				g_n64_needs_recollect = 0;
+				if (changed) {
+					g_n64_cache_ready = 0; // need final FPGA response (Phase 2 will deserialize)
+				} else {
+					// Stable: restore state directly since Phase 2 is skipped (cache_ready stays 1)
+					if (g_n64_progress_buf)
+						rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
+					g_n64_resolve_cooldown = 30;
+					RA_LOG("N64 OptionC: State restored after stable resolution, cooldown=30");
+				}
 			}
 		} else {
 			// Phase 5: Normal frame processing
@@ -2141,25 +2204,39 @@ void achievements_poll(void)
 					}
 				}
 
-				// Re-collect every 600 frames (~10s) to track pointer changes
-				int re_collect = (g_n64_game_frames % 600 == 0) && (g_n64_game_frames > 0);
-				if (re_collect) {
-					RA_LOG("N64 OptionC: Re-collect starting at game_frame=%u",
-						g_n64_game_frames);
+				if (g_n64_resolve_cooldown > 0) {
+					// Cooldown: evaluate normally without collection to avoid oscillation
+					g_n64_resolve_cooldown--;
+					rc_client_do_frame(g_client);
+				} else {
+					// Per-frame collection: detect pointer changes
+					// Pre-serialize state (in case pointer change corrupts evaluation)
+					{
+						size_t psize = rc_client_progress_size(g_client);
+						if (psize > g_n64_progress_size) {
+							free(g_n64_progress_buf);
+							g_n64_progress_buf = (uint8_t *)malloc(psize);
+							g_n64_progress_size = psize;
+						}
+						if (g_n64_progress_buf)
+							rc_client_serialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
+					}
+
+					// Combined collection + evaluation
 					g_n64_collecting = 1;
 					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
+					rc_client_do_frame(g_client);
 					g_n64_collecting = 0;
+
 					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("N64 OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-						g_n64_cache_ready = 0; // wait for new FPGA data
-					} else {
-						RA_LOG("N64 OptionC: Re-collect done, no address changes");
+						// Pointer change: evaluation used stale data, roll back
+						if (g_n64_progress_buf)
+							rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
+						RA_LOG("N64 OptionC: Pointer change detected at game_frame=%u, %d addrs",
+							g_n64_game_frames, ra_snes_addrlist_count());
+						g_n64_cache_ready = 0;
+						g_n64_needs_recollect = 1;
+						g_n64_resolve_pass = 0;
 					}
 				}
 			}

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -1,0 +1,80 @@
+#ifndef ACHIEVEMENTS_CONSOLE_H
+#define ACHIEVEMENTS_CONSOLE_H
+
+#include <stdint.h>
+#include <time.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#endif
+
+// Common console state structure for Option C consoles
+typedef struct {
+	int optionc;              // 1 if FPGA has Option C protocol
+	int collecting;           // 1 during address collection do_frame
+	int cache_ready;          // 1 when FPGA response matches request
+	int needs_recollect;      // 1 if re-collection needed (PSX/N64)
+	uint32_t last_resp_frame; // Last processed response frame
+	uint32_t game_frames;     // Frames processed since cache active
+	uint32_t poll_logged;     // Last game_frames milestone logged
+	struct timespec cache_time; // Timestamp when cache became active
+} console_state_t;
+
+// Console-specific interface
+typedef struct {
+	// Initialize console-specific state
+	void (*init)(void);
+	
+	// Reset console state (called on load_game)
+	void (*reset)(void);
+	
+	// Read memory for this console
+	uint32_t (*read_memory)(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
+	
+	// Poll achievements for this console (called every frame)
+	void (*poll)(void *map, void *client, int game_loaded);
+	
+	// Calculate ROM hash (NULL = use default MD5)
+	int (*calculate_hash)(const char *rom_path, char *md5_hex_out);
+	
+	// Set hardcore mode bits (NULL = no hardcore mode support)
+	void (*set_hardcore)(int enabled);
+	
+	// Get console ID (RC_CONSOLE_*)
+	int console_id;
+	
+	// Console name
+	const char *name;
+} console_handler_t;
+
+// Console handlers (implemented in separate files)
+extern const console_handler_t g_console_nes;
+extern const console_handler_t g_console_snes;
+extern const console_handler_t g_console_genesis;
+extern const console_handler_t g_console_psx;
+extern const console_handler_t g_console_n64;
+extern const console_handler_t g_console_gameboy;
+extern const console_handler_t g_console_gba;
+extern const console_handler_t g_console_sms;
+extern const console_handler_t g_console_neogeo;
+
+// Get console handler by name (returns NULL if not found)
+const console_handler_t *get_console_handler_by_name(const char *core_name);
+
+// Get console handler by ID (returns NULL if not found)
+const console_handler_t *get_console_handler_by_id(int console_id);
+
+// Initialize all console handlers (called once at startup)
+void init_all_console_handlers(void);
+
+// Declare protocol detection functions (called from main achievements code)
+void snes_detect_protocol(void *map);
+void genesis_detect_protocol(void *map);
+void psx_detect_protocol(void *map);
+void n64_detect_protocol(void *map);
+void gameboy_detect_protocol(void *map);
+void gba_detect_protocol(void *map);
+void sms_detect_protocol(void *map);
+void neogeo_detect_protocol(void *map);
+
+#endif // ACHIEVEMENTS_CONSOLE_H

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -17,6 +17,7 @@ typedef struct {
 	uint32_t last_resp_frame; // Last processed response frame
 	uint32_t game_frames;     // Frames processed since cache active
 	uint32_t poll_logged;     // Last game_frames milestone logged
+	int resolve_pass;         // Current pointer-resolution pass number
 	struct timespec cache_time; // Timestamp when cache became active
 } console_state_t;
 

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -1,0 +1,82 @@
+// achievements_console_lookup.cpp — Console handler lookup table
+
+#include "achievements_console.h"
+#include <string.h>
+#include <strings.h>
+
+// Console handlers from separate files
+extern const console_handler_t g_console_nes;
+extern const console_handler_t g_console_snes;
+extern const console_handler_t g_console_genesis;
+extern const console_handler_t g_console_psx;
+extern const console_handler_t g_console_n64;
+extern const console_handler_t g_console_gameboy;
+extern const console_handler_t g_console_gba;
+extern const console_handler_t g_console_sms;
+extern const console_handler_t g_console_neogeo;
+
+// Master lookup table
+static const console_handler_t *g_console_handlers[] = {
+	&g_console_nes,
+	&g_console_snes,
+	&g_console_genesis,
+	&g_console_psx,
+	&g_console_n64,
+	&g_console_gameboy,
+	&g_console_gba,
+	&g_console_sms,
+	&g_console_neogeo,
+	NULL
+};
+
+const console_handler_t *get_console_handler_by_name(const char *core_name)
+{
+	if (!core_name) return NULL;
+
+	// Check exact matches first
+	for (int i = 0; g_console_handlers[i] != NULL; i++) {
+		if (!strcasecmp(core_name, g_console_handlers[i]->name)) {
+			return g_console_handlers[i];
+		}
+	}
+
+	// Check aliases
+	if (!strcasecmp(core_name, "MegaDrive")) {
+		return &g_console_genesis;
+	}
+	if (!strcasecmp(core_name, "GBC")) {
+		return &g_console_gameboy;  // GameBoy handler handles both GB and GBC
+	}
+
+	return NULL;
+}
+
+const console_handler_t *get_console_handler_by_id(int console_id)
+{
+	for (int i = 0; g_console_handlers[i] != NULL; i++) {
+		if (g_console_handlers[i]->console_id == console_id) {
+			return g_console_handlers[i];
+		}
+	}
+
+	// Special cases: GameBoy Color (ID 6) uses GameBoy handler (ID 4)
+	if (console_id == 6) {
+		return &g_console_gameboy;
+	}
+	// Game Gear (ID 15) uses SMS handler (ID 11)
+	if (console_id == 15) {
+		return &g_console_sms;
+	}
+
+	return NULL;
+}
+
+// Initialize all console handlers
+void init_all_console_handlers(void)
+{
+	for (int i = 0; g_console_handlers[i] != NULL; i++) {
+		if (g_console_handlers[i]->init) {
+			g_console_handlers[i]->init();
+		}
+	}
+}

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -1,0 +1,214 @@
+// achievements_gameboy.cpp — RetroAchievements GameBoy/GameBoy Color-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// GameBoy State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_gb_state = {};
+
+// Value-change watchers for debugging
+typedef struct {
+	uint32_t addr;
+	uint8_t last_val;
+	int initialized;
+	const char *name;
+} gb_watcher_t;
+
+static gb_watcher_t g_gb_watchers[] = {
+	{0xD190, 0, 0, "stateChange"},
+	{0xFF99, 0, 0, "gameMode"},
+	{0xFFFA, 0, 0, "coins"},
+	{0xFFB3, 0, 0, "gameState"},
+	{0xFFB4, 0, 0, "subState"},
+	{0xFFDA, 0, 0, "secState"},
+	{0xC0A0, 0, 0, "scoreHi"},
+	{0xC0A1, 0, 0, "scoreLo"},
+};
+#define GB_WATCHER_COUNT (sizeof(g_gb_watchers) / sizeof(g_gb_watchers[0]))
+
+// ---------------------------------------------------------------------------
+// GameBoy Implementation
+// ---------------------------------------------------------------------------
+
+static void gameboy_init(void)
+{
+	memset(&g_gb_state, 0, sizeof(g_gb_state));
+	memset(g_gb_watchers, 0, sizeof(g_gb_watchers));
+	ra_snes_addrlist_init();
+}
+
+static void gameboy_reset(void)
+{
+	g_gb_state.optionc = 0;
+	g_gb_state.collecting = 0;
+	g_gb_state.cache_ready = 0;
+	g_gb_state.last_resp_frame = 0;
+	g_gb_state.game_frames = 0;
+	g_gb_state.poll_logged = 0;
+	
+	// Reset watchers
+	for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+		g_gb_watchers[i].initialized = 0;
+		g_gb_watchers[i].last_val = 0;
+	}
+}
+
+static uint32_t gameboy_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_gb_state.optionc) {
+		if (g_gb_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_gb_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void gameboy_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_gb_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
+		// Bootstrap
+		g_gb_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_gb_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("GameBoy OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_gb_state.cache_ready) {
+		// Wait for cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_gb_state.cache_ready = 1;
+			g_gb_state.last_resp_frame = 0;
+			g_gb_state.game_frames = 0;
+			g_gb_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_gb_state.cache_time);
+			ra_log_write("GameBoy OptionC: Cache active!\n");
+		}
+	} else {
+		// Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_gb_state.last_resp_frame) {
+			g_gb_state.last_resp_frame = resp_frame;
+			g_gb_state.game_frames++;
+
+			// Initialize watchers on first frame
+			if (g_gb_state.game_frames == 1) {
+				for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+					g_gb_watchers[i].last_val = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
+					g_gb_watchers[i].initialized = 1;
+				}
+			}
+
+			// Check for value changes in watchers
+			for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+				if (!g_gb_watchers[i].initialized) continue;
+				uint8_t cur_val = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
+				if (cur_val != g_gb_watchers[i].last_val) {
+					ra_log_write("GB Watch[%s @ 0x%04X]: 0x%02X -> 0x%02X (frame %u)\n",
+						g_gb_watchers[i].name, g_gb_watchers[i].addr,
+						g_gb_watchers[i].last_val, cur_val, g_gb_state.game_frames);
+					g_gb_watchers[i].last_val = cur_val;
+				}
+			}
+
+			// Re-collect every ~5 min
+			int re_collect = (g_gb_state.game_frames % 18000 == 0) && (g_gb_state.game_frames > 0);
+			if (re_collect) {
+				g_gb_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_gb_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("GameBoy OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_gb_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_gb_state.poll_logged) {
+		g_gb_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_gb_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_gb_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(GB): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_gb_state.last_resp_frame, g_gb_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int gameboy_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	(void)rom_path;
+	(void)md5_hex_out;
+	// GameBoy uses standard MD5
+	return 0; // Let main code handle it
+}
+
+static void gameboy_set_hardcore(int enabled)
+{
+	ra_log_write("GameBoy: Hardcore mode %s (no FPGA bits mapped yet)\n",
+		enabled ? "enabled" : "disabled");
+}
+
+// Called from main achievements code to detect protocol
+void gameboy_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_gb_state.optionc = 1;
+		ra_log_write("GameBoy FPGA protocol: Option C (selective address reading)\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_gameboy = {
+	.init = gameboy_init,
+	.reset = gameboy_reset,
+	.read_memory = gameboy_read_memory,
+	.poll = gameboy_poll,
+	.calculate_hash = gameboy_calculate_hash,
+	.set_hardcore = gameboy_set_hardcore,
+	.console_id = 4,  // RC_CONSOLE_GAMEBOY (also handles GBC with ID 6)
+	.name = "GAMEBOY"
+};

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -1,0 +1,167 @@
+// achievements_gba.cpp — RetroAchievements Game Boy Advance-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// GBA State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_gba_state = {};
+
+// ---------------------------------------------------------------------------
+// GBA Implementation
+// ---------------------------------------------------------------------------
+
+static void gba_init(void)
+{
+	memset(&g_gba_state, 0, sizeof(g_gba_state));
+	ra_snes_addrlist_init();
+}
+
+static void gba_reset(void)
+{
+	g_gba_state.optionc = 0;
+	g_gba_state.collecting = 0;
+	g_gba_state.cache_ready = 0;
+	g_gba_state.last_resp_frame = 0;
+	g_gba_state.game_frames = 0;
+	g_gba_state.poll_logged = 0;
+}
+
+static uint32_t gba_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_gba_state.optionc) {
+		if (g_gba_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_gba_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void gba_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_gba_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
+		// Bootstrap
+		g_gba_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_gba_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("GBA OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_gba_state.cache_ready) {
+		// Wait for cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_gba_state.cache_ready = 1;
+			g_gba_state.last_resp_frame = 0;
+			g_gba_state.game_frames = 0;
+			g_gba_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_gba_state.cache_time);
+			ra_log_write("GBA OptionC: Cache active!\n");
+		}
+	} else {
+		// Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_gba_state.last_resp_frame) {
+			g_gba_state.last_resp_frame = resp_frame;
+			g_gba_state.game_frames++;
+
+			// Re-collect every ~5 min
+			int re_collect = (g_gba_state.game_frames % 18000 == 0) && (g_gba_state.game_frames > 0);
+			if (re_collect) {
+				g_gba_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_gba_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("GBA OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_gba_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_gba_state.poll_logged) {
+		g_gba_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_gba_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_gba_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(GBA): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_gba_state.last_resp_frame, g_gba_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int gba_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	(void)rom_path;
+	(void)md5_hex_out;
+	// GBA uses standard MD5
+	return 0; // Let main code handle it
+}
+
+static void gba_set_hardcore(int enabled)
+{
+	ra_log_write("GBA: Hardcore mode %s (no FPGA bits mapped yet)\n",
+		enabled ? "enabled" : "disabled");
+}
+
+// Called from main achievements code to detect protocol
+void gba_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_gba_state.optionc = 1;
+		ra_log_write("GBA FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_gba = {
+	.init = gba_init,
+	.reset = gba_reset,
+	.read_memory = gba_read_memory,
+	.poll = gba_poll,
+	.calculate_hash = gba_calculate_hash,
+	.set_hardcore = gba_set_hardcore,
+	.console_id = 5,  // RC_CONSOLE_GAMEBOY_ADVANCE
+	.name = "GBA"
+};

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -1,0 +1,198 @@
+// achievements_genesis.cpp — RetroAchievements Genesis/MegaDrive-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// Genesis/MegaDrive State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_md_state = {};
+
+// ---------------------------------------------------------------------------
+// Genesis/MegaDrive Implementation
+// ---------------------------------------------------------------------------
+
+static void genesis_init(void)
+{
+	memset(&g_md_state, 0, sizeof(g_md_state));
+	ra_snes_addrlist_init();
+}
+
+static void genesis_reset(void)
+{
+	g_md_state.optionc = 0;
+	g_md_state.collecting = 0;
+	g_md_state.cache_ready = 0;
+	g_md_state.last_resp_frame = 0;
+	g_md_state.game_frames = 0;
+	g_md_state.poll_logged = 0;
+}
+
+static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_md_state.optionc) {
+		if (g_md_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_md_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void genesis_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_md_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
+		// Bootstrap collection
+		g_md_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_md_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("Genesis OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_md_state.cache_ready) {
+		// Wait for cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_md_state.cache_ready = 1;
+			g_md_state.last_resp_frame = 0;
+			g_md_state.game_frames = 0;
+			g_md_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_md_state.cache_time);
+			ra_log_write("Genesis OptionC: Cache active!\n");
+		}
+	} else {
+		// Normal frame processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_md_state.last_resp_frame) {
+			g_md_state.last_resp_frame = resp_frame;
+			g_md_state.game_frames++;
+
+			// Dump first 5 frames with Sonic 1 addresses
+			if (g_md_state.game_frames <= 5) {
+				const uint8_t *vals = (const uint8_t *)map + 0x48000 + 8;
+				int cnt = ra_snes_addrlist_count();
+				int dump_len = cnt < 32 ? cnt : 32;
+				int non_zero = 0;
+				char hex[256];
+				int pos = 0;
+				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+					if (vals[i]) non_zero++;
+				}
+				ra_log_write("Genesis Frame %u: VALCACHE[0..%d]: %s (%d non-zero)\n", 
+					g_md_state.game_frames, dump_len - 1, hex, non_zero);
+				
+				// Sonic 1 key addresses
+				uint8_t gs   = ra_snes_addrlist_read_cached(map, 0xF601);
+				uint8_t act  = ra_snes_addrlist_read_cached(map, 0xFE10);
+				uint8_t zone = ra_snes_addrlist_read_cached(map, 0xFE11);
+				uint8_t lives= ra_snes_addrlist_read_cached(map, 0xFE13);
+				ra_log_write("  Sonic1: state=%02X act=%02X zone=%02X lives=%02X\n",
+					gs, act, zone, lives);
+			}
+
+			// Re-collect every ~5 min
+			int re_collect = (g_md_state.game_frames % 18000 == 0) && (g_md_state.game_frames > 0);
+			if (re_collect) {
+				g_md_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_md_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("Genesis OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_md_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_md_state.poll_logged) {
+		g_md_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_md_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_md_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(Genesis): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_md_state.last_resp_frame, g_md_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int genesis_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	(void)rom_path;
+	(void)md5_hex_out;
+	// Genesis uses standard MD5
+	return 0; // Let main code handle it
+}
+
+static void genesis_set_hardcore(int enabled)
+{
+	if (enabled) {
+		user_io_status_set("[64]", 1);  // Disable cheats
+		user_io_status_set("[24]", 1);  // Disable save states
+		ra_log_write("Genesis: Hardcore mode enabled\n");
+	} else {
+		user_io_status_set("[64]", 0);
+		user_io_status_set("[24]", 0);
+		ra_log_write("Genesis: Hardcore mode disabled\n");
+	}
+}
+
+// Called from main achievements code to detect protocol
+void genesis_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_md_state.optionc = 1;
+		ra_log_write("Genesis FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_genesis = {
+	.init = genesis_init,
+	.reset = genesis_reset,
+	.read_memory = genesis_read_memory,
+	.poll = genesis_poll,
+	.calculate_hash = genesis_calculate_hash,
+	.set_hardcore = genesis_set_hardcore,
+	.console_id = 1,  // RC_CONSOLE_MEGA_DRIVE
+	.name = "Genesis"
+};

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -1,0 +1,214 @@
+// achievements_n64.cpp — RetroAchievements Nintendo 64-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// N64 State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_n64_state = {};
+
+// ---------------------------------------------------------------------------
+// N64 Implementation
+// ---------------------------------------------------------------------------
+
+static void n64_init(void)
+{
+	memset(&g_n64_state, 0, sizeof(g_n64_state));
+	ra_snes_addrlist_init();
+	
+	// N64 uses special DDRAM base to avoid save state collision
+	ra_ramread_set_base(0x38000000);
+	ra_log_write("N64: Using RA DDRAM base 0x38000000 (avoiding SS slot collision)\n");
+}
+
+static void n64_reset(void)
+{
+	g_n64_state.optionc = 0;
+	g_n64_state.collecting = 0;
+	g_n64_state.cache_ready = 0;
+	g_n64_state.needs_recollect = 0;
+	g_n64_state.last_resp_frame = 0;
+	g_n64_state.game_frames = 0;
+	g_n64_state.poll_logged = 0;
+}
+
+static uint32_t n64_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_n64_state.optionc) {
+		// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is little-endian
+		// within 32-bit words. XOR 3 on the low 2 bits converts between byte orders.
+		if (g_n64_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(((address + i) ^ 3));  // XOR 3 for byte-order
+		}
+		if (g_n64_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, ((address + i) ^ 3));
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void n64_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_n64_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// N64 has 5 phases like PSX: bootstrap, wait, pointer-resolution, wait, normal
+	if (ra_snes_addrlist_count() == 0 && !g_n64_state.cache_ready) {
+		// Phase 1: Bootstrap
+		g_n64_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_n64_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("N64 OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+			g_n64_state.needs_recollect = 1;
+		}
+	} else if (!g_n64_state.cache_ready && g_n64_state.needs_recollect) {
+		// Phase 2 & 3: Wait and pointer-resolution
+		if (ra_snes_addrlist_is_ready(map)) {
+			ra_log_write("N64 OptionC: Doing pointer resolution pass\n");
+			g_n64_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_n64_state.collecting = 0;
+			if (ra_snes_addrlist_end_collect(map)) {
+				ra_log_write("N64 OptionC: Pointer-resolution done, %d addrs\n",
+					ra_snes_addrlist_count());
+			}
+			g_n64_state.needs_recollect = 0;
+		}
+	} else if (!g_n64_state.cache_ready) {
+		// Phase 4: Final cache wait
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_n64_state.cache_ready = 1;
+			g_n64_state.last_resp_frame = 0;
+			g_n64_state.game_frames = 0;
+			g_n64_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_n64_state.cache_time);
+			ra_log_write("N64 OptionC: Cache active!\n");
+		}
+	} else {
+		// Phase 5: Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_n64_state.last_resp_frame) {
+			g_n64_state.last_resp_frame = resp_frame;
+			g_n64_state.game_frames++;
+
+			// Byte-order diagnostic at frames 30 and 300
+			if (g_n64_state.game_frames == 30 || g_n64_state.game_frames == 300) {
+				ra_log_write("N64: Byte-order diagnostic at frame %u\n", g_n64_state.game_frames);
+				// Sample Super Mario 64 addresses
+				uint8_t map_id = ra_snes_addrlist_read_cached(map, 0x0033b24a ^ 3);
+				uint8_t hp = ra_snes_addrlist_read_cached(map, 0x0033b21d ^ 3);
+				uint8_t lives = ra_snes_addrlist_read_cached(map, 0x0033b21e ^ 3);
+				ra_log_write("  SM64: MapID=%02X HP=%02X Lives=%02X\n", map_id, hp, lives);
+			}
+
+			// Re-collect every 600 frames (~10s)
+			int re_collect = (g_n64_state.game_frames % 600 == 0) && (g_n64_state.game_frames > 0);
+			if (re_collect) {
+				g_n64_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_n64_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("N64 OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log every 100 frames (more frequent than other consoles)
+	uint32_t milestone = g_n64_state.game_frames / 100;
+	if (milestone > 0 && milestone != g_n64_state.poll_logged) {
+		g_n64_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_n64_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_n64_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(N64): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_n64_state.last_resp_frame, g_n64_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int n64_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+#ifdef HAS_RCHEEVOS
+	// N64 requires rc_hash_generate_from_file due to variable byte-order
+	char abs_path[1024];
+	if (rom_path[0] != '/') {
+		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	} else {
+		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
+		abs_path[sizeof(abs_path) - 1] = '\0';
+	}
+
+	if (rc_hash_generate_from_file(md5_hex_out, 2, abs_path)) {
+		ra_log_write("N64 hash: %s\n", md5_hex_out);
+		return 1;
+	}
+	ra_log_write("N64 hash failed\n");
+#endif
+	return 0;
+}
+
+static void n64_set_hardcore(int enabled)
+{
+	ra_log_write("N64: Hardcore mode %s (no FPGA bits mapped yet)\n", 
+		enabled ? "enabled" : "disabled");
+}
+
+// Called from main achievements code to detect protocol
+void n64_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_n64_state.optionc = 1;
+		ra_log_write("N64 FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_n64 = {
+	.init = n64_init,
+	.reset = n64_reset,
+	.read_memory = n64_read_memory,
+	.poll = n64_poll,
+	.calculate_hash = n64_calculate_hash,
+	.set_hardcore = n64_set_hardcore,
+	.console_id = 2,  // RC_CONSOLE_NINTENDO_64
+	.name = "N64"
+};

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef HAS_RCHEEVOS
 #include "rc_client.h"
@@ -19,6 +20,8 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_n64_state = {};
+static uint8_t *g_n64_progress_buf = NULL;
+static size_t   g_n64_progress_size = 0;
 
 // ---------------------------------------------------------------------------
 // N64 Implementation
@@ -27,6 +30,8 @@ static console_state_t g_n64_state = {};
 static void n64_init(void)
 {
 	memset(&g_n64_state, 0, sizeof(g_n64_state));
+	g_n64_progress_buf = NULL;
+	g_n64_progress_size = 0;
 	ra_snes_addrlist_init();
 	
 	// N64 uses special DDRAM base to avoid save state collision
@@ -43,6 +48,9 @@ static void n64_reset(void)
 	g_n64_state.last_resp_frame = 0;
 	g_n64_state.game_frames = 0;
 	g_n64_state.poll_logged = 0;
+	g_n64_state.resolve_pass = 0;
+	if (g_n64_progress_buf) { free(g_n64_progress_buf); g_n64_progress_buf = NULL; }
+	g_n64_progress_size = 0;
 }
 
 static uint32_t n64_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
@@ -75,29 +83,49 @@ static void n64_poll(void *map, void *client, int game_loaded)
 	// N64 has 5 phases like PSX: bootstrap, wait, pointer-resolution, wait, normal
 	if (ra_snes_addrlist_count() == 0 && !g_n64_state.cache_ready) {
 		// Phase 1: Bootstrap
+		// Save rcheevos state before collection to prevent delta corruption
+		size_t psize = rc_client_progress_size(rc_client);
+		if (psize > g_n64_progress_size) {
+			free(g_n64_progress_buf);
+			g_n64_progress_buf = (uint8_t *)malloc(psize);
+			g_n64_progress_size = psize;
+		}
+		if (g_n64_progress_buf)
+			rc_client_serialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 		g_n64_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_n64_state.collecting = 0;
+		// Restore state (undo delta/hit changes from zero-value reads)
+		if (g_n64_progress_buf)
+			rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
 			ra_log_write("N64 OptionC: Bootstrap collection done, %d addrs\n",
 				ra_snes_addrlist_count());
 			g_n64_state.needs_recollect = 1;
+			g_n64_state.resolve_pass = 0;
 		}
 	} else if (!g_n64_state.cache_ready && g_n64_state.needs_recollect) {
-		// Phase 2 & 3: Wait and pointer-resolution
+		// Phase 2 & 3: Iterative pointer-resolution for multi-level AddAddress
 		if (ra_snes_addrlist_is_ready(map)) {
-			ra_log_write("N64 OptionC: Doing pointer resolution pass\n");
+			g_n64_state.resolve_pass++;
+			ra_log_write("N64 OptionC: Pointer resolution pass %d\n", g_n64_state.resolve_pass);
 			g_n64_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
 			g_n64_state.collecting = 0;
-			if (ra_snes_addrlist_end_collect(map)) {
-				ra_log_write("N64 OptionC: Pointer-resolution done, %d addrs\n",
-					ra_snes_addrlist_count());
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed && g_n64_state.resolve_pass < 4) {
+				ra_log_write("N64 OptionC: Pass %d found new addrs, %d total - re-resolving\n",
+					g_n64_state.resolve_pass, ra_snes_addrlist_count());
+				// Stay in needs_recollect to do another pass once cache is ready
+			} else {
+				ra_log_write("N64 OptionC: Pointer-resolution %s after %d passes, %d addrs\n",
+					changed ? "done (max passes)" : "stable",
+					g_n64_state.resolve_pass, ra_snes_addrlist_count());
+				g_n64_state.needs_recollect = 0;
 			}
-			g_n64_state.needs_recollect = 0;
 		}
 	} else if (!g_n64_state.cache_ready) {
 		// Phase 4: Final cache wait
@@ -108,6 +136,9 @@ static void n64_poll(void *map, void *client, int game_loaded)
 			g_n64_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_n64_state.cache_time);
 			ra_log_write("N64 OptionC: Cache active!\n");
+			// Restore rcheevos state saved before resolution began
+			if (g_n64_progress_buf)
+				rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 		}
 	} else {
 		// Phase 5: Normal processing
@@ -126,9 +157,18 @@ static void n64_poll(void *map, void *client, int game_loaded)
 				ra_log_write("  SM64: MapID=%02X HP=%02X Lives=%02X\n", map_id, hp, lives);
 			}
 
-			// Re-collect every 600 frames (~10s)
+			// Re-collect every 600 frames (~10s) with multi-pass for AddAddress
 			int re_collect = (g_n64_state.game_frames % 600 == 0) && (g_n64_state.game_frames > 0);
 			if (re_collect) {
+				// Save state before re-collection
+				size_t psize = rc_client_progress_size(rc_client);
+				if (psize > g_n64_progress_size) {
+					free(g_n64_progress_buf);
+					g_n64_progress_buf = (uint8_t *)malloc(psize);
+					g_n64_progress_size = psize;
+				}
+				if (g_n64_progress_buf)
+					rc_client_serialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 				g_n64_state.collecting = 1;
 				ra_snes_addrlist_begin_collect();
 			}
@@ -138,8 +178,15 @@ static void n64_poll(void *map, void *client, int game_loaded)
 			if (re_collect) {
 				g_n64_state.collecting = 0;
 				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("N64 OptionC: Address list refreshed, %d addrs\n",
+					ra_log_write("N64 OptionC: Address list refreshed, %d addrs - scheduling re-resolve\n",
 						ra_snes_addrlist_count());
+					g_n64_state.cache_ready = 0;
+					g_n64_state.needs_recollect = 1;
+					g_n64_state.resolve_pass = 0;
+				} else {
+					// No change, restore state
+					if (g_n64_progress_buf)
+						rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 				}
 			}
 		}

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -1,0 +1,181 @@
+// achievements_neogeo.cpp — RetroAchievements NeoGeo-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// NeoGeo State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_neogeo_state = {};
+
+// ---------------------------------------------------------------------------
+// NeoGeo Implementation
+// ---------------------------------------------------------------------------
+
+static void neogeo_init(void)
+{
+	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
+	ra_snes_addrlist_init();
+}
+
+static void neogeo_reset(void)
+{
+	g_neogeo_state.optionc = 0;
+	g_neogeo_state.collecting = 0;
+	g_neogeo_state.cache_ready = 0;
+	g_neogeo_state.last_resp_frame = 0;
+	g_neogeo_state.game_frames = 0;
+	g_neogeo_state.poll_logged = 0;
+}
+
+static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_neogeo_state.optionc) {
+		if (g_neogeo_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_neogeo_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void neogeo_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_neogeo_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
+		// Bootstrap
+		g_neogeo_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_neogeo_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("NeoGeo OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_neogeo_state.cache_ready) {
+		// Wait for cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_neogeo_state.cache_ready = 1;
+			g_neogeo_state.last_resp_frame = 0;
+			g_neogeo_state.game_frames = 0;
+			g_neogeo_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.cache_time);
+			ra_log_write("NeoGeo OptionC: Cache active!\n");
+		}
+	} else {
+		// Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_neogeo_state.last_resp_frame) {
+			g_neogeo_state.last_resp_frame = resp_frame;
+			g_neogeo_state.game_frames++;
+
+			// Re-collect every ~5 min
+			int re_collect = (g_neogeo_state.game_frames % 18000 == 0) && (g_neogeo_state.game_frames > 0);
+			if (re_collect) {
+				g_neogeo_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_neogeo_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("NeoGeo OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_neogeo_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_neogeo_state.poll_logged) {
+		g_neogeo_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_neogeo_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_neogeo_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(NeoGeo): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_neogeo_state.last_resp_frame, g_neogeo_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int neogeo_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+#ifdef HAS_RCHEEVOS
+	// NeoGeo requires rc_hash_generate_from_file for filename-based hashing
+	char abs_path[1024];
+	if (rom_path[0] != '/') {
+		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	} else {
+		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
+		abs_path[sizeof(abs_path) - 1] = '\0';
+	}
+
+	if (rc_hash_generate_from_file(md5_hex_out, 27, abs_path)) {
+		ra_log_write("NeoGeo hash: %s\n", md5_hex_out);
+		return 1;
+	}
+	ra_log_write("NeoGeo hash failed\n");
+#endif
+	return 0;
+}
+
+static void neogeo_set_hardcore(int enabled)
+{
+	ra_log_write("NeoGeo: Hardcore mode %s (no FPGA bits mapped yet)\n",
+		enabled ? "enabled" : "disabled");
+}
+
+// Called from main achievements code to detect protocol
+void neogeo_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_neogeo_state.optionc = 1;
+		ra_log_write("NeoGeo FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_neogeo = {
+	.init = neogeo_init,
+	.reset = neogeo_reset,
+	.read_memory = neogeo_read_memory,
+	.poll = neogeo_poll,
+	.calculate_hash = neogeo_calculate_hash,
+	.set_hardcore = neogeo_set_hardcore,
+	.console_id = 27,  // RC_CONSOLE_ARCADE
+	.name = "NEOGEO"
+};

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -1,0 +1,134 @@
+// achievements_nes.cpp — RetroAchievements NES-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "lib/md5/md5.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// NES Implementation
+// ---------------------------------------------------------------------------
+
+static void nes_init(void)
+{
+	// NES has no console-specific state
+}
+
+static void nes_reset(void)
+{
+	// NES has no console-specific state to reset
+}
+
+static uint32_t nes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	// NES uses region-based layout (no Option C)
+	return ra_ramread_nes_read(map, address, buffer, num_bytes);
+}
+
+static void nes_poll(void *map, void *client, int game_loaded)
+{
+	(void)map;
+	(void)client;
+	(void)game_loaded;
+	// NES uses default frame tracking (no Option C)
+	// All polling logic is handled in main achievements_poll()
+}
+
+static int nes_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	// NES requires special handling: skip iNES header + optional trainer
+	FILE *f = fopen(rom_path, "rb");
+	if (!f) {
+		ra_log_write("NES: Failed to open ROM for hashing: %s\n", rom_path);
+		return 0;
+	}
+
+	fseek(f, 0, SEEK_END);
+	long file_size = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (file_size <= 0) {
+		fclose(f);
+		return 0;
+	}
+
+	uint8_t *rom_data = (uint8_t *)malloc(file_size);
+	if (!rom_data) {
+		fclose(f);
+		return 0;
+	}
+
+	size_t nread = fread(rom_data, 1, file_size, f);
+	fclose(f);
+	
+	if ((long)nread != file_size) {
+		free(rom_data);
+		return 0;
+	}
+
+	const uint8_t *hash_data = rom_data;
+	long hash_size = file_size;
+
+	// NES: skip iNES header ("NES\x1a") + optional 512-byte trainer
+	if (file_size > 16 &&
+		rom_data[0] == 0x4E && rom_data[1] == 0x45 &&  // 'N' 'E'
+		rom_data[2] == 0x53 && rom_data[3] == 0x1A) {  // 'S' 0x1a
+		uint32_t skip = 16;
+		if (rom_data[6] & 0x04) skip += 512; // trainer present
+		ra_log_write("NES: iNES header detected, skipping %u bytes (trainer=%d)\n",
+			skip, (rom_data[6] & 0x04) ? 1 : 0);
+		hash_data = rom_data + skip;
+		hash_size = file_size - skip;
+	}
+
+	// Calculate MD5
+	MD5_CTX ctx;
+	MD5Init(&ctx);
+	MD5Update(&ctx, hash_data, hash_size);
+	unsigned char md5_bin[16];
+	MD5Final(md5_bin, &ctx);
+
+	for (int i = 0; i < 16; i++) {
+		sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
+	}
+	md5_hex_out[32] = '\0';
+
+	free(rom_data);
+	return 1;
+}
+
+static void nes_set_hardcore(int enabled)
+{
+	if (enabled) {
+		user_io_status_set("[70]", 1);  // Disable cheats
+		user_io_status_set("[20]", 1);  // Disable save states
+		ra_log_write("NES: Hardcore mode enabled (cheats/states disabled)\n");
+	} else {
+		user_io_status_set("[70]", 0);
+		user_io_status_set("[20]", 0);
+		ra_log_write("NES: Hardcore mode disabled\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_nes = {
+	.init = nes_init,
+	.reset = nes_reset,
+	.read_memory = nes_read_memory,
+	.poll = nes_poll,
+	.calculate_hash = nes_calculate_hash,
+	.set_hardcore = nes_set_hardcore,
+	.console_id = 7,  // RC_CONSOLE_NINTENDO
+	.name = "NES"
+};

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -1,0 +1,206 @@
+// achievements_psx.cpp — RetroAchievements PlayStation-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// PSX State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_psx_state = {};
+
+// ---------------------------------------------------------------------------
+// PSX Implementation
+// ---------------------------------------------------------------------------
+
+static void psx_init(void)
+{
+	memset(&g_psx_state, 0, sizeof(g_psx_state));
+	ra_snes_addrlist_init();
+}
+
+static void psx_reset(void)
+{
+	g_psx_state.optionc = 0;
+	g_psx_state.collecting = 0;
+	g_psx_state.cache_ready = 0;
+	g_psx_state.needs_recollect = 0;
+	g_psx_state.last_resp_frame = 0;
+	g_psx_state.game_frames = 0;
+	g_psx_state.poll_logged = 0;
+}
+
+static uint32_t psx_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_psx_state.optionc) {
+		if (g_psx_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_psx_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void psx_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_psx_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// PSX has 5 phases: bootstrap, wait, pointer-resolution re-collect, wait again, normal
+	if (ra_snes_addrlist_count() == 0 && !g_psx_state.cache_ready) {
+		// Phase 1: Bootstrap collection
+		g_psx_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_psx_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("PSX OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+			g_psx_state.needs_recollect = 1;
+		}
+	} else if (!g_psx_state.cache_ready && g_psx_state.needs_recollect) {
+		// Phase 2: Wait for first cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			ra_log_write("PSX OptionC: Pre-recollect cache ready, doing pointer resolution pass\n");
+			// Phase 3: Pointer-resolution re-collection
+			g_psx_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_psx_state.collecting = 0;
+			if (ra_snes_addrlist_end_collect(map)) {
+				ra_log_write("PSX OptionC: Pointer-resolution done, %d addrs\n",
+					ra_snes_addrlist_count());
+			}
+			g_psx_state.needs_recollect = 0;
+		}
+	} else if (!g_psx_state.cache_ready) {
+		// Phase 4: Wait for final cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_psx_state.cache_ready = 1;
+			g_psx_state.last_resp_frame = 0;
+			g_psx_state.game_frames = 0;
+			g_psx_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_psx_state.cache_time);
+			ra_log_write("PSX OptionC: Final cache active!\n");
+		}
+	} else {
+		// Phase 5: Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_psx_state.last_resp_frame) {
+			g_psx_state.last_resp_frame = resp_frame;
+			g_psx_state.game_frames++;
+
+			// Re-collect more frequently for PSX (every 600 frames ~10s)
+			int re_collect = (g_psx_state.game_frames % 600 == 0) && (g_psx_state.game_frames > 0);
+			if (re_collect) {
+				g_psx_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_psx_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("PSX OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_psx_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_psx_state.poll_logged) {
+		g_psx_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_psx_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_psx_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(PSX): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_psx_state.last_resp_frame, g_psx_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int psx_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+#ifdef HAS_RCHEEVOS
+	// PSX requires rc_hash_generate_from_file for CD/ISO images
+	char abs_path[1024];
+	if (rom_path[0] != '/') {
+		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	} else {
+		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
+		abs_path[sizeof(abs_path) - 1] = '\0';
+	}
+
+	if (rc_hash_generate_from_file(md5_hex_out, 12, abs_path)) {
+		ra_log_write("PSX hash: %s\n", md5_hex_out);
+		return 1;
+	}
+	ra_log_write("PSX hash failed\n");
+#endif
+	return 0;
+}
+
+static void psx_set_hardcore(int enabled)
+{
+	if (enabled) {
+		user_io_status_set("[93]", 1);  // Disable cheats
+		user_io_status_set("[6]", 1);   // Disable save states
+		ra_log_write("PSX: Hardcore mode enabled\n");
+	} else {
+		user_io_status_set("[93]", 0);
+		user_io_status_set("[6]", 0);
+		ra_log_write("PSX: Hardcore mode disabled\n");
+	}
+}
+
+// Called from main achievements code to detect protocol
+void psx_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_psx_state.optionc = 1;
+		ra_log_write("PSX FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_psx = {
+	.init = psx_init,
+	.reset = psx_reset,
+	.read_memory = psx_read_memory,
+	.poll = psx_poll,
+	.calculate_hash = psx_calculate_hash,
+	.set_hardcore = psx_set_hardcore,
+	.console_id = 12,  // RC_CONSOLE_PLAYSTATION
+	.name = "PSX"
+};

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -1,0 +1,172 @@
+// achievements_sms.cpp — RetroAchievements Master System/Game Gear-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// SMS State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_sms_state = {};
+
+// ---------------------------------------------------------------------------
+// SMS Implementation
+// ---------------------------------------------------------------------------
+
+static void sms_init(void)
+{
+	memset(&g_sms_state, 0, sizeof(g_sms_state));
+	ra_snes_addrlist_init();
+}
+
+static void sms_reset(void)
+{
+	g_sms_state.optionc = 0;
+	g_sms_state.collecting = 0;
+	g_sms_state.cache_ready = 0;
+	g_sms_state.last_resp_frame = 0;
+	g_sms_state.game_frames = 0;
+	g_sms_state.poll_logged = 0;
+}
+
+static uint32_t sms_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_sms_state.optionc) {
+		if (g_sms_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_sms_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static void sms_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_sms_state.optionc) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_sms_state.cache_ready) {
+		// Bootstrap
+		g_sms_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_sms_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("SMS OptionC: Bootstrap collection done, %d addrs\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_sms_state.cache_ready) {
+		// Wait for cache
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_sms_state.cache_ready = 1;
+			g_sms_state.last_resp_frame = 0;
+			g_sms_state.game_frames = 0;
+			g_sms_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_sms_state.cache_time);
+			ra_log_write("SMS OptionC: Cache active!\n");
+		}
+	} else {
+		// Normal processing
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_sms_state.last_resp_frame) {
+			g_sms_state.last_resp_frame = resp_frame;
+			g_sms_state.game_frames++;
+
+			// Re-collect every ~5 min
+			int re_collect = (g_sms_state.game_frames % 18000 == 0) && (g_sms_state.game_frames > 0);
+			if (re_collect) {
+				g_sms_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_sms_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("SMS OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_sms_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_sms_state.poll_logged) {
+		g_sms_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_sms_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_sms_state.cache_time.tv_nsec) / 1e9;
+		ra_log_write("POLL(SMS): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
+			g_sms_state.last_resp_frame, g_sms_state.game_frames, elapsed,
+			ra_snes_addrlist_count());
+	}
+#endif
+}
+
+static int sms_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	(void)rom_path;
+	(void)md5_hex_out;
+	// SMS uses standard MD5
+	return 0; // Let main code handle it
+}
+
+static void sms_set_hardcore(int enabled)
+{
+	if (enabled) {
+		user_io_status_set("[24]", 1);  // Disable cheats
+		ra_log_write("SMS: Hardcore mode enabled (cheats disabled)\n");
+	} else {
+		user_io_status_set("[24]", 0);
+		ra_log_write("SMS: Hardcore mode disabled\n");
+	}
+}
+
+// Called from main achievements code to detect protocol
+void sms_detect_protocol(void *map)
+{
+	if (!map) return;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_sms_state.optionc = 1;
+		ra_log_write("SMS FPGA protocol: Option C\n");
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_sms = {
+	.init = sms_init,
+	.reset = sms_reset,
+	.read_memory = sms_read_memory,
+	.poll = sms_poll,
+	.calculate_hash = sms_calculate_hash,
+	.set_hardcore = sms_set_hardcore,
+	.console_id = 11,  // RC_CONSOLE_MASTER_SYSTEM (also handles Game Gear ID 15)
+	.name = "SMS"
+};

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -1,0 +1,354 @@
+// achievements_snes.cpp — RetroAchievements SNES-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "lib/md5/md5.h"
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// SNES State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_snes_state = {0};
+
+// ---------------------------------------------------------------------------
+// SNES Option C Diagnostics
+// ---------------------------------------------------------------------------
+
+static void snes_optionc_dump_valcache(const char *label, void *map)
+{
+	if (!map) return;
+	const uint8_t *base = (const uint8_t *)map;
+	int addr_count = ra_snes_addrlist_count();
+	const uint32_t *addrs = ra_snes_addrlist_addrs();
+
+	// Response header
+	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
+	ra_log_write("DUMP[%s] VALCACHE hdr: resp_id=%u resp_frame=%u\n",
+		label, resp->response_id, resp->response_frame);
+
+	// Raw VALCACHE bytes (first 32)
+	const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
+	int dump_len = addr_count < 32 ? addr_count : 32;
+	if (dump_len <= 0) dump_len = 32;
+	char hex[200];
+	int pos = 0;
+	int non_zero = 0;
+	for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+		pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+		if (vals[i]) non_zero++;
+	}
+	ra_log_write("DUMP[%s] VALCACHE raw[0..%d]: %s\n", label, dump_len - 1, hex);
+
+	// Count non-zero in full address range
+	int nz_all = 0;
+	for (int i = 0; i < addr_count; i++)
+		if (vals[i]) nz_all++;
+	ra_log_write("DUMP[%s] non-zero: %d/%d\n", label, nz_all, addr_count);
+
+	// Address+value pairs (first 10)
+	int show = addr_count < 10 ? addr_count : 10;
+	for (int i = 0; i < show; i++) {
+		ra_log_write("DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
+	}
+	
+	// Also show a few known SMW addresses if present
+	const uint32_t smw_addrs[] = {0x00019, 0x00DBF, 0x00F06, 0x00F31, 0x01490};
+	const char *smw_names[] = {"playerSts", "dragonCoin", "lives", "coinCnt", "score"};
+	for (int j = 0; j < 5; j++) {
+		for (int i = 0; i < addr_count; i++) {
+			if (addrs[i] == smw_addrs[j]) {
+				ra_log_write("DUMP[%s]   SMW:%s(0x%05X)=0x%02X\n", 
+					label, smw_names[j], smw_addrs[j], vals[i]);
+				break;
+			}
+		}
+	}
+
+	// ADDRLIST header readback
+	const ra_addr_req_hdr_t *ahdr = (const ra_addr_req_hdr_t *)(base + RA_SNES_ADDRLIST_OFFSET);
+	ra_log_write("DUMP[%s] ADDRLIST hdr readback: addr_count=%u request_id=%u\n",
+		label, ahdr->addr_count, ahdr->request_id);
+
+	// ADDRLIST address readback (first 5 from DDRAM)
+	const uint32_t *ddram_addrs = (const uint32_t *)(base + RA_SNES_ADDRLIST_OFFSET + 8);
+	int rshow = addr_count < 5 ? addr_count : 5;
+	for (int i = 0; i < rshow; i++) {
+		ra_log_write("DUMP[%s]   DDRAM_ADDR[%d]=0x%08X (local=0x%05X)\n", 
+			label, i, ddram_addrs[i], addrs[i]);
+	}
+
+	// FPGA debug words
+	const uint8_t *dbg8 = (const uint8_t *)(base + 0x10);
+	uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
+	uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
+	uint16_t first_dout  = dbg8[4] | (dbg8[5] << 8);
+	uint8_t  dispatch_cnt = dbg8[6];
+	uint8_t  fpga_ver     = dbg8[7];
+
+	const uint8_t *dbg8b = (const uint8_t *)(base + 0x18);
+	uint16_t max_timeout  = dbg8b[0] | (dbg8b[1] << 8);
+	uint16_t bsram_cnt    = dbg8b[2] | (dbg8b[3] << 8);
+	uint16_t wram_cnt     = dbg8b[4] | (dbg8b[5] << 8);
+	uint16_t first_addr   = dbg8b[6] | (dbg8b[7] << 8);
+
+	ra_log_write("DUMP[%s] FPGA_DBG: ver=0x%02X ok=%u timeout=%u first_dout=0x%04X dispatch=%u\n",
+		label, fpga_ver, ok_cnt, timeout_cnt, first_dout, dispatch_cnt);
+	ra_log_write("DUMP[%s] FPGA_DBG2: wram=%u bsram=%u first_addr=0x%04X max_timeout=%u\n",
+		label, wram_cnt, bsram_cnt, first_addr, max_timeout);
+
+	// Bypass check: addresses should match pattern: addr[7:0] ^ 0xA5
+	int bypass_fail = 0;
+	for (int i = 0; i < addr_count && i < 16; i++) {
+		uint8_t expected = (addrs[i] & 0xFF) ^ 0xA5;
+		if (vals[i] != expected) bypass_fail++;
+	}
+	if (bypass_fail > 0) {
+		ra_log_write("DUMP[%s] Bypass check: %d/%d mismatches (expected addr[7:0]^0xA5)\n",
+			label, bypass_fail, addr_count < 16 ? addr_count : 16);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SNES Implementation
+// ---------------------------------------------------------------------------
+
+static void snes_init(void)
+{
+	memset(&g_snes_state, 0, sizeof(g_snes_state));
+	ra_snes_addrlist_init();
+}
+
+static void snes_reset(void)
+{
+	g_snes_state.optionc = 0;
+	g_snes_state.collecting = 0;
+	g_snes_state.cache_ready = 0;
+	g_snes_state.last_resp_frame = 0;
+	g_snes_state.game_frames = 0;
+	g_snes_state.poll_logged = 0;
+}
+
+static uint32_t snes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_snes_state.optionc) {
+		// Option C: selective address reading
+		if (g_snes_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_snes_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	} else {
+		// VBlank-gated: read from full WRAM mirror
+		return ra_ramread_snes_read(map, address, buffer, num_bytes);
+	}
+}
+
+static void snes_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map) return;
+	
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (g_snes_state.optionc) {
+		// Option C selective reading mode
+		if (ra_snes_addrlist_count() == 0 && !g_snes_state.cache_ready) {
+			// Bootstrap: run one do_frame with zeros to discover needed addresses
+			g_snes_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_snes_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed) {
+				ra_log_write("SNES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+					ra_snes_addrlist_count());
+				snes_optionc_dump_valcache("bootstrap", map);
+			} else {
+				ra_log_write("SNES OptionC: No addresses collected — achievements may have no memory refs\n");
+			}
+		} else if (!g_snes_state.cache_ready) {
+			// Wait for FPGA to respond with cached values
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_snes_state.cache_ready = 1;
+				g_snes_state.last_resp_frame = 0;
+				g_snes_state.game_frames = 0;
+				g_snes_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_snes_state.cache_time);
+				ra_log_write("SNES OptionC: Cache active! FPGA response matched request.\n");
+				snes_optionc_dump_valcache("cache-active", map);
+			}
+		} else {
+			// Normal frame processing from cache
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			if (resp_frame > g_snes_state.last_resp_frame) {
+				g_snes_state.last_resp_frame = resp_frame;
+				g_snes_state.game_frames++;
+
+				// Dump first 5 frames after cache became active
+				if (g_snes_state.game_frames <= 5) {
+					ra_log_write("SNES OptionC: GameFrame %u (resp_frame=%u)\n",
+						g_snes_state.game_frames, resp_frame);
+					snes_optionc_dump_valcache("early-frame", map);
+				}
+
+				// Periodically re-collect to catch address changes (every ~5 min)
+				int re_collect = (g_snes_state.game_frames % 18000 == 0) && (g_snes_state.game_frames > 0);
+				if (re_collect) {
+					g_snes_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
+
+				rc_client_do_frame(rc_client);
+
+				if (re_collect) {
+					g_snes_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("SNES OptionC: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
+				}
+			}
+		}
+
+		// Periodic SNES debug — log once per 300-frame milestone
+		uint32_t milestone = g_snes_state.game_frames / 300;
+		if (milestone > 0 && milestone != g_snes_state.poll_logged) {
+			g_snes_state.poll_logged = milestone;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			double elapsed = (now.tv_sec - g_snes_state.cache_time.tv_sec)
+				+ (now.tv_nsec - g_snes_state.cache_time.tv_nsec) / 1e9;
+			double ms_per_cycle = (g_snes_state.game_frames > 0) ?
+				(elapsed * 1000.0 / g_snes_state.game_frames) : 0.0;
+			ra_log_write("POLL(SNES): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+				g_snes_state.last_resp_frame, g_snes_state.game_frames, elapsed, ms_per_cycle,
+				ra_snes_addrlist_count());
+			
+			// Dump VALCACHE every 1800 game frames (~30s)
+			if ((g_snes_state.game_frames % 1800) == 0) {
+				snes_optionc_dump_valcache("periodic", map);
+			}
+		}
+	}
+	// VBlank-gated mode uses default frame tracking in main achievements_poll()
+#endif
+}
+
+static int snes_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	// SNES: skip optional 512-byte SMC/SWC copier header
+	FILE *f = fopen(rom_path, "rb");
+	if (!f) {
+		ra_log_write("SNES: Failed to open ROM for hashing: %s\n", rom_path);
+		return 0;
+	}
+
+	fseek(f, 0, SEEK_END);
+	long file_size = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (file_size <= 0) {
+		fclose(f);
+		return 0;
+	}
+
+	uint8_t *rom_data = (uint8_t *)malloc(file_size);
+	if (!rom_data) {
+		fclose(f);
+		return 0;
+	}
+
+	size_t nread = fread(rom_data, 1, file_size, f);
+	fclose(f);
+	
+	if ((long)nread != file_size) {
+		free(rom_data);
+		return 0;
+	}
+
+	const uint8_t *hash_data = rom_data;
+	long hash_size = file_size;
+
+	// SNES: skip optional 512-byte SMC/SWC copier header
+	if ((file_size % 1024) == 512 && file_size > 512) {
+		ra_log_write("SNES: SMC header detected (file_size %% 1024 == 512), skipping 512 bytes\n");
+		hash_data = rom_data + 512;
+		hash_size = file_size - 512;
+	}
+
+	// Calculate MD5
+	MD5_CTX ctx;
+	MD5Init(&ctx);
+	MD5Update(&ctx, hash_data, hash_size);
+	unsigned char md5_bin[16];
+	MD5Final(md5_bin, &ctx);
+
+	for (int i = 0; i < 16; i++) {
+		sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
+	}
+	md5_hex_out[32] = '\0';
+
+	free(rom_data);
+	return 1;
+}
+
+static void snes_set_hardcore(int enabled)
+{
+	if (enabled) {
+		user_io_status_set("[58]", 1);  // Disable cheats
+		user_io_status_set("[24]", 1);  // Disable save states
+		ra_log_write("SNES: Hardcore mode enabled (cheats/states disabled)\n");
+	} else {
+		user_io_status_set("[58]", 0);
+		user_io_status_set("[24]", 0);
+		ra_log_write("SNES: Hardcore mode disabled\n");
+	}
+}
+
+// Called from main achievements code to detect protocol type
+void snes_detect_protocol(void *map)
+{
+	if (!map) return;
+	
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->region_count == 0) {
+		g_snes_state.optionc = 1;
+		ra_log_write("SNES FPGA protocol: Option C (selective address reading)\n");
+	} else {
+		g_snes_state.optionc = 0;
+		ra_log_write("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n", 
+			hdr->region_count);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_snes = {
+	.init = snes_init,
+	.reset = snes_reset,
+	.read_memory = snes_read_memory,
+	.poll = snes_poll,
+	.calculate_hash = snes_calculate_hash,
+	.set_hardcore = snes_set_hardcore,
+	.console_id = 3,  // RC_CONSOLE_SUPER_NINTENDO
+	.name = "SNES"
+};


### PR DESCRIPTION
This pull request introduces RetroAchievements support for MiSTer FPGA by integrating the [rcheevos](https://github.com/RetroAchievements/rcheevos) library and adding a new achievements subsystem. The changes include conditional compilation and linking of the rcheevos library, new source and header files for the achievements integration, and comprehensive documentation in the `README.md` describing supported cores, architecture, and usage.

The most important changes are:
This pull request introduces a new modular architecture for console-specific RetroAchievements logic, refactoring the codebase to use a unified handler interface for each supported console. It adds a generic `console_handler_t` interface and lookup system, and provides an initial implementation for GameBoy (and GameBoy Color), paving the way for similar separation for other consoles. Additionally, it brings significant improvements and bug fixes to the N64 Option C protocol, especially around pointer resolution, state management, and fallback memory reads.

The most important changes are:

**Console Handler Refactor and GameBoy Implementation:**

* Introduced the `console_handler_t` interface and `console_state_t` structure in `achievements_console.h` to encapsulate console-specific logic and state, and added lookup functions to retrieve handlers by name or ID.
* Added `achievements_console_lookup.cpp` to implement the handler lookup table and initialization logic for all supported consoles.
* Implemented a new modular GameBoy handler in `achievements_gameboy.cpp`, including Option C protocol support, value-change watchers for debugging, and periodic address re-collection. This handler also supports GameBoy Color via aliasing.

**N64 Option C Protocol Improvements:**

* Improved N64 Option C pointer-resolution: now supports iterative multi-pass resolution, state serialization/deserialization to avoid delta corruption, and a cooldown phase to prevent oscillation after resolution. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR2039-R2068) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL2037-R2123) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL2144-R2239)
* Added direct RDRAM mapping as a fallback for memory reads, ensuring consistency and avoiding mixing stale FPGA cache with live values.
* Refactored N64 state management: added new state variables, ensured proper cleanup/reset on game load, and improved logging and build versioning. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR175-R179) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1405-R1409) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1214-R1229)

These changes lay the foundation for further modularization of console-specific logic and provide a more robust and extensible achievements infrastructure.
**RetroAchievements Integration:**
* Added new `achievements.h`, `achievements_console.h`, and `achievements_console_lookup.cpp` files, providing the interface, per-console handler abstraction, and lookup logic for the RetroAchievements subsystem. These files define the lifecycle, per-frame polling, and core-specific RAM access needed for achievement evaluation. [[1]](diffhunk://#diff-ee4fed7675082f718263a601afeb6b87d598d18d444c81eb28238b646df05eeeR1-R46) [[2]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R1-R81) [[3]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R1-R82)

**Build System Updates:**
* Updated `Makefile` to conditionally include and compile the rcheevos library if present, add the necessary source files and include paths, and define required preprocessor macros. The build will automatically enable RetroAchievements support if `lib/rcheevos` is present. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R29-R66) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L39-R78) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L52-R93)

**Documentation:**
* Rewrote `README.md` to document the fork’s purpose, supported cores, setup instructions, technical architecture, and the specifics of how the RetroAchievements integration works on MiSTer. The README also details the RAM mirroring protocols, ROM hashing, and per-core adaptations.

These changes lay the groundwork for full RetroAchievements support in MiSTer, including core detection, RAM mirroring, achievement polling, and user notifications.