### PR TITLE
Add NeoGeo MVS and MegaCD support, organize console implementations

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -1142,8 +1142,10 @@ void achievements_poll(void)
 	}
 
 	// Frame delta check (detect missed frames)
+	// Only log if delta is in a plausible range (≤1000 missed frames),
+	// to avoid spam when the counter is garbage/oscillating.
 	uint32_t delta = frame - g_last_frame;
-	if (delta > 1 && g_last_frame > 0) {
+	if (delta > 1 && g_last_frame > 0 && delta <= 1000) {
 		RA_LOG("WARNING: Missed %u frames (last=%u, now=%u)", delta - 1, g_last_frame, frame);
 	}
 

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -14,13 +14,13 @@
 #include <execinfo.h>
 
 #include "achievements.h"
+#include "achievements_console.h"
 #include "ra_ramread.h"
 #include "ra_http.h"
 #include "user_io.h"
 #include "file_io.h"
 #include "menu.h"
 #include "hardware.h"
-#include "shmem.h"
 #include "lib/md5/md5.h"
 
 #ifdef HAS_RCHEEVOS
@@ -139,87 +139,8 @@ static int g_mirror_validated = 0;   // DDRAM mirror has been validated at least
 static char g_rom_md5[33] = {};      // MD5 hex string of current ROM
 static char g_rom_path[1024] = {};   // Path to current ROM
 
-// SNES state
-static int g_snes_optionc = 0;       // 1 if FPGA has Option C protocol, 0 for VBlank-gated
-static int g_snes_collecting = 0;    // 1 during address collection do_frame
-static int g_snes_cache_ready = 0;   // 1 when FPGA response matches request
-static uint32_t g_snes_last_resp_frame = 0; // Last processed response frame
-static uint32_t g_snes_game_frames = 0;     // Frames processed since cache active
-static uint32_t g_snes_poll_logged = 0;     // Last g_snes_game_frames milestone logged
-static struct timespec g_snes_cache_time;   // Timestamp when cache became active
-
-// PSX state (uses same Option C infrastructure as SNES)
-static int g_psx_optionc = 0;
-static int g_psx_collecting = 0;
-static int g_psx_cache_ready = 0;
-static int g_psx_needs_recollect = 0; // pointer-resolution pass after boot
-static uint32_t g_psx_last_resp_frame = 0;
-static uint32_t g_psx_game_frames = 0;
-static uint32_t g_psx_poll_logged = 0;
-static struct timespec g_psx_cache_time;
-static int g_psx_rtquery = 0;           // 1 if FPGA supports realtime queries
-
-// MegaDrive/Genesis state (Option C, same infrastructure)
-static int g_md_optionc = 0;
-static int g_md_collecting = 0;
-static int g_md_cache_ready = 0;
-static uint32_t g_md_last_resp_frame = 0;
-static uint32_t g_md_game_frames = 0;
-static uint32_t g_md_poll_logged = 0;
-static struct timespec g_md_cache_time;
-
-// N64 state (Option C, same infrastructure)
-static int g_n64_optionc = 0;
-static int g_n64_collecting = 0;
-static int g_n64_cache_ready = 0;
-static int g_n64_needs_recollect = 0;
-static int g_n64_resolve_pass = 0;
-static int g_n64_resolve_cooldown = 0;
-static void *g_n64_rdram_direct = NULL;
-static uint8_t *g_n64_progress_buf = NULL;
-static size_t   g_n64_progress_size = 0;
-static uint32_t g_n64_last_resp_frame = 0;
-static uint32_t g_n64_game_frames = 0;
-static uint32_t g_n64_poll_logged = 0;
-static struct timespec g_n64_cache_time;
-
-// Gameboy/Gameboy Color state (Option C, same infrastructure)
-static int g_gb_optionc = 0;
-static int g_gb_collecting = 0;
-static int g_gb_cache_ready = 0;
-static uint32_t g_gb_last_resp_frame = 0;
-static uint32_t g_gb_game_frames = 0;
-static uint32_t g_gb_poll_logged = 0;
-static struct timespec g_gb_cache_time;
-
-// SMS / Game Gear state (Option C, same infrastructure)
-static int g_sms_optionc = 0;
-static int g_sms_collecting = 0;
-static int g_sms_cache_ready = 0;
-static uint32_t g_sms_last_resp_frame = 0;
-static uint32_t g_sms_game_frames = 0;
-static uint32_t g_sms_poll_logged = 0;
-static struct timespec g_sms_cache_time;
-
-// GBA state (Option C, same infrastructure)
-static int g_gba_optionc = 0;
-static int g_gba_collecting = 0;
-static int g_gba_cache_ready = 0;
-static uint32_t g_gba_last_resp_frame = 0;
-static uint32_t g_gba_game_frames = 0;
-static uint32_t g_gba_poll_logged = 0;
-static struct timespec g_gba_cache_time;
-
-// NeoGeo state (Option C, same infrastructure)
-static int g_neogeo_optionc = 0;
-static int g_neogeo_collecting = 0;
-static int g_neogeo_cache_ready = 0;
-static int g_neogeo_needs_recollect = 0;
-static int g_neogeo_resolve_pass = 0;
-static uint32_t g_neogeo_last_resp_frame = 0;
-static uint32_t g_neogeo_game_frames = 0;
-static uint32_t g_neogeo_poll_logged = 0;
-static struct timespec g_neogeo_cache_time;
+// Active console handler (set in achievements_init, dispatches all per-console logic)
+static const console_handler_t *g_active_handler = NULL;
 
 #ifdef HAS_RCHEEVOS
 static rc_client_t *g_client = NULL;
@@ -237,6 +158,12 @@ static uint32_t g_frames_processed = 0;
 static uint32_t g_frames_skipped = 0;  // frames where busy flag was set
 static time_t g_load_time = 0;
 
+void ra_frame_processed(uint32_t frame)
+{
+	g_last_frame = frame;
+	g_frames_processed++;
+}
+
 // Config file path
 #define RA_CFG_PATH  "/media/fat/retroachievements.cfg"
 #define RA_SFX_PATH  "/media/fat/achievement.wav"
@@ -248,6 +175,66 @@ static int g_show_progress_popups      = 1; // 1 = show progress indicator popup
 static int g_show_progress_name        = 1; // 1 = include achievement name in progress popup
 static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheats & save states)
 static char g_ua_clause[64]            = ""; // rcheevos user-agent clause (e.g. "rcheevos/11.6")
+
+// ---------------------------------------------------------------------------
+// Per-achievement event state (rate-limiting CHALLENGE, dedup PROGRESS)
+// ---------------------------------------------------------------------------
+
+#define RA_ACH_STATE_MAX 128
+struct ra_ach_state_t {
+	uint32_t id;
+	time_t   challenge_last_popup; // monotonic: last time SHOW popup was shown
+	char     progress_last[32];    // last progress string displayed
+};
+static ra_ach_state_t g_ach_state[RA_ACH_STATE_MAX];
+static int g_ach_state_count = 0;
+
+#define CHALLENGE_POPUP_COOLDOWN_SEC  10  // suppress CHALLENGE SHOW popup if one was shown < 10s ago
+#define PROGRESS_SAME_VAL_COOLDOWN_SEC 5  // suppress PROGRESS popup if same value shown < 5s ago
+
+static ra_ach_state_t *ra_ach_state_get(uint32_t id)
+{
+	for (int i = 0; i < g_ach_state_count; i++)
+		if (g_ach_state[i].id == id) return &g_ach_state[i];
+	if (g_ach_state_count < RA_ACH_STATE_MAX) {
+		ra_ach_state_t *s = &g_ach_state[g_ach_state_count++];
+		s->id                  = id;
+		s->challenge_last_popup = 0;
+		s->progress_last[0]    = '\0';
+		return s;
+	}
+	return NULL;
+}
+
+// Returns 1 if CHALLENGE SHOW popup should be suppressed (fired too recently)
+static int ra_challenge_popup_suppressed(uint32_t id)
+{
+	ra_ach_state_t *s = ra_ach_state_get(id);
+	if (!s) return 0;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	time_t elapsed = now.tv_sec - s->challenge_last_popup;
+	if (elapsed < CHALLENGE_POPUP_COOLDOWN_SEC) return 1;
+	s->challenge_last_popup = now.tv_sec;
+	return 0;
+}
+
+// Returns 1 if PROGRESS popup should be suppressed (same value shown recently)
+static int ra_progress_popup_suppressed(uint32_t id, const char *progress)
+{
+	ra_ach_state_t *s = ra_ach_state_get(id);
+	if (!s) return 0;
+	if (strcmp(s->progress_last, progress) == 0) {
+		// Same value as last time — suppress unless it's been a while
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		// (future: could add time-based override here)
+		return 1;
+	}
+	// New value — update and allow
+	snprintf(s->progress_last, sizeof(s->progress_last), "%s", progress);
+	return 0;
+}
 
 // ---------------------------------------------------------------------------
 // Achievement Sound
@@ -522,197 +509,6 @@ static int ra_load_credentials(void)
 	return 1;
 }
 
-// ---------------------------------------------------------------------------
-// SNES Option C VALCACHE diagnostic dump (uses RA_LOG)
-// ---------------------------------------------------------------------------
-static void snes_optionc_dump_valcache(const char *label)
-{
-	if (!g_ra_map) return;
-	const uint8_t *base = (const uint8_t *)g_ra_map;
-	int addr_count = ra_snes_addrlist_count();
-	const uint32_t *addrs = ra_snes_addrlist_addrs();
-
-	// Response header
-	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
-	RA_LOG("DUMP[%s] VALCACHE hdr: resp_id=%u resp_frame=%u",
-		label, resp->response_id, resp->response_frame);
-
-	// Raw VALCACHE bytes (first 32)
-	const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
-	int dump_len = addr_count < 32 ? addr_count : 32;
-	if (dump_len <= 0) dump_len = 32;
-	char hex[200];
-	int pos = 0;
-	int non_zero = 0;
-	for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-		pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-		if (vals[i]) non_zero++;
-	}
-	RA_LOG("DUMP[%s] VALCACHE raw[0..%d]: %s", label, dump_len - 1, hex);
-
-	// Count non-zero in full address range
-	int nz_all = 0;
-	for (int i = 0; i < addr_count; i++)
-		if (vals[i]) nz_all++;
-	RA_LOG("DUMP[%s] non-zero: %d/%d", label, nz_all, addr_count);
-
-	// Address+value pairs (first 10)
-	int show = addr_count < 10 ? addr_count : 10;
-	for (int i = 0; i < show; i++) {
-		RA_LOG("DUMP[%s]   [%d] addr=0x%05X val=0x%02X", label, i, addrs[i], vals[i]);
-	}
-	// Also show a few known SMW addresses if present
-	const uint32_t smw_addrs[] = {0x00019, 0x00DBF, 0x00F06, 0x00F31, 0x01490};
-	const char *smw_names[] = {"playerSts", "dragonCoin", "lives", "coinCnt", "score"};
-	for (int j = 0; j < 5; j++) {
-		for (int i = 0; i < addr_count; i++) {
-			if (addrs[i] == smw_addrs[j]) {
-				RA_LOG("DUMP[%s]   SMW:%s(0x%05X)=0x%02X", label, smw_names[j], smw_addrs[j], vals[i]);
-				break;
-			}
-		}
-	}
-
-	// ADDRLIST header readback
-	const ra_addr_req_hdr_t *ahdr = (const ra_addr_req_hdr_t *)(base + RA_SNES_ADDRLIST_OFFSET);
-	RA_LOG("DUMP[%s] ADDRLIST hdr readback: addr_count=%u request_id=%u",
-		label, ahdr->addr_count, ahdr->request_id);
-
-	// ADDRLIST address readback (first 5 from DDRAM)
-	const uint32_t *ddram_addrs = (const uint32_t *)(base + RA_SNES_ADDRLIST_OFFSET + 8);
-	int rshow = addr_count < 5 ? addr_count : 5;
-	for (int i = 0; i < rshow; i++) {
-		RA_LOG("DUMP[%s]   DDRAM_ADDR[%d]=0x%08X (local=0x%05X)", label, i, ddram_addrs[i], addrs[i]);
-	}
-
-	// FPGA debug word 1 at offset 0x10 (DDRAM_BASE + 2)
-	// Format: {ver(8), dispatch_cnt(8), first_dout(16), timeout_cnt(16), ok_cnt(16)}
-	const uint8_t *dbg8 = (const uint8_t *)(base + 0x10);
-	uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
-	uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
-	uint16_t first_dout  = dbg8[4] | (dbg8[5] << 8);
-	uint8_t  dispatch_cnt = dbg8[6];
-	uint8_t  fpga_ver     = dbg8[7];
-
-	// FPGA debug word 2 at offset 0x18 (DDRAM_BASE + 3)
-	// Format: {first_addr(16), wram_cnt(16), bsram_cnt(16), max_timeout(16)}
-	const uint8_t *dbg8b = (const uint8_t *)(base + 0x18);
-	uint16_t max_timeout  = dbg8b[0] | (dbg8b[1] << 8);
-	uint16_t bsram_cnt    = dbg8b[2] | (dbg8b[3] << 8);
-	uint16_t wram_cnt     = dbg8b[4] | (dbg8b[5] << 8);
-	uint16_t first_addr   = dbg8b[6] | (dbg8b[7] << 8);
-
-	RA_LOG("DUMP[%s] FPGA_DBG: ver=0x%02X ok=%u timeout=%u first_dout=0x%04X dispatch=%u",
-		label, fpga_ver, ok_cnt, timeout_cnt, first_dout, dispatch_cnt);
-	RA_LOG("DUMP[%s] FPGA_DBG2: wram=%u bsram=%u first_addr=0x%04X max_timeout=%u",
-		label, wram_cnt, bsram_cnt, first_addr, max_timeout);
-	if (fpga_ver != 0x0A) {
-		RA_LOG("DUMP[%s] *** WARNING: FPGA version mismatch! Expected 0x0A, got 0x%02X ***",
-			label, fpga_ver);
-		RA_LOG("DUMP[%s] *** The FPGA bitstream may be outdated. Recompile and redeploy .rbf ***",
-			label);
-	}
-
-	// Bypass pattern verification: FPGA sets val = addr[7:0] ^ 0xA5
-	if (addr_count > 0 && addrs) {
-		int bypass_match = 0, bypass_mismatch = 0;
-		for (int i = 0; i < addr_count; i++) {
-			uint8_t expected = (uint8_t)(addrs[i] & 0xFF) ^ 0xA5;
-			if (vals[i] == expected)
-				bypass_match++;
-			else
-				bypass_mismatch++;
-		}
-		RA_LOG("DUMP[%s] BYPASS_CHECK: match=%d mismatch=%d (expected addr[7:0]^0xA5)",
-			label, bypass_match, bypass_mismatch);
-		if (bypass_mismatch > 0 && bypass_mismatch <= 5) {
-			for (int i = 0; i < addr_count && bypass_mismatch > 0; i++) {
-				uint8_t expected = (uint8_t)(addrs[i] & 0xFF) ^ 0xA5;
-				if (vals[i] != expected) {
-					RA_LOG("DUMP[%s]   MISMATCH[%d] addr=0x%05X got=0x%02X expected=0x%02X",
-						label, i, addrs[i], vals[i], expected);
-					bypass_mismatch--;
-				}
-			}
-		}
-	}
-}
-
-static void psx_optionc_dump_valcache(const char *label)
-{
-	if (!g_ra_map) return;
-	const uint8_t *base = (const uint8_t *)g_ra_map;
-	int addr_count = ra_snes_addrlist_count();
-	const uint32_t *addrs = ra_snes_addrlist_addrs();
-
-	// Response header
-	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
-	RA_LOG("DUMP[%s] VALCACHE hdr: resp_id=%u resp_frame=%u",
-		label, resp->response_id, resp->response_frame);
-
-	// Raw VALCACHE bytes (first 32)
-	const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
-	int dump_len = addr_count < 32 ? addr_count : 32;
-	if (dump_len <= 0) dump_len = 32;
-	char hex[200];
-	int pos = 0;
-	for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-		pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-	}
-	RA_LOG("DUMP[%s] VALCACHE raw[0..%d]: %s", label, dump_len - 1, hex);
-
-	// Count non-zero in full address range
-	int nz_all = 0;
-	for (int i = 0; i < addr_count; i++)
-		if (vals[i]) nz_all++;
-	RA_LOG("DUMP[%s] non-zero: %d/%d", label, nz_all, addr_count);
-
-	// Address+value pairs (first 16)
-	int show = addr_count < 16 ? addr_count : 16;
-	for (int i = 0; i < show; i++) {
-		RA_LOG("DUMP[%s]   [%d] addr=0x%06X val=0x%02X", label, i, addrs[i], vals[i]);
-	}
-
-	// Check THPS achievement-relevant addresses
-	const uint32_t thps_addrs[] = {0x0a5be0, 0x0d17c8, 0x0d1414, 0x0d1410, 0x0a42f4, 0x0d16a4};
-	const char *thps_names[] = {"gameState", "ptrBase", "check1", "check2", "check3", "levelState"};
-	for (int j = 0; j < 6; j++) {
-		for (int i = 0; i < addr_count; i++) {
-			if (addrs[i] == thps_addrs[j]) {
-				RA_LOG("DUMP[%s]   THPS:%s(0x%06X)=0x%02X", label, thps_names[j], thps_addrs[j], vals[i]);
-				break;
-			}
-		}
-	}
-
-	// ADDRLIST header readback
-	const ra_addr_req_hdr_t *ahdr = (const ra_addr_req_hdr_t *)(base + RA_SNES_ADDRLIST_OFFSET);
-	RA_LOG("DUMP[%s] ADDRLIST hdr readback: addr_count=%u request_id=%u",
-		label, ahdr->addr_count, ahdr->request_id);
-
-	// FPGA debug words (same layout as SNES mirror)
-	const uint8_t *dbg8 = (const uint8_t *)(base + 0x10);
-	uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
-	uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
-	uint16_t first_dout  = dbg8[4] | (dbg8[5] << 8);
-	uint8_t  dispatch_cnt = dbg8[6];
-	uint8_t  fpga_ver     = dbg8[7];
-
-	// Debug word 2: {first_addr(16), saveram_cnt(8), iwram_cnt(8), ewram_cnt(16), max_timeout(16)}
-	const uint8_t *dbg8b = (const uint8_t *)(base + 0x18);
-	uint16_t max_timeout   = dbg8b[0] | (dbg8b[1] << 8);
-	uint16_t ewram_cnt     = dbg8b[2] | (dbg8b[3] << 8);
-	uint8_t  iwram_cnt     = dbg8b[4];
-	uint8_t  saveram_cnt   = dbg8b[5];
-	uint16_t first_addr    = dbg8b[6] | (dbg8b[7] << 8);
-
-	RA_LOG("DUMP[%s] FPGA_DBG: ver=0x%02X ok=%u timeout=%u first_dout=0x%04X dispatch=%u max_timeout=%u first_addr=0x%04X iwram=%u ewram=%u saveram=%u",
-		label, fpga_ver, ok_cnt, timeout_cnt, first_dout, dispatch_cnt, max_timeout, first_addr, iwram_cnt, ewram_cnt, saveram_cnt);
-	if (fpga_ver != 0x02) {
-		RA_LOG("DUMP[%s] *** WARNING: FPGA version mismatch! Expected 0x02, got 0x%02X ***",
-			label, fpga_ver);
-	}
-}
 
 // ---------------------------------------------------------------------------
 // rcheevos callbacks (compiled only if library is available)
@@ -726,173 +522,24 @@ static uint32_t ra_read_memory(uint32_t address, uint8_t *buffer,
 	(void)client;
 	if (!g_ra_map || !ra_ramread_active(g_ra_map)) {
 		memset(buffer, 0, num_bytes);
-		// For supported consoles, return num_bytes so rcheevos keeps
-		// addresses valid during the mirror startup window (FPGA may
-		// not have written the magic header yet after a core reset).
 		return ra_core_supported() ? num_bytes : 0;
 	}
 
-	int console = ra_get_console_id();
-	switch (console) {
-		case 3:  // RC_CONSOLE_SUPER_NINTENDO
-			if (g_snes_optionc) {
-				// Option C: selective address reading
-				if (g_snes_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_snes_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			} else {
-				// VBlank-gated: read from full WRAM mirror
-				return ra_ramread_snes_read(g_ra_map, address, buffer, num_bytes);
-			}
-		case 7:  // RC_CONSOLE_NINTENDO (NES)
-			return ra_ramread_nes_read(g_ra_map, address, buffer, num_bytes);
-		case 1:  // RC_CONSOLE_MEGA_DRIVE (Genesis)
-			if (g_md_optionc) {
-				if (g_md_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_md_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-		case 12: // RC_CONSOLE_PLAYSTATION (PSX)
-			if (g_psx_optionc) {
-				if (g_psx_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_psx_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-					return num_bytes;
-				}
-				// Realtime query fallback for addresses not in batch cache
-				if (g_psx_rtquery && !g_psx_collecting && num_bytes <= 4) {
-					uint32_t val = ra_rtquery_read(g_ra_map, address, num_bytes);
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = (uint8_t)(val >> (i * 8));
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-			case 2: // RC_CONSOLE_NINTENDO_64 (N64)
-				// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is
-				// little-endian within 32-bit words.  XOR 3 on the low 2 bits
-				// converts between the two byte orders.
-				if (g_n64_optionc) {
-					if (g_n64_collecting) {
-						for (uint32_t i = 0; i < num_bytes; i++)
-							ra_snes_addrlist_add(((address + i) ^ 3));
-					}
-					// Always prefer direct RDRAM reads for consistency
-					// (avoids mixing stale FPGA cache with live RDRAM values)
-					if (g_n64_rdram_direct) {
-						const uint8_t *rdram = (const uint8_t *)g_n64_rdram_direct;
-						for (uint32_t i = 0; i < num_bytes; i++) {
-							uint32_t ddr_addr = (address + i) ^ 3;
-							buffer[i] = (ddr_addr < 0x800000) ? rdram[ddr_addr] : 0;
-						}
-						return num_bytes;
-					}
-					if (g_n64_cache_ready) {
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, ((address + i) ^ 3));
-						return num_bytes;
-					}
-					memset(buffer, 0, num_bytes);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			case 11: // RC_CONSOLE_MASTER_SYSTEM
-			case 15: // RC_CONSOLE_GAME_GEAR
-				if (g_sms_optionc) {
-					if (g_sms_collecting) {
-						for (uint32_t i = 0; i < num_bytes; i++)
-							ra_snes_addrlist_add(address + i);
-					}
-					if (g_sms_cache_ready) {
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-						return num_bytes;
-					}
-					memset(buffer, 0, num_bytes);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-		case 5:  // RC_CONSOLE_GAMEBOY_ADVANCE
-			if (g_gba_optionc) {
-				if (g_gba_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_gba_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-		case 4:  // RC_CONSOLE_GAMEBOY
-		case 6:  // RC_CONSOLE_GAMEBOY_COLOR
-			if (g_gb_optionc) {
-				if (g_gb_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
-				}
-				if (g_gb_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-		case 27: // RC_CONSOLE_ARCADE (NeoGeo)
-			// NeoGeo 68K big-endian: XOR addr bit 0 to match RA LE-host convention
-			if (g_neogeo_optionc) {
-				if (g_neogeo_collecting) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add((address + i) ^ 1);
-				}
-				if (g_neogeo_cache_ready) {
-					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, (address + i) ^ 1);
-					return num_bytes;
-				}
-				memset(buffer, 0, num_bytes);
-				return num_bytes;
-			}
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
-		default:
-			memset(buffer, 0, num_bytes);
-			return num_bytes;
+	// Dispatch to active console handler
+	if (g_active_handler && g_active_handler->read_memory) {
+		uint32_t r = g_active_handler->read_memory(g_ra_map, address, buffer, num_bytes);
+		if (r > 0) return r;
 	}
+
+	// Fallback: VBlank-gated region reads for NES and SNES
+	int console = ra_get_console_id();
+	if (console == 7)  // NES
+		return ra_ramread_nes_read(g_ra_map, address, buffer, num_bytes);
+	if (console == 3)  // SNES VBlank-gated (handler returned 0 = not optionc)
+		return ra_ramread_snes_read(g_ra_map, address, buffer, num_bytes);
+
+	memset(buffer, 0, num_bytes);
+	return num_bytes;
 }
 
 static void ra_server_call(const rc_api_request_t *request,
@@ -1015,7 +662,8 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 		{
 			RA_LOG("CHALLENGE SHOW: [%u] %s",
 				event->achievement->id, event->achievement->title);
-			if (g_show_challenge_show_popup) {
+			if (g_show_challenge_show_popup &&
+			    !ra_challenge_popup_suppressed(event->achievement->id)) {
 				const int title_max = 28;
 				char title_buf[32];
 				snprintf(title_buf, title_max + 1, "%s", event->achievement->title);
@@ -1049,7 +697,8 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 	case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
 		{
 			RA_LOG("PROGRESS: %s — %s", event->achievement->title, event->achievement->measured_progress);
-			if (g_show_progress_popups) {
+			if (g_show_progress_popups &&
+			    !ra_progress_popup_suppressed(event->achievement->id, event->achievement->measured_progress)) {
 				char buf[NOTIF_TEXT_MAX];
 				if (g_show_progress_name) {
 					const int title_max = 28;
@@ -1189,32 +838,16 @@ static void ra_load_game_callback(int result, const char *error_message,
 // Core identification
 // ---------------------------------------------------------------------------
 
-// Returns the rcheevos console ID for the current core, or 0 if unsupported.
+// Returns the rcheevos console ID for the current handler, or 0 if unsupported.
 static int ra_get_console_id(void)
 {
-	const char *name = user_io_get_core_name(1); // orig name
-	if (!name || !name[0]) return 0;
-
-	if (!strcasecmp(name, "NES"))     return 7;  // RC_CONSOLE_NINTENDO
-	if (!strcasecmp(name, "SNES"))    return 3;  // RC_CONSOLE_SUPER_NINTENDO
-	if (!strcasecmp(name, "Genesis")
-		|| !strcasecmp(name, "MegaDrive")) return 1; // RC_CONSOLE_MEGA_DRIVE
-	if (!strcasecmp(name, "GBA"))     return 5;  // RC_CONSOLE_GAMEBOY_ADVANCE
-	if (!strcasecmp(name, "PSX"))     return 12; // RC_CONSOLE_PLAYSTATION
-	if (!strcasecmp(name, "N64"))     return 2;  // RC_CONSOLE_NINTENDO_64
-	if (!strcasecmp(name, "TGFX16")) return 8;  // RC_CONSOLE_PC_ENGINE
-	if (!strcasecmp(name, "GAMEBOY")) return 4;  // RC_CONSOLE_GAMEBOY
-	if (!strcasecmp(name, "SMS"))     return 11; // RC_CONSOLE_MASTER_SYSTEM
-	if (!strcasecmp(name, "NEOGEO"))  return 27; // RC_CONSOLE_ARCADE
-
-	RA_LOG("Core '%s' not yet mapped to RA console ID", name);
-	return 0;
+	return g_active_handler ? g_active_handler->console_id : 0;
 }
 
 // Returns 1 if the current core is supported for RA
 static int ra_core_supported(void)
 {
-	return ra_get_console_id() != 0;
+	return g_active_handler != NULL;
 }
 
 // ---------------------------------------------------------------------------
@@ -1237,18 +870,22 @@ void achievements_init(void)
 	signal(SIGFPE,  ra_crash_handler);
 
 	RA_LOG("=== RetroAchievements for MiSTer ===");
-	RA_LOG("Build: OptionC v28-b4 (2026-04-18)");
-	RA_LOG("Phase 3 — Full pipeline: HTTP + login + achievements");
+	RA_LOG("Build: OptionC v29-b1 (2026-04-19)");
+	RA_LOG("Phase 5 — Handler dispatch: all per-console logic in separate files");
 
 	const char *core = user_io_get_core_name(1);
-	int console_id = ra_get_console_id();
-	RA_LOG("Core: '%s' -> console_id=%d supported=%d", core ? core : "(null)",
-		console_id, ra_core_supported());
+	g_active_handler = core ? get_console_handler_by_name(core) : NULL;
+	RA_LOG("Core: '%s' -> handler=%s console_id=%d", core ? core : "(null)",
+		g_active_handler ? g_active_handler->name : "none",
+		ra_get_console_id());
 
-	if (!ra_core_supported()) {
+	if (!g_active_handler) {
 		RA_LOG("Core not supported for RetroAchievements. Inactive.");
 		return;
 	}
+
+	// Call handler init — N64 sets DDRAM base here, must happen before ra_ramread_map()
+	g_active_handler->init();
 
 #ifdef HAS_RCHEEVOS
 	// Initialize rcheevos hash infrastructure (needed for disc-based consoles)
@@ -1257,14 +894,6 @@ void achievements_init(void)
 	rc_hash_init_error_message_callback(ra_hash_message);
 	rc_hash_init_verbose_message_callback(ra_hash_message);
 #endif
-
-	// N64 savestates occupy 0x3C000000-0x3FFFFFFF (4 slots × 16MB),
-	// colliding with the default RA base at 0x3D000000 (= SS slot 1).
-	// Move N64 RA mirror to the unused gap at 0x38000000.
-	if (console_id == 2) {  // RC_CONSOLE_NINTENDO_64
-		ra_ramread_set_base(0x38000000);
-		RA_LOG("N64: Using RA DDRAM base 0x38000000 (avoiding SS slot collision)");
-	}
 
 	// Map DDRAM mirror region
 	g_ra_map = ra_ramread_map();
@@ -1331,7 +960,7 @@ void achievements_init(void)
 
 void achievements_load_game(const char *rom_path, uint32_t crc32)
 {
-	if (!ra_core_supported()) return;
+	if (!g_active_handler) return;
 
 	// Update User-Agent with core-specific prefix (e.g. "NES_MiSTer/1.0 rcheevos/11.6")
 	if (g_ua_clause[0]) {
@@ -1352,37 +981,15 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 	// Store ROM path
 	snprintf(g_rom_path, sizeof(g_rom_path), "%s", rom_path);
 
-	// Calculate hash
+	// Calculate hash — try handler first, fall back to generic MD5
 	g_rom_md5[0] = '\0';
 	if (rom_path && rom_path[0]) {
-		int console_id = ra_get_console_id();
-#ifdef HAS_RCHEEVOS
-		// For disc-based consoles (PSX), byte-order-variable ROMs (N64),
-		// or filename-based hashing (Arcade/NeoGeo), use rcheevos hash
-		if (console_id == 12 || console_id == 2 || console_id == 27) {
-			// Build absolute path — rom_path is relative to getRootDir()
-			char abs_path[1024];
-			if (rom_path[0] == '/') {
-				snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
-			} else {
-				snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
-			}
-			const char *cname = (console_id == 12) ? "PSX" : (console_id == 2) ? "N64" : "NeoGeo";
-			RA_LOG("Using rcheevos hash for %s: %s", cname, abs_path);
-			if (rc_hash_generate_from_file(g_rom_md5, console_id, abs_path)) {
-				RA_LOG("%s hash: %s", cname, g_rom_md5);
-			} else {
-				RA_LOG("ERROR: rc_hash_generate_from_file failed for %s", cname);
-				g_rom_md5[0] = '\0';
-			}
-		} else
-#endif
-		{
+		if (!g_active_handler->calculate_hash(rom_path, g_rom_md5)) {
 			ra_calculate_rom_md5(rom_path, g_rom_md5);
 		}
 	}
 
-	// Reset frame tracking
+	// Reset frame tracking and console state
 	g_last_frame = 0;
 	g_first_frame = 0;
 	g_mirror_validated = 0;
@@ -1390,57 +997,8 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 	g_frames_skipped = 0;
 	g_game_loaded = 0;
 	g_load_time = time(NULL);
-	g_snes_optionc = 0;
-	g_snes_collecting = 0;
-	g_snes_cache_ready = 0;
-	g_snes_last_resp_frame = 0;
-	g_snes_game_frames = 0;
-	g_snes_poll_logged = 0;
-	g_psx_optionc = 0;
-	g_psx_collecting = 0;
-	g_psx_cache_ready = 0;
-	g_psx_needs_recollect = 0;
-	g_psx_last_resp_frame = 0;
-	g_psx_game_frames = 0;
-	g_psx_poll_logged = 0;
-	g_md_optionc = 0;
-	g_md_collecting = 0;
-	g_md_cache_ready = 0;
-	g_md_last_resp_frame = 0;
-	g_md_game_frames = 0;
-	g_md_poll_logged = 0;
-	g_n64_optionc = 0;
-	g_n64_collecting = 0;
-	g_n64_cache_ready = 0;
-	g_n64_needs_recollect = 0;
-	g_n64_resolve_pass = 0;
-	g_n64_resolve_cooldown = 0;
-	if (g_n64_rdram_direct) { shmem_unmap(g_n64_rdram_direct, 0x800000); g_n64_rdram_direct = NULL; }
-	if (g_n64_progress_buf) { free(g_n64_progress_buf); g_n64_progress_buf = NULL; }
-	g_n64_progress_size = 0;
-	g_n64_last_resp_frame = 0;
-	g_n64_game_frames = 0;
-	g_n64_poll_logged = 0;
-	g_gb_optionc = 0;
-	g_gb_collecting = 0;
-	g_gb_cache_ready = 0;
-	g_gb_last_resp_frame = 0;
-	g_gb_game_frames = 0;
-	g_gb_poll_logged = 0;
-	g_gba_optionc = 0;
-	g_gba_collecting = 0;
-	g_gba_cache_ready = 0;
-	g_gba_last_resp_frame = 0;
-	g_gba_game_frames = 0;
-	g_gba_poll_logged = 0;
-	g_neogeo_optionc = 0;
-	g_neogeo_collecting = 0;
-	g_neogeo_cache_ready = 0;
-	g_neogeo_needs_recollect = 0;
-	g_neogeo_resolve_pass = 0;
-	g_neogeo_last_resp_frame = 0;
-	g_neogeo_game_frames = 0;
-	g_neogeo_poll_logged = 0;
+	g_ach_state_count = 0;
+	g_active_handler->reset();
 	ra_snes_addrlist_init();
 
 	// Check mirror state
@@ -1469,34 +1027,10 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 
 	RA_LOG("--- Game Load Complete, monitoring frames ---");
 
-	// Hardcore mode: force FPGA status bits to disable cheats & save states
-	if (g_hardcore) {
-		int cid = ra_get_console_id();
-		switch (cid) {
-		case 7:  // NES
-			user_io_status_set("[70]", 1);
-			user_io_status_set("[20]", 1);
-			break;
-		case 3:  // SNES
-			user_io_status_set("[58]", 1);
-			user_io_status_set("[24]", 1);
-			break;
-		case 1:  // MegaDrive / Genesis
-			user_io_status_set("[64]", 1);
-			user_io_status_set("[24]", 1);
-			break;
-		case 12: // PSX
-			user_io_status_set("[93]", 1);
-			user_io_status_set("[6]", 1);
-			break;
-		case 11: // SMS / Game Gear — cheats bit [24], no save states to disable
-			user_io_status_set("[24]", 1);
-			break;
-		default:
-			RA_LOG("Hardcore: no FPGA bit mapping for console %d", cid);
-			break;
-		}
-		RA_LOG("Hardcore: forced FPGA status bits (cheats off, savestates off)");
+	// Hardcore mode: let handler set console-specific FPGA bits
+	if (g_hardcore && g_active_handler->set_hardcore) {
+		g_active_handler->set_hardcore(1);
+		RA_LOG("Hardcore: FPGA bits applied for %s", g_active_handler->name);
 	}
 }
 
@@ -1536,53 +1070,9 @@ void achievements_poll(void)
 			RA_LOG("=== DDRAM Mirror Activated! ===");
 			ra_ramread_debug_dump(g_ra_map);
 
-			// Detect FPGA protocol: region_count==0 means Option C, non-zero means VBlank-gated
-			const ra_header_t *hdr = (const ra_header_t *)g_ra_map;
-			if (ra_get_console_id() == 3) {
-				if (hdr->region_count == 0) {
-					g_snes_optionc = 1;
-					RA_LOG("SNES FPGA protocol: Option C (selective address reading)");
-				} else {
-					g_snes_optionc = 0;
-					RA_LOG("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)", hdr->region_count);
-				}
-			}
-			if (ra_get_console_id() == 12) {
-				g_psx_optionc = 1;
-				RA_LOG("PSX FPGA protocol: Option C (selective address reading)");
-					if (ra_rtquery_supported(g_ra_map)) {
-						g_psx_rtquery = 1;
-						ra_rtquery_init(g_ra_map);
-						RA_LOG("PSX: Realtime queries supported (FPGA v2+)");
-					} else {
-						g_psx_rtquery = 0;
-						RA_LOG("PSX: Realtime queries NOT supported (FPGA v1)");
-					}
-			}
-			if (ra_get_console_id() == 1) {
-				g_md_optionc = 1;
-				RA_LOG("MegaDrive FPGA protocol: Option C (selective address reading)");
-			}
-			if (ra_get_console_id() == 2) {
-				g_n64_optionc = 1;
-				RA_LOG("N64 FPGA protocol: Option C (selective address reading)");
-			}
-			if (ra_get_console_id() == 4) {
-				g_gb_optionc = 1;
-				RA_LOG("Gameboy FPGA protocol: Option C (selective address reading)");
-			}
-			if (ra_get_console_id() == 5) {
-				g_gba_optionc = 1;
-				RA_LOG("GBA FPGA protocol: Option C (selective address reading)");
-			}
-			if (ra_get_console_id() == 11) {
-				g_sms_optionc = 1;
-				RA_LOG("SMS FPGA protocol: Option C (selective address reading)");
-			}
-			if (ra_get_console_id() == 27) {
-				g_neogeo_optionc = 1;
-				RA_LOG("NeoGeo FPGA protocol: Option C (selective address reading)");
-			}
+			// Detect FPGA protocol — delegate to the active console handler
+			if (g_active_handler && g_active_handler->detect_protocol)
+				g_active_handler->detect_protocol(g_ra_map);
 		} else {
 			// Periodic debug while waiting for FPGA mirror
 			static uint32_t wait_count = 0;
@@ -1602,1224 +1092,24 @@ void achievements_poll(void)
 	uint32_t frame = ra_ramread_frame(g_ra_map);
 	int busy = ra_ramread_busy(g_ra_map);
 
-	// Periodic diagnostics every ~5s (assuming poll is called frequently)
+	// Periodic diagnostics
 	if ((poll_calls % 18000) == 1) {
-		int console = ra_get_console_id();
-		int optionc = (console == 4) ? g_gb_optionc : (console == 5) ? g_gba_optionc : (console == 11) ? g_sms_optionc : (console == 2) ? g_n64_optionc : (console == 12) ? g_psx_optionc : (console == 1) ? g_md_optionc : (console == 27) ? g_neogeo_optionc : g_snes_optionc;
-		RA_LOG("DIAG: poll_calls=%u frame=%u last_frame=%u busy=%d processed=%u skipped=%u game_loaded=%d console=%d optionc=%d",
-			poll_calls, frame, g_last_frame, busy, g_frames_processed, g_frames_skipped, g_game_loaded,
-			console, optionc);
-
-		if (console == 3 && g_snes_optionc) {
-			// SNES Option C: show address cache status
-			RA_LOG("SNES OptionC: addrs=%d cache=%s resp_frame=%u",
-				ra_snes_addrlist_count(),
-				g_snes_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map));
-		} else if (console == 3) {
-			// SNES VBlank-gated: show WRAM data
-			const uint8_t *base = (const uint8_t *)g_ra_map;
-			const uint8_t *wram = base + RA_SNES_WRAM_OFFSET;
-			char hex[200];
-			int pos = 0;
-			for (int i = 0; i < 32 && pos < (int)sizeof(hex) - 4; i++)
-				pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", wram[i]);
-			RA_LOG("WRAM[0..31]: %s", hex);
-			const ra_header_t *hdr = (const ra_header_t *)base;
-			RA_LOG("BSRAM size=%u", hdr->reserved2);
-		} else if (console == 12 && g_psx_optionc) {
-			// PSX Option C: show address cache status
-			RA_LOG("PSX OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_psx_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_psx_game_frames);
-		} else if (console == 2 && g_n64_optionc) {
-			// N64 Option C: show address cache status
-			RA_LOG("N64 OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_n64_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_n64_game_frames);
-			if (g_ra_map) {
-				const uint8_t *base = (const uint8_t *)g_ra_map;
-				// Header: magic + flags
-				const uint32_t *hdr32 = (const uint32_t *)base;
-				uint32_t magic = hdr32[0];
-				uint8_t flags = base[5];
-				uint32_t frame = hdr32[2]; // frame_counter at offset 0x08
-				// Debug word 1 at offset 0x10:
-				// {ver(8), state_snap(8), vblank_cnt(16), timeout_cnt(16), ok_cnt(16)}
-				const uint64_t *dbg1 = (const uint64_t *)(base + 0x10);
-				uint64_t d1 = *dbg1;
-				uint8_t  fpga_ver    = (d1 >> 56) & 0xFF;
-				uint8_t  state_snap  = (d1 >> 48) & 0xFF;
-				uint16_t vbl_hb      = (d1 >> 32) & 0xFFFF;
-				uint16_t timeout_cnt = (d1 >> 16) & 0xFFFF;
-				uint16_t ok_cnt      = d1 & 0xFFFF;
-				// Debug word 2 at offset 0x18:
-				// {first_addr(16), warmup_left(8), 0(8), dispatch_cnt(16), max_timeout(16)}
-				const uint64_t *dbg2 = (const uint64_t *)(base + 0x18);
-				uint64_t d2 = *dbg2;
-				uint16_t first_addr  = (d2 >> 48) & 0xFFFF;
-				uint8_t  warmup_left = (d2 >> 40) & 0x0F;
-				uint16_t disp_cnt    = (d2 >> 16) & 0xFFFF;
-				uint16_t max_timeout = d2 & 0xFFFF;
-				RA_LOG("N64 FPGA: magic=%08X flags=%02X frame=%u ver=0x%02X state=%u vbl_hb=%u ok=%u disp=%u timeout=%u/%u warmup=%u first=0x%04X",
-					magic, flags, frame, fpga_ver, state_snap, vbl_hb,
-					ok_cnt, disp_cnt, timeout_cnt, max_timeout, warmup_left, first_addr);
-				if (fpga_ver != 0x03) {
-					RA_LOG("N64 FPGA: *** VERSION MISMATCH! Expected 0x03, got 0x%02X — old bitstream? ***", fpga_ver);
-				}
-				// VALCACHE response header
-				const uint32_t *resp32 = (const uint32_t *)(base + 0x48000);
-				RA_LOG("N64 VALCACHE: resp_id=%u resp_frame=%u (expect req_id=%u)",
-					resp32[0], resp32[1], ra_snes_addrlist_request_id());
-			}
-		} else if (console == 1 && g_md_optionc) {
-			// MegaDrive Option C: show address cache status
-			RA_LOG("MD OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_md_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_md_game_frames);
-			if (g_md_cache_ready && g_ra_map) {
-				const uint8_t *vals = (const uint8_t *)g_ra_map + 0x48000 + 8;
-				int cnt = ra_snes_addrlist_count();
-				int dump_len = cnt < 45 ? cnt : 45;
-				int non_zero = 0;
-				char hex[256];
-				int pos = 0;
-				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-					if (vals[i]) non_zero++;
-				}
-				RA_LOG("VALCACHE[0..%d]: %s (%d non-zero)", dump_len - 1, hex, non_zero);
-				// v0x04 debug layout:
-				// Word 1 (0x10): {ver(8), dispatch(8), ok(16), oob(16), 0(16)}
-				// Words 2-5 (0x18-0x30): 8 debug records at 32 bits each, 2 per word
-				//   Each rec: {bram_addr[14:0](15), cur_addr_bit0(1), bram_dout(16)}
-				// Word 6 (0x38): sweep test {0x5B00(16), sweep_dout(16), bram_dout_now(16), 0(16)}
-				const uint8_t *base = (const uint8_t *)g_ra_map;
-				const uint64_t *dbg1 = (const uint64_t *)(base + 0x10);
-				uint64_t d1 = *dbg1;
-				uint8_t  fpga_ver     = (d1 >> 56) & 0xFF;
-				uint8_t  dispatch_cnt = (d1 >> 48) & 0xFF;
-				uint16_t ok_cnt       = (d1 >> 32) & 0xFFFF;
-				uint16_t oob_cnt      = (d1 >> 16) & 0xFFFF;
-				RA_LOG("FPGA_DBG: ver=0x%02X disp=%u ok=%u oob=%u",
-					fpga_ver, dispatch_cnt, ok_cnt, oob_cnt);
-
-				// Read 8 per-address debug records (first 8 addresses)
-				// Addresses in sorted order: D003 D008 D009 D01B D023 D5C1 F601 F602
-				for (int w = 0; w < 4; w++) {
-					const uint64_t *dw = (const uint64_t *)(base + 0x18 + w * 8);
-					uint64_t word = *dw;
-					uint32_t rec_lo = word & 0xFFFFFFFF;
-					uint32_t rec_hi = (word >> 32) & 0xFFFFFFFF;
-					int idx0 = w * 2, idx1 = w * 2 + 1;
-					uint16_t baddr0 = (rec_lo >> 17) & 0x7FFF;
-					uint8_t  bit0_0 = (rec_lo >> 16) & 1;
-					uint16_t bdout0 = rec_lo & 0xFFFF;
-					uint16_t baddr1 = (rec_hi >> 17) & 0x7FFF;
-					uint8_t  bit0_1 = (rec_hi >> 16) & 1;
-					uint16_t bdout1 = rec_hi & 0xFFFF;
-					RA_LOG("  REC[%d]: waddr=0x%04X a0=%u dout=0x%04X | REC[%d]: waddr=0x%04X a0=%u dout=0x%04X",
-						idx0, baddr0, bit0_0, bdout0, idx1, baddr1, bit0_1, bdout1);
-				}
-
-				// Sweep test result: {sweep1_F601(16), sweep2_FF84(16), addr1(16), addr2(16)}
-				const uint64_t *dsweep = (const uint64_t *)(base + 0x38);
-				uint64_t sw = *dsweep;
-				uint16_t sw_val1 = (sw >> 48) & 0xFFFF;  // bram_dout at 0x5B00 (F601)
-				uint16_t sw_val2 = (sw >> 32) & 0xFFFF;  // bram_dout at 0x5F02 (FF84)
-				uint16_t sw_a1   = (sw >> 16) & 0xFFFF;   // should be 0x5B00
-				uint16_t sw_a2   = sw & 0xFFFF;            // should be 0x5F02
-				RA_LOG("SWEEP1(F601): bram=0x%04X dout=0x%04X | SWEEP2(FF84): bram=0x%04X dout=0x%04X",
-					sw_a1, sw_val1, sw_a2, sw_val2);
-
-				// Dump first 20 addresses from the sorted address list
-				const uint32_t *addrs = ra_snes_addrlist_addrs();
-				int acnt = ra_snes_addrlist_count();
-				int adump = acnt < 20 ? acnt : 20;
-				char ahex[256];
-				int apos = 0;
-				for (int i = 0; i < adump && apos < (int)sizeof(ahex) - 8; i++)
-					apos += snprintf(ahex + apos, sizeof(ahex) - apos, "%04X ", addrs[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", adump - 1, ahex, acnt);
-
-				// Direct lookup of key Sonic 1 / MD addresses
-				uint8_t gs   = ra_snes_addrlist_read_cached(g_ra_map, 0xF601);
-				uint8_t act  = ra_snes_addrlist_read_cached(g_ra_map, 0xFE10);
-				uint8_t zone = ra_snes_addrlist_read_cached(g_ra_map, 0xFE11);
-				uint8_t lives= ra_snes_addrlist_read_cached(g_ra_map, 0xFE13);
-				uint8_t rings_h = ra_snes_addrlist_read_cached(g_ra_map, 0xFE20);
-				uint8_t rings_l = ra_snes_addrlist_read_cached(g_ra_map, 0xFE21);
-				uint8_t tmin = ra_snes_addrlist_read_cached(g_ra_map, 0xFE22);
-				uint8_t tsec = ra_snes_addrlist_read_cached(g_ra_map, 0xFE25);
-				uint8_t demo = ra_snes_addrlist_read_cached(g_ra_map, 0xFFF0);
-				uint8_t dbgm = ra_snes_addrlist_read_cached(g_ra_map, 0xFFFA);
-				RA_LOG("KEY: F601(state)=%02X FE10(act)=%02X FE11(zone)=%02X FE13(lives)=%02X FE20-21(rings)=%02X%02X FE22(tmin)=%02X FE25(tsec)=%02X FFF0(demo)=%02X FFFA(dbg)=%02X",
-					gs, act, zone, lives, rings_h, rings_l, tmin, tsec, demo, dbgm);
-			}
-		} else if (console == 4 && g_gb_optionc) {
-			// GB Option C: show address cache status and value dump
-			RA_LOG("GB OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_gb_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_gb_game_frames);
-			if (g_gb_cache_ready && g_ra_map) {
-				// Dump all cached values
-				const uint8_t *vals = (const uint8_t *)g_ra_map + 0x48000 + 8;
-				int cnt = ra_snes_addrlist_count();
-				int dump_len = cnt < 32 ? cnt : 32;
-				int non_zero = 0;
-				char hex[256];
-				int pos = 0;
-				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-					if (vals[i]) non_zero++;
-				}
-				RA_LOG("VALCACHE[0..%d]: %s (%d non-zero)", dump_len - 1, hex, non_zero);
-
-				// Dump sorted address list
-				const uint32_t *addrs = ra_snes_addrlist_addrs();
-				char ahex[256];
-				int apos = 0;
-				for (int i = 0; i < dump_len && apos < (int)sizeof(ahex) - 8; i++)
-					apos += snprintf(ahex + apos, sizeof(ahex) - apos, "%04X ", addrs[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", dump_len - 1, ahex, cnt);
-
-				// Key SML addresses from code notes
-				uint8_t gstate = ra_snes_addrlist_read_cached(g_ra_map, 0xFFB3);
-				uint8_t gmode  = ra_snes_addrlist_read_cached(g_ra_map, 0xFFD8);
-				uint8_t screen = ra_snes_addrlist_read_cached(g_ra_map, 0xFFF4);
-				uint8_t conts  = ra_snes_addrlist_read_cached(g_ra_map, 0xC0A6);
-				uint8_t event  = ra_snes_addrlist_read_cached(g_ra_map, 0xDFE1);
-				RA_LOG("SML KEY: FFB3(state)=%02X FFD8(mode)=%02X FFF4(screen)=%02X C0A6(conts)=%02X DFE1(event)=%02X",
-					gstate, gmode, screen, conts, event);
-
-				// FPGA debug words
-				const uint8_t *base = (const uint8_t *)g_ra_map;
-				const uint64_t *dbg1 = (const uint64_t *)(base + 0x10);
-				uint64_t d1 = *dbg1;
-				uint8_t  fpga_ver     = (d1 >> 56) & 0xFF;
-				uint16_t timeout_cnt  = (d1 >> 16) & 0xFFFF;
-				uint16_t ok_cnt       = d1 & 0xFFFF;
-				const uint64_t *dbg2 = (const uint64_t *)(base + 0x18);
-				uint64_t d2 = *dbg2;
-				uint16_t wram_cnt   = (d2 >> 32) & 0xFFFF;
-				uint16_t cram_cnt   = (d2 >> 16) & 0xFFFF;
-				uint16_t hram_cnt   = d2 & 0xFFFF;
-				RA_LOG("GB FPGA: ver=0x%02X ok=%u timeout=%u wram=%u cram=%u hram=%u",
-					fpga_ver, ok_cnt, timeout_cnt, wram_cnt, cram_cnt, hram_cnt);
-			}
-		} else if (console == 11 && g_sms_optionc) {
-			// SMS/GG Option C: show address cache status
-			RA_LOG("SMS OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_sms_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_sms_game_frames);
-			if (g_sms_cache_ready && g_ra_map) {
-				const uint8_t *vals = (const uint8_t *)g_ra_map + 0x48000 + 8;
-				int cnt = ra_snes_addrlist_count();
-				int dump_len = cnt < 45 ? cnt : 45;
-				int non_zero = 0;
-				char hex[256];
-				int pos = 0;
-				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-					if (vals[i]) non_zero++;
-				}
-				RA_LOG("VALCACHE[0..%d]: %s (%d non-zero)", dump_len - 1, hex, non_zero);
-			}
-		} else if (console == 5 && g_gba_optionc) {
-			// GBA Option C: show address cache status
-			RA_LOG("GBA OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_gba_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_gba_game_frames);
-		} else if (console == 27 && g_neogeo_optionc) {
-			// NeoGeo Option C: show address cache status and value dump
-			RA_LOG("NeoGeo OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
-				ra_snes_addrlist_count(),
-				g_neogeo_cache_ready ? "active" : "waiting",
-				ra_snes_addrlist_response_frame(g_ra_map),
-				g_neogeo_game_frames);
-			if (g_neogeo_cache_ready && g_ra_map) {
-				const uint8_t *vals = (const uint8_t *)g_ra_map + 0x48000 + 8;
-				int cnt = ra_snes_addrlist_count();
-				int dump_len = cnt < 52 ? cnt : 52;
-				int non_zero = 0;
-				char hex[400];
-				int pos = 0;
-				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-					if (vals[i]) non_zero++;
-				}
-				RA_LOG("VALCACHE[0..%d]: %s (%d non-zero)", dump_len - 1, hex, non_zero);
-				// Dump address list
-				const uint32_t *addrs = ra_snes_addrlist_addrs();
-				char ahex[400];
-				int apos = 0;
-				for (int i = 0; i < dump_len && apos < (int)sizeof(ahex) - 8; i++)
-					apos += snprintf(ahex + apos, sizeof(ahex) - apos, "%04X ", addrs[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", dump_len - 1, ahex, cnt);
-				// FPGA debug words
-				const uint8_t *base = (const uint8_t *)g_ra_map;
-				const uint64_t *dbg1 = (const uint64_t *)(base + 0x10);
-				uint64_t d1 = *dbg1;
-				uint8_t  fpga_ver     = (d1 >> 56) & 0xFF;
-				uint8_t  dispatch_cnt = (d1 >> 48) & 0xFF;
-				uint16_t ok_cnt       = (d1 >> 32) & 0xFFFF;
-				uint16_t oob_cnt      = (d1 >> 16) & 0xFFFF;
-				RA_LOG("NeoGeo FPGA: ver=0x%02X dispatch=%u ok=%u oob=%u",
-					fpga_ver, dispatch_cnt, ok_cnt, oob_cnt);
-				// Debug records (first 2 addresses)
-				const uint64_t *dbg2 = (const uint64_t *)(base + 0x18);
-				uint64_t d2 = *dbg2;
-				uint32_t rec0 = d2 & 0xFFFFFFFF;
-				uint32_t rec1 = (d2 >> 32) & 0xFFFFFFFF;
-				RA_LOG("NeoGeo REC[0]: bram=0x%04X a0=%u wraml=0x%02X wramu=0x%02X",
-					(rec0 >> 17) & 0x7FFF, (rec0 >> 16) & 1, (rec0 >> 8) & 0xFF, rec0 & 0xFF);
-				RA_LOG("NeoGeo REC[1]: bram=0x%04X a0=%u wraml=0x%02X wramu=0x%02X",
-					(rec1 >> 17) & 0x7FFF, (rec1 >> 16) & 1, (rec1 >> 8) & 0xFF, rec1 & 0xFF);
-			}
-		} else {
-			// NES: region-based layout
-			const uint8_t *cpuram = ra_ramread_region_data(g_ra_map, 0);
-			uint16_t cpuram_sz = ra_ramread_region_size(g_ra_map, 0);
-			if (cpuram && cpuram_sz > 0) {
-				int n = cpuram_sz < 32 ? cpuram_sz : 32;
-				char hex[200];
-				int pos = 0;
-				for (int i = 0; i < n && pos < (int)sizeof(hex) - 4; i++)
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", cpuram[i]);
-				RA_LOG("RAM[0..%d]: %s", n - 1, hex);
-			} else {
-				RA_LOG("RAM: region 0 not available (ptr=%p sz=%u)", cpuram, cpuram_sz);
-			}
-		}
+		RA_LOG("DIAG: poll=%u frame=%u last=%u busy=%d processed=%u skipped=%u loaded=%d handler=%s addrs=%d",
+			poll_calls, frame, g_last_frame, busy, g_frames_processed, g_frames_skipped,
+			g_game_loaded, g_active_handler ? g_active_handler->name : "none",
+			ra_snes_addrlist_count());
 	}
 
 	(void)busy;
 
 #ifdef HAS_RCHEEVOS
-	// ================================================================
-	// SNES: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 3 && g_snes_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_snes_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_snes_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_snes_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("SNES OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-				snes_optionc_dump_valcache("bootstrap");
-			} else {
-				RA_LOG("SNES OptionC: No addresses collected — achievements may have no memory refs");
-			}
-		} else if (!g_snes_cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_snes_cache_ready = 1;
-				g_snes_last_resp_frame = 0;
-				g_snes_game_frames = 0;
-				g_snes_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_snes_cache_time);
-				RA_LOG("SNES OptionC: Cache active! FPGA response matched request.");
-				snes_optionc_dump_valcache("cache-active");
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_snes_last_resp_frame) {
-				g_snes_last_resp_frame = resp_frame;
-				g_frames_processed++;
-				g_snes_game_frames++;
-
-				// Dump first 5 frames after cache became active
-				if (g_snes_game_frames <= 5) {
-					RA_LOG("SNES OptionC: GameFrame %u (resp_frame=%u)",
-						g_snes_game_frames, resp_frame);
-					snes_optionc_dump_valcache("early-frame");
-				}
-
-				// Periodically re-collect to catch address changes (every ~5 min)
-				int re_collect = (g_snes_game_frames % 18000 == 0) && (g_snes_game_frames > 0);
-				if (re_collect) {
-					g_snes_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_snes_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("SNES OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		// Periodic SNES debug — log once per 300-frame milestone
-		uint32_t milestone = g_snes_game_frames / 300;
-		if (milestone > 0 && milestone != g_snes_poll_logged) {
-			g_snes_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_snes_cache_time.tv_sec)
-				+ (now.tv_nsec - g_snes_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_snes_game_frames > 0) ?
-				(elapsed * 1000.0 / g_snes_game_frames) : 0.0;
-			RA_LOG("POLL(SNES): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_snes_last_resp_frame, g_snes_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-			// Also dump VALCACHE every 1800 game frames (~30s)
-			if ((g_snes_game_frames % 1800) < 300) {
-				snes_optionc_dump_valcache("periodic");
-			}
-		}
-		return; // SNES handled — skip default frame tracking
+	// Dispatch to active console handler (handles all Option C consoles)
+	if (g_active_handler && g_active_handler->poll) {
+		if (g_active_handler->poll(g_ra_map, g_client, g_game_loaded))
+			return;
 	}
 
-	// ================================================================
-	// PSX: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 12 && g_psx_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_psx_cache_ready) {
-			// Phase 1: Bootstrap — collect addresses with zero values
-			g_psx_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_psx_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				g_psx_needs_recollect = 1; // schedule pointer-resolution pass
-				RA_LOG("PSX OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-				psx_optionc_dump_valcache("bootstrap");
-			} else {
-				RA_LOG("PSX OptionC: No addresses collected");
-			}
-		} else if (!g_psx_cache_ready) {
-			// Phase 2/4: Wait for FPGA cache
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_psx_cache_ready = 1;
-				g_psx_last_resp_frame = 0;
-				g_psx_game_frames = 0;
-				g_psx_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_psx_cache_time);
-				if (g_psx_needs_recollect) {
-					RA_LOG("PSX OptionC: Cache active (pre-recollect). Will resolve pointers.");
-					psx_optionc_dump_valcache("pre-recollect");
-				} else {
-					RA_LOG("PSX OptionC: Cache active! FPGA response matched request.");
-					psx_optionc_dump_valcache("cache-active");
-				}
-			}
-		} else if (g_psx_needs_recollect) {
-			// Phase 3: Pointer-resolution re-collection
-			// Now that cache has real values, AddAddress conditions will
-			// compute correct derived addresses from pointer base values.
-			g_psx_needs_recollect = 0;
-			g_psx_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_psx_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("PSX OptionC: Pointer-resolve re-collection done, %d addrs (was different!)",
-					ra_snes_addrlist_count());
-				g_psx_cache_ready = 0; // wait for new FPGA data with correct addresses
-				psx_optionc_dump_valcache("ptr-resolve");
-			} else {
-				RA_LOG("PSX OptionC: Pointer-resolve complete, no address changes");
-			}
-		} else {
-			// Phase 5: Normal frame processing
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_psx_last_resp_frame) {
-				g_psx_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_psx_game_frames++;
-
-				if (g_psx_game_frames <= 5) {
-					RA_LOG("PSX OptionC: GameFrame %u (resp_frame=%u)",
-						g_psx_game_frames, resp_frame);
-					psx_optionc_dump_valcache("early-frame");
-				}
-
-				// Re-collect every 600 frames (~10s) to track pointer changes
-				int re_collect = (g_psx_game_frames % 600 == 0) && (g_psx_game_frames > 0);
-				if (re_collect) {
-					g_psx_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_psx_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("PSX OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-						g_psx_cache_ready = 0; // wait for new FPGA data
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_psx_game_frames / 300;
-		if (milestone > 0 && milestone != g_psx_poll_logged) {
-			g_psx_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_psx_cache_time.tv_sec)
-				+ (now.tv_nsec - g_psx_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_psx_game_frames > 0) ?
-				(elapsed * 1000.0 / g_psx_game_frames) : 0.0;
-			RA_LOG("POLL(PSX): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_psx_last_resp_frame, g_psx_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-			if ((g_psx_game_frames % 1800) < 300) {
-				psx_optionc_dump_valcache("periodic");
-			}
-		}
-		return; // PSX handled
-	}
-
-	// ================================================================
-	// N64: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 2 && g_n64_optionc) {
-		// Ensure direct RDRAM mapping is available for fallback reads
-		if (!g_n64_rdram_direct) {
-			g_n64_rdram_direct = shmem_map(0x30000000, 0x800000);
-			if (g_n64_rdram_direct)
-				RA_LOG("N64 OptionC: Direct RDRAM mapped for fallback reads");
-			else
-				RA_LOG("N64 OptionC: WARNING - failed to map RDRAM for fallback!");
-		}
-		if (ra_snes_addrlist_count() == 0 && !g_n64_cache_ready) {
-			// Phase 1: Bootstrap — collect addresses with zero values
-			// Save rcheevos state before collection to prevent delta corruption
-			size_t psize = rc_client_progress_size(g_client);
-			if (psize > g_n64_progress_size) {
-				free(g_n64_progress_buf);
-				g_n64_progress_buf = (uint8_t *)malloc(psize);
-				g_n64_progress_size = psize;
-			}
-			if (g_n64_progress_buf)
-				rc_client_serialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-			g_n64_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_n64_collecting = 0;
-			// Restore state (undo delta/hit changes from zero-value reads)
-			if (g_n64_progress_buf)
-				rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				g_n64_needs_recollect = 1; // schedule pointer-resolution pass
-				g_n64_resolve_pass = 0;
-				RA_LOG("N64 OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("N64 OptionC: No addresses collected");
-			}
-		} else if (!g_n64_cache_ready) {
-			// Phase 2/4: Wait for FPGA cache
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_n64_cache_ready = 1;
-				if (g_n64_needs_recollect) {
-					RA_LOG("N64 OptionC: Cache active (pre-recollect). Will resolve pointers.");
-				} else {
-					if (g_n64_game_frames == 0) {
-						// First activation after bootstrap
-						g_n64_last_resp_frame = 0;
-						g_n64_poll_logged = 0;
-						clock_gettime(CLOCK_MONOTONIC, &g_n64_cache_time);
-						RA_LOG("N64 OptionC: Cache active! FPGA response matched request.");
-					} else {
-						RA_LOG("N64 OptionC: Resolution complete, resuming (%d addrs)",
-							ra_snes_addrlist_count());
-					}
-					// Restore rcheevos state saved before resolution began
-					if (g_n64_progress_buf)
-						rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-					g_n64_resolve_cooldown = 30;
-					RA_LOG("N64 OptionC: State restored via Phase 2, cooldown=30");
-				}
-			}
-		} else if (g_n64_needs_recollect) {
-			// Phase 3: Iterative pointer-resolution (multi-pass for AddAddress chains)
-			g_n64_resolve_pass++;
-			g_n64_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_n64_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed && g_n64_resolve_pass < 4) {
-				RA_LOG("N64 OptionC: Pass %d found new addrs, %d total - re-resolving",
-					g_n64_resolve_pass, ra_snes_addrlist_count());
-				g_n64_cache_ready = 0; // wait for FPGA to respond with new addresses
-			} else {
-				RA_LOG("N64 OptionC: Pointer-resolution %s after %d passes, %d addrs",
-					changed ? "done (max passes)" : "stable",
-					g_n64_resolve_pass, ra_snes_addrlist_count());
-				g_n64_needs_recollect = 0;
-				if (changed) {
-					g_n64_cache_ready = 0; // need final FPGA response (Phase 2 will deserialize)
-				} else {
-					// Stable: restore state directly since Phase 2 is skipped (cache_ready stays 1)
-					if (g_n64_progress_buf)
-						rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-					g_n64_resolve_cooldown = 30;
-					RA_LOG("N64 OptionC: State restored after stable resolution, cooldown=30");
-				}
-			}
-		} else {
-			// Phase 5: Normal frame processing
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_n64_last_resp_frame) {
-				g_n64_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_n64_game_frames++;
-
-				if (g_n64_game_frames <= 5) {
-					RA_LOG("N64 OptionC: GameFrame %u (resp_frame=%u)",
-						g_n64_game_frames, resp_frame);
-				}
-
-				// Log every 100 frames to track progress (temporary)
-				if ((g_n64_game_frames % 100) == 0) {
-					RA_LOG("N64 OptionC: frame tick %u (resp=%u)",
-						g_n64_game_frames, resp_frame);
-				}
-
-				// Value diagnostic at frame 30 and 300: compare FPGA cached values
-				// with direct ARM reads of RDRAM to verify byte ordering.
-				if (g_n64_game_frames == 30 || g_n64_game_frames == 300) {
-					void *rdram_direct = shmem_map(0x30000000, 0x800000);
-					if (rdram_direct) {
-						const uint8_t *rdram = (const uint8_t *)rdram_direct;
-						const uint8_t *vals = (const uint8_t *)g_ra_map + RA_SNES_VALCACHE_OFFSET + 8;
-						int addr_count = ra_snes_addrlist_count();
-						const uint32_t *addrs = ra_snes_addrlist_addrs();
-						int show = addr_count < 30 ? addr_count : 30;
-						RA_LOG("=== N64 RDRAM Value Diagnostic (frame %u, %d addrs) ===",
-							g_n64_game_frames, addr_count);
-						int match_direct = 0, match_xor3 = 0, match_none = 0;
-						for (int i = 0; i < show; i++) {
-							uint32_t a = addrs[i];
-							uint8_t cached = vals[i];
-							uint8_t direct = (a < 0x800000) ? rdram[a] : 0;
-							uint8_t xor3   = (a < 0x800000) ? rdram[a ^ 3] : 0;
-							const char *tag;
-							if (cached == direct && cached == xor3) tag = "BOTH";
-							else if (cached == direct) { tag = "DIRECT"; match_direct++; }
-							else if (cached == xor3) { tag = "XOR3"; match_xor3++; }
-							else { tag = "DIFF"; match_none++; }
-							RA_LOG("  [%3d] addr=0x%06X cached=0x%02X direct=0x%02X xor3=0x%02X %s",
-								i, a, cached, direct, xor3, tag);
-						}
-						RA_LOG("  SUMMARY: direct=%d xor3=%d diff=%d (of %d shown)",
-							match_direct, match_xor3, match_none, show);
-
-						// SM64-specific known addresses (from code notes)
-						const struct { uint32_t addr; const char *name; } sm64[] = {
-							{0x0033b24a, "MapID"},
-							{0x0033b21d, "HP"},
-							{0x0033b21e, "Lives"},
-							{0x0033b21a, "Coins"},
-							{0x0033b218, "Stars"},
-							{0x0033b17c, "Animation"},
-							{0x0032ddfa, "MapID2"},
-							{0x0032ddf6, "CurFile"},
-						};
-						RA_LOG("  --- SM64 Known Addresses ---");
-						for (int j = 0; j < 8; j++) {
-							uint32_t a = sm64[j].addr;
-							if (a < 0x800000) {
-								uint8_t d = rdram[a];
-								uint8_t x = rdram[a ^ 3];
-								// Check if this address is in the monitored list
-								uint8_t c = 0;
-								int found = 0;
-								for (int k = 0; k < addr_count; k++) {
-									if (addrs[k] == a) { c = vals[k]; found = 1; break; }
-								}
-								RA_LOG("  SM64 %s(0x%06X): direct=0x%02X xor3=0x%02X cached=%s0x%02X",
-									sm64[j].name, a, d, x, found ? "" : "N/A:", c);
-							}
-						}
-						shmem_unmap(rdram_direct, 0x800000);
-					} else {
-						RA_LOG("N64 VALDIAG: failed to mmap RDRAM at 0x30000000");
-					}
-				}
-
-				if (g_n64_resolve_cooldown > 0) {
-					// Cooldown: evaluate normally without collection to avoid oscillation
-					g_n64_resolve_cooldown--;
-					rc_client_do_frame(g_client);
-				} else {
-					// Per-frame collection: detect pointer changes
-					// Pre-serialize state (in case pointer change corrupts evaluation)
-					{
-						size_t psize = rc_client_progress_size(g_client);
-						if (psize > g_n64_progress_size) {
-							free(g_n64_progress_buf);
-							g_n64_progress_buf = (uint8_t *)malloc(psize);
-							g_n64_progress_size = psize;
-						}
-						if (g_n64_progress_buf)
-							rc_client_serialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-					}
-
-					// Combined collection + evaluation
-					g_n64_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-					rc_client_do_frame(g_client);
-					g_n64_collecting = 0;
-
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						// Pointer change: evaluation used stale data, roll back
-						if (g_n64_progress_buf)
-							rc_client_deserialize_progress_sized(g_client, g_n64_progress_buf, g_n64_progress_size);
-						RA_LOG("N64 OptionC: Pointer change detected at game_frame=%u, %d addrs",
-							g_n64_game_frames, ra_snes_addrlist_count());
-						g_n64_cache_ready = 0;
-						g_n64_needs_recollect = 1;
-						g_n64_resolve_pass = 0;
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_n64_game_frames / 300;
-		if (milestone > 0 && milestone != g_n64_poll_logged) {
-			g_n64_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_n64_cache_time.tv_sec)
-				+ (now.tv_nsec - g_n64_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_n64_game_frames > 0) ?
-				(elapsed * 1000.0 / g_n64_game_frames) : 0.0;
-			RA_LOG("POLL(N64): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_n64_last_resp_frame, g_n64_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-		}
-		return; // N64 handled
-	}
-
-	// ================================================================
-	// MegaDrive/Genesis: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 1 && g_md_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_md_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_md_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_md_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("MD OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("MD OptionC: No addresses collected");
-			}
-		} else if (!g_md_cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_md_cache_ready = 1;
-				g_md_last_resp_frame = 0;
-				g_md_game_frames = 0;
-				g_md_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_md_cache_time);
-				RA_LOG("MD OptionC: Cache active! FPGA response matched request.");
-				// Dump address list once on activation
-				const uint32_t *a0 = ra_snes_addrlist_addrs();
-				int ac = ra_snes_addrlist_count();
-				int ad = ac < 20 ? ac : 20;
-				char ah[256]; int ap = 0;
-				for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
-					ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", ad - 1, ah, ac);
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_md_last_resp_frame) {
-				g_md_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_md_game_frames++;
-
-				if (g_md_game_frames <= 5) {
-					const uint8_t *ev = (const uint8_t *)g_ra_map + 0x48000 + 8;
-					int ec = ra_snes_addrlist_count();
-					int ed = ec < 45 ? ec : 45;
-					int enz = 0;
-					char eh[256]; int ep = 0;
-					for (int i = 0; i < ed && ep < (int)sizeof(eh) - 4; i++) {
-						ep += snprintf(eh + ep, sizeof(eh) - ep, "%02X ", ev[i]);
-						if (ev[i]) enz++;
-					}
-					RA_LOG("MD early[%u]: %s (%d nz)", g_md_game_frames, eh, enz);
-					uint8_t egs = ra_snes_addrlist_read_cached(g_ra_map, 0xF601);
-					uint8_t eact = ra_snes_addrlist_read_cached(g_ra_map, 0xFE10);
-					uint8_t ezone = ra_snes_addrlist_read_cached(g_ra_map, 0xFE11);
-					uint8_t elives = ra_snes_addrlist_read_cached(g_ra_map, 0xFE13);
-					uint8_t edemo = ra_snes_addrlist_read_cached(g_ra_map, 0xFFF0);
-					RA_LOG("MD early KEY: state=%02X act=%02X zone=%02X lives=%02X demo=%02X",
-						egs, eact, ezone, elives, edemo);
-				}
-
-				// Re-collect every ~5 min to catch address changes
-				int re_collect = (g_md_game_frames % 18000 == 0) && (g_md_game_frames > 0);
-				if (re_collect) {
-					g_md_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_md_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("MD OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_md_game_frames / 300;
-		if (milestone > 0 && milestone != g_md_poll_logged) {
-			g_md_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_md_cache_time.tv_sec)
-				+ (now.tv_nsec - g_md_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_md_game_frames > 0) ?
-				(elapsed * 1000.0 / g_md_game_frames) : 0.0;
-			RA_LOG("POLL(MD): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_md_last_resp_frame, g_md_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-			// Key address snapshot at each milestone
-			if (g_md_cache_ready && g_ra_map) {
-				uint8_t gs   = ra_snes_addrlist_read_cached(g_ra_map, 0xF601);
-				uint8_t act  = ra_snes_addrlist_read_cached(g_ra_map, 0xFE10);
-				uint8_t zone = ra_snes_addrlist_read_cached(g_ra_map, 0xFE11);
-				uint8_t lives= ra_snes_addrlist_read_cached(g_ra_map, 0xFE13);
-				uint8_t demo = ra_snes_addrlist_read_cached(g_ra_map, 0xFFF0);
-				uint8_t ffe0 = ra_snes_addrlist_read_cached(g_ra_map, 0xFFE0);
-				uint8_t ffe3 = ra_snes_addrlist_read_cached(g_ra_map, 0xFFE3);
-				uint8_t fff9 = ra_snes_addrlist_read_cached(g_ra_map, 0xFFF9);
-				RA_LOG("KEY: state=%02X act=%02X zone=%02X lives=%02X demo=%02X FFE0=%02X FFE3=%02X FFF9=%02X",
-					gs, act, zone, lives, demo, ffe0, ffe3, fff9);
-			}
-		}
-		return; // MegaDrive handled
-	}
-
-	// ================================================================
-	// Gameboy/Gameboy Color: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 4 && g_gb_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_gb_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_gb_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_gb_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("GB OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("GB OptionC: No addresses collected — achievements may have no memory refs");
-			}
-		} else if (!g_gb_cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_gb_cache_ready = 1;
-				g_gb_last_resp_frame = 0;
-				g_gb_game_frames = 0;
-				g_gb_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_gb_cache_time);
-				RA_LOG("GB OptionC: Cache active! FPGA response matched request.");
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_gb_last_resp_frame) {
-				g_gb_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;  // keep DIAG display in sync
-				g_frames_processed++;
-				g_gb_game_frames++;
-
-				// Periodically re-collect to catch address changes (every ~5 min)
-				int re_collect = (g_gb_game_frames % 18000 == 0) && (g_gb_game_frames > 0);
-				if (re_collect) {
-					g_gb_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				// Value-change watchers: log every transition of key addresses
-				{
-					static uint8_t prev_d190 = 0, prev_ff99 = 0, prev_fffa = 0;
-					static uint8_t prev_ffb3 = 0, prev_ffb4 = 0, prev_ffda = 0;
-					static uint16_t prev_score = 0;
-					static int watch_init = 0;
-
-					uint8_t cur_d190 = ra_snes_addrlist_read_cached(g_ra_map, 0xD190);
-					uint8_t cur_ff99 = ra_snes_addrlist_read_cached(g_ra_map, 0xFF99);
-					uint8_t cur_fffa = ra_snes_addrlist_read_cached(g_ra_map, 0xFFFA);
-					uint8_t cur_ffb3 = ra_snes_addrlist_read_cached(g_ra_map, 0xFFB3);
-					uint8_t cur_ffb4 = ra_snes_addrlist_read_cached(g_ra_map, 0xFFB4);
-					uint8_t cur_ffda = ra_snes_addrlist_read_cached(g_ra_map, 0xFFDA);
-					uint16_t cur_score = ra_snes_addrlist_read_cached(g_ra_map, 0xC0A0)
-					                   | (ra_snes_addrlist_read_cached(g_ra_map, 0xC0A1) << 8);
-
-					if (!watch_init) {
-						watch_init = 1;
-						prev_d190 = cur_d190; prev_ff99 = cur_ff99;
-						prev_fffa = cur_fffa; prev_ffb3 = cur_ffb3;
-						prev_ffb4 = cur_ffb4; prev_ffda = cur_ffda;
-						prev_score = cur_score;
-					} else {
-						if (cur_d190 != prev_d190)
-							RA_LOG("WATCH: D190 %02X->%02X gf=%u (FF99=%02X score=%04X D192=%02X D193=%02X)",
-								prev_d190, cur_d190, g_gb_game_frames, cur_ff99, cur_score,
-								ra_snes_addrlist_read_cached(g_ra_map, 0xD192),
-								ra_snes_addrlist_read_cached(g_ra_map, 0xD193));
-						if (cur_ff99 != prev_ff99)
-							RA_LOG("WATCH: FF99 %02X->%02X gf=%u (D190=%02X)",
-								prev_ff99, cur_ff99, g_gb_game_frames, cur_d190);
-						if (cur_fffa != prev_fffa)
-							RA_LOG("WATCH: FFFA %02X->%02X gf=%u (coin count)",
-								prev_fffa, cur_fffa, g_gb_game_frames);
-						if (cur_ffb3 != prev_ffb3)
-							RA_LOG("WATCH: FFB3 %02X->%02X gf=%u",
-								prev_ffb3, cur_ffb3, g_gb_game_frames);
-						if (cur_ffb4 != prev_ffb4)
-							RA_LOG("WATCH: FFB4 %02X->%02X gf=%u",
-								prev_ffb4, cur_ffb4, g_gb_game_frames);
-						if (cur_ffda != prev_ffda)
-							RA_LOG("WATCH: FFDA %02X->%02X gf=%u",
-								prev_ffda, cur_ffda, g_gb_game_frames);
-						if (cur_score != prev_score)
-							RA_LOG("WATCH: score %04X->%04X gf=%u (D190=%02X FF99=%02X)",
-								prev_score, cur_score, g_gb_game_frames, cur_d190, cur_ff99);
-						prev_d190 = cur_d190; prev_ff99 = cur_ff99;
-						prev_fffa = cur_fffa; prev_ffb3 = cur_ffb3;
-						prev_ffb4 = cur_ffb4; prev_ffda = cur_ffda;
-						prev_score = cur_score;
-					}
-				}
-
-				if (re_collect) {
-					g_gb_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("GB OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		// Periodic GB debug — log once per 300-frame milestone
-		uint32_t milestone = g_gb_game_frames / 300;
-		if (milestone > 0 && milestone != g_gb_poll_logged) {
-			g_gb_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_gb_cache_time.tv_sec)
-				+ (now.tv_nsec - g_gb_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_gb_game_frames > 0) ?
-				(elapsed * 1000.0 / g_gb_game_frames) : 0.0;
-			RA_LOG("POLL(GB): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_gb_last_resp_frame, g_gb_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-		}
-		return; // Gameboy handled
-	}
-
-	// ================================================================
-	// SMS / Game Gear: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 11 && g_sms_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_sms_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_sms_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_sms_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("SMS OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("SMS OptionC: No addresses collected");
-			}
-		} else if (!g_sms_cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_sms_cache_ready = 1;
-				g_sms_last_resp_frame = 0;
-				g_sms_game_frames = 0;
-				g_sms_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_sms_cache_time);
-				RA_LOG("SMS OptionC: Cache active! FPGA response matched request.");
-				const uint32_t *a0 = ra_snes_addrlist_addrs();
-				int ac = ra_snes_addrlist_count();
-				int ad = ac < 20 ? ac : 20;
-				char ah[256]; int ap = 0;
-				for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
-					ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", ad - 1, ah, ac);
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_sms_last_resp_frame) {
-				g_sms_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_sms_game_frames++;
-
-				// Re-collect every ~5 min to catch address changes
-				int re_collect = (g_sms_game_frames % 18000 == 0) && (g_sms_game_frames > 0);
-				if (re_collect) {
-					g_sms_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_sms_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("SMS OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_sms_game_frames / 300;
-		if (milestone > 0 && milestone != g_sms_poll_logged) {
-			g_sms_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_sms_cache_time.tv_sec)
-				+ (now.tv_nsec - g_sms_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_sms_game_frames > 0) ?
-				(elapsed * 1000.0 / g_sms_game_frames) : 0.0;
-			RA_LOG("POLL(SMS): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_sms_last_resp_frame, g_sms_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-		}
-		return; // SMS handled
-	}
-
-	// ================================================================
-	// NeoGeo (Arcade): Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 27 && g_neogeo_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_neogeo_cache_ready) {
-			// Phase 1: Bootstrap — collect addresses with zeros
-			g_neogeo_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_neogeo_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				g_neogeo_needs_recollect = 1;
-				g_neogeo_resolve_pass = 0;
-				RA_LOG("NeoGeo OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("NeoGeo OptionC: No addresses collected");
-			}
-		} else if (!g_neogeo_cache_ready) {
-			// Phase 2/4: Wait for FPGA cache
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_neogeo_cache_ready = 1;
-				g_neogeo_last_resp_frame = 0;
-				g_neogeo_game_frames = 0;
-				g_neogeo_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_neogeo_cache_time);
-				if (g_neogeo_needs_recollect) {
-					RA_LOG("NeoGeo OptionC: Cache active (pre-recollect). Will resolve pointers.");
-				} else {
-					RA_LOG("NeoGeo OptionC: Cache active! FPGA response matched request.");
-				}
-				const uint32_t *a0 = ra_snes_addrlist_addrs();
-				int ac = ra_snes_addrlist_count();
-				int ad = ac < 20 ? ac : 20;
-				char ah[256]; int ap = 0;
-				for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
-					ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
-				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", ad - 1, ah, ac);
-			}
-		} else if (g_neogeo_needs_recollect) {
-			// Phase 3: Pointer-resolution re-collection
-			// Now that cache has real values, AddAddress conditions will
-			// compute correct derived addresses from pointer base values.
-			g_neogeo_resolve_pass++;
-			g_neogeo_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_neogeo_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed && g_neogeo_resolve_pass < 4) {
-				RA_LOG("NeoGeo OptionC: Pointer-resolve pass %d, %d addrs (changed, retrying)",
-					g_neogeo_resolve_pass, ra_snes_addrlist_count());
-				g_neogeo_cache_ready = 0; // wait for new FPGA data
-			} else {
-				g_neogeo_needs_recollect = 0;
-				if (changed) {
-					RA_LOG("NeoGeo OptionC: Pointer-resolve done (max passes), %d addrs",
-						ra_snes_addrlist_count());
-					g_neogeo_cache_ready = 0;
-				} else {
-					RA_LOG("NeoGeo OptionC: Pointer-resolve complete, no address changes (%d addrs)",
-						ra_snes_addrlist_count());
-				}
-			}
-		} else {
-			// Phase 5: Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_neogeo_last_resp_frame) {
-				g_neogeo_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_neogeo_game_frames++;
-
-				// Re-collect every 600 frames (~10s) to track pointer changes
-				int re_collect = (g_neogeo_game_frames % 600 == 0) && (g_neogeo_game_frames > 0);
-				if (re_collect) {
-					g_neogeo_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_neogeo_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("NeoGeo OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-						g_neogeo_cache_ready = 0; // wait for new FPGA data
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_neogeo_game_frames / 300;
-		if (milestone > 0 && milestone != g_neogeo_poll_logged) {
-			g_neogeo_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_neogeo_cache_time.tv_sec)
-				+ (now.tv_nsec - g_neogeo_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_neogeo_game_frames > 0) ?
-				(elapsed * 1000.0 / g_neogeo_game_frames) : 0.0;
-			RA_LOG("POLL(NeoGeo): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_neogeo_last_resp_frame, g_neogeo_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-		}
-		return; // NeoGeo handled
-	}
-
-	// ================================================================
-	// GBA: Option C — selective address reading
-	// ================================================================
-	if (g_client && g_game_loaded && ra_get_console_id() == 5 && g_gba_optionc) {
-		if (ra_snes_addrlist_count() == 0 && !g_gba_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_gba_collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(g_client);
-			g_gba_collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(g_ra_map);
-			if (changed) {
-				RA_LOG("GBA OptionC: Bootstrap collection done, %d addrs written to DDRAM",
-					ra_snes_addrlist_count());
-			} else {
-				RA_LOG("GBA OptionC: No addresses collected — achievements may have no memory refs");
-			}
-		} else if (!g_gba_cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(g_ra_map)) {
-				g_gba_cache_ready = 1;
-				g_gba_last_resp_frame = 0;
-				g_gba_game_frames = 0;
-				g_gba_poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_gba_cache_time);
-				RA_LOG("GBA OptionC: Cache active! FPGA response matched request.");
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
-			if (resp_frame > g_gba_last_resp_frame) {
-				g_gba_last_resp_frame = resp_frame;
-				g_last_frame = resp_frame;
-				g_frames_processed++;
-				g_gba_game_frames++;
-
-				// Re-collect every ~5 min to catch address changes
-				int re_collect = (g_gba_game_frames % 18000 == 0) && (g_gba_game_frames > 0);
-				if (re_collect) {
-					g_gba_collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(g_client);
-
-				if (re_collect) {
-					g_gba_collecting = 0;
-					if (ra_snes_addrlist_end_collect(g_ra_map)) {
-						RA_LOG("GBA OptionC: Address list refreshed, %d addrs",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		uint32_t milestone = g_gba_game_frames / 300;
-		if (milestone > 0 && milestone != g_gba_poll_logged) {
-			g_gba_poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_gba_cache_time.tv_sec)
-				+ (now.tv_nsec - g_gba_cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_gba_game_frames > 0) ?
-				(elapsed * 1000.0 / g_gba_game_frames) : 0.0;
-			RA_LOG("POLL(GBA): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d",
-				g_gba_last_resp_frame, g_gba_game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count());
-		}
-		return; // GBA handled
-	}
+	// --- removed per-console poll blocks (now handled by handler->poll()) ---
 #endif
 
 	// ================================================================
@@ -2896,7 +1186,7 @@ void achievements_poll(void)
 
 void achievements_unload_game(void)
 {
-	if (!ra_core_supported()) return;
+	if (!g_active_handler) return;
 
 	RA_LOG("--- Game Unload ---");
 	RA_LOG("Stats: %u frames processed, %u skipped", g_frames_processed, g_frames_skipped);
@@ -2907,45 +1197,15 @@ void achievements_unload_game(void)
 	}
 #endif
 
+	g_active_handler->reset();
+	ra_snes_addrlist_init();
+
 	g_game_loaded = 0;
 	g_game_load_pending = 0;
 	g_last_frame = 0;
 	g_mirror_validated = 0;
-	g_snes_optionc = 0;
 	g_rom_md5[0] = '\0';
 	g_rom_path[0] = '\0';
-	g_snes_collecting = 0;
-	g_snes_cache_ready = 0;
-	g_snes_last_resp_frame = 0;
-	g_snes_game_frames = 0;
-	g_snes_poll_logged = 0;
-	g_sms_optionc = 0;
-	g_sms_collecting = 0;
-	g_sms_cache_ready = 0;
-	g_sms_last_resp_frame = 0;
-	g_sms_game_frames = 0;
-	g_sms_poll_logged = 0;
-	g_gb_optionc = 0;
-	g_gb_collecting = 0;
-	g_gb_cache_ready = 0;
-	g_gb_last_resp_frame = 0;
-	g_gb_game_frames = 0;
-	g_gb_poll_logged = 0;
-	g_gba_optionc = 0;
-	g_gba_collecting = 0;
-	g_gba_cache_ready = 0;
-	g_gba_last_resp_frame = 0;
-	g_gba_game_frames = 0;
-	g_gba_poll_logged = 0;
-	g_neogeo_optionc = 0;
-	g_neogeo_collecting = 0;
-	g_neogeo_cache_ready = 0;
-	g_neogeo_needs_recollect = 0;
-	g_neogeo_resolve_pass = 0;
-	g_neogeo_last_resp_frame = 0;
-	g_neogeo_game_frames = 0;
-	g_neogeo_poll_logged = 0;
-	ra_snes_addrlist_init();
 
 	// Clear pending notifications
 	s_urgent_head = s_urgent_tail = 0;

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -157,6 +157,7 @@ static uint32_t g_psx_last_resp_frame = 0;
 static uint32_t g_psx_game_frames = 0;
 static uint32_t g_psx_poll_logged = 0;
 static struct timespec g_psx_cache_time;
+static int g_psx_rtquery = 0;           // 1 if FPGA supports realtime queries
 
 // MegaDrive/Genesis state (Option C, same infrastructure)
 static int g_md_optionc = 0;
@@ -213,6 +214,8 @@ static struct timespec g_gba_cache_time;
 static int g_neogeo_optionc = 0;
 static int g_neogeo_collecting = 0;
 static int g_neogeo_cache_ready = 0;
+static int g_neogeo_needs_recollect = 0;
+static int g_neogeo_resolve_pass = 0;
 static uint32_t g_neogeo_last_resp_frame = 0;
 static uint32_t g_neogeo_game_frames = 0;
 static uint32_t g_neogeo_poll_logged = 0;
@@ -778,6 +781,13 @@ static uint32_t ra_read_memory(uint32_t address, uint8_t *buffer,
 						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
 					return num_bytes;
 				}
+				// Realtime query fallback for addresses not in batch cache
+				if (g_psx_rtquery && !g_psx_collecting && num_bytes <= 4) {
+					uint32_t val = ra_rtquery_read(g_ra_map, address, num_bytes);
+					for (uint32_t i = 0; i < num_bytes; i++)
+						buffer[i] = (uint8_t)(val >> (i * 8));
+					return num_bytes;
+				}
 				memset(buffer, 0, num_bytes);
 				return num_bytes;
 			}
@@ -863,14 +873,15 @@ static uint32_t ra_read_memory(uint32_t address, uint8_t *buffer,
 			memset(buffer, 0, num_bytes);
 			return num_bytes;
 		case 27: // RC_CONSOLE_ARCADE (NeoGeo)
+			// NeoGeo 68K big-endian: XOR addr bit 0 to match RA LE-host convention
 			if (g_neogeo_optionc) {
 				if (g_neogeo_collecting) {
 					for (uint32_t i = 0; i < num_bytes; i++)
-						ra_snes_addrlist_add(address + i);
+						ra_snes_addrlist_add((address + i) ^ 1);
 				}
 				if (g_neogeo_cache_ready) {
 					for (uint32_t i = 0; i < num_bytes; i++)
-						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, address + i);
+						buffer[i] = ra_snes_addrlist_read_cached(g_ra_map, (address + i) ^ 1);
 					return num_bytes;
 				}
 				memset(buffer, 0, num_bytes);
@@ -1425,6 +1436,8 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 	g_neogeo_optionc = 0;
 	g_neogeo_collecting = 0;
 	g_neogeo_cache_ready = 0;
+	g_neogeo_needs_recollect = 0;
+	g_neogeo_resolve_pass = 0;
 	g_neogeo_last_resp_frame = 0;
 	g_neogeo_game_frames = 0;
 	g_neogeo_poll_logged = 0;
@@ -1537,6 +1550,14 @@ void achievements_poll(void)
 			if (ra_get_console_id() == 12) {
 				g_psx_optionc = 1;
 				RA_LOG("PSX FPGA protocol: Option C (selective address reading)");
+					if (ra_rtquery_supported(g_ra_map)) {
+						g_psx_rtquery = 1;
+						ra_rtquery_init(g_ra_map);
+						RA_LOG("PSX: Realtime queries supported (FPGA v2+)");
+					} else {
+						g_psx_rtquery = 0;
+						RA_LOG("PSX: Realtime queries NOT supported (FPGA v1)");
+					}
 			}
 			if (ra_get_console_id() == 1) {
 				g_md_optionc = 1;
@@ -1821,6 +1842,52 @@ void achievements_poll(void)
 				g_gba_cache_ready ? "active" : "waiting",
 				ra_snes_addrlist_response_frame(g_ra_map),
 				g_gba_game_frames);
+		} else if (console == 27 && g_neogeo_optionc) {
+			// NeoGeo Option C: show address cache status and value dump
+			RA_LOG("NeoGeo OptionC: addrs=%d cache=%s resp_frame=%u game_frames=%u",
+				ra_snes_addrlist_count(),
+				g_neogeo_cache_ready ? "active" : "waiting",
+				ra_snes_addrlist_response_frame(g_ra_map),
+				g_neogeo_game_frames);
+			if (g_neogeo_cache_ready && g_ra_map) {
+				const uint8_t *vals = (const uint8_t *)g_ra_map + 0x48000 + 8;
+				int cnt = ra_snes_addrlist_count();
+				int dump_len = cnt < 52 ? cnt : 52;
+				int non_zero = 0;
+				char hex[400];
+				int pos = 0;
+				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+					if (vals[i]) non_zero++;
+				}
+				RA_LOG("VALCACHE[0..%d]: %s (%d non-zero)", dump_len - 1, hex, non_zero);
+				// Dump address list
+				const uint32_t *addrs = ra_snes_addrlist_addrs();
+				char ahex[400];
+				int apos = 0;
+				for (int i = 0; i < dump_len && apos < (int)sizeof(ahex) - 8; i++)
+					apos += snprintf(ahex + apos, sizeof(ahex) - apos, "%04X ", addrs[i]);
+				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", dump_len - 1, ahex, cnt);
+				// FPGA debug words
+				const uint8_t *base = (const uint8_t *)g_ra_map;
+				const uint64_t *dbg1 = (const uint64_t *)(base + 0x10);
+				uint64_t d1 = *dbg1;
+				uint8_t  fpga_ver     = (d1 >> 56) & 0xFF;
+				uint8_t  dispatch_cnt = (d1 >> 48) & 0xFF;
+				uint16_t ok_cnt       = (d1 >> 32) & 0xFFFF;
+				uint16_t oob_cnt      = (d1 >> 16) & 0xFFFF;
+				RA_LOG("NeoGeo FPGA: ver=0x%02X dispatch=%u ok=%u oob=%u",
+					fpga_ver, dispatch_cnt, ok_cnt, oob_cnt);
+				// Debug records (first 2 addresses)
+				const uint64_t *dbg2 = (const uint64_t *)(base + 0x18);
+				uint64_t d2 = *dbg2;
+				uint32_t rec0 = d2 & 0xFFFFFFFF;
+				uint32_t rec1 = (d2 >> 32) & 0xFFFFFFFF;
+				RA_LOG("NeoGeo REC[0]: bram=0x%04X a0=%u wraml=0x%02X wramu=0x%02X",
+					(rec0 >> 17) & 0x7FFF, (rec0 >> 16) & 1, (rec0 >> 8) & 0xFF, rec0 & 0xFF);
+				RA_LOG("NeoGeo REC[1]: bram=0x%04X a0=%u wraml=0x%02X wramu=0x%02X",
+					(rec1 >> 17) & 0x7FFF, (rec1 >> 16) & 1, (rec1 >> 8) & 0xFF, rec1 & 0xFF);
+			}
 		} else {
 			// NES: region-based layout
 			const uint8_t *cpuram = ra_ramread_region_data(g_ra_map, 0);
@@ -2578,27 +2645,33 @@ void achievements_poll(void)
 	// ================================================================
 	if (g_client && g_game_loaded && ra_get_console_id() == 27 && g_neogeo_optionc) {
 		if (ra_snes_addrlist_count() == 0 && !g_neogeo_cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
+			// Phase 1: Bootstrap — collect addresses with zeros
 			g_neogeo_collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(g_client);
 			g_neogeo_collecting = 0;
 			int changed = ra_snes_addrlist_end_collect(g_ra_map);
 			if (changed) {
+				g_neogeo_needs_recollect = 1;
+				g_neogeo_resolve_pass = 0;
 				RA_LOG("NeoGeo OptionC: Bootstrap collection done, %d addrs written to DDRAM",
 					ra_snes_addrlist_count());
 			} else {
 				RA_LOG("NeoGeo OptionC: No addresses collected");
 			}
 		} else if (!g_neogeo_cache_ready) {
-			// Wait for FPGA to respond with cached values
+			// Phase 2/4: Wait for FPGA cache
 			if (ra_snes_addrlist_is_ready(g_ra_map)) {
 				g_neogeo_cache_ready = 1;
 				g_neogeo_last_resp_frame = 0;
 				g_neogeo_game_frames = 0;
 				g_neogeo_poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_neogeo_cache_time);
-				RA_LOG("NeoGeo OptionC: Cache active! FPGA response matched request.");
+				if (g_neogeo_needs_recollect) {
+					RA_LOG("NeoGeo OptionC: Cache active (pre-recollect). Will resolve pointers.");
+				} else {
+					RA_LOG("NeoGeo OptionC: Cache active! FPGA response matched request.");
+				}
 				const uint32_t *a0 = ra_snes_addrlist_addrs();
 				int ac = ra_snes_addrlist_count();
 				int ad = ac < 20 ? ac : 20;
@@ -2607,8 +2680,33 @@ void achievements_poll(void)
 					ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
 				RA_LOG("ADDRLIST[0..%d]: %s (total=%d)", ad - 1, ah, ac);
 			}
+		} else if (g_neogeo_needs_recollect) {
+			// Phase 3: Pointer-resolution re-collection
+			// Now that cache has real values, AddAddress conditions will
+			// compute correct derived addresses from pointer base values.
+			g_neogeo_resolve_pass++;
+			g_neogeo_collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(g_client);
+			g_neogeo_collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(g_ra_map);
+			if (changed && g_neogeo_resolve_pass < 4) {
+				RA_LOG("NeoGeo OptionC: Pointer-resolve pass %d, %d addrs (changed, retrying)",
+					g_neogeo_resolve_pass, ra_snes_addrlist_count());
+				g_neogeo_cache_ready = 0; // wait for new FPGA data
+			} else {
+				g_neogeo_needs_recollect = 0;
+				if (changed) {
+					RA_LOG("NeoGeo OptionC: Pointer-resolve done (max passes), %d addrs",
+						ra_snes_addrlist_count());
+					g_neogeo_cache_ready = 0;
+				} else {
+					RA_LOG("NeoGeo OptionC: Pointer-resolve complete, no address changes (%d addrs)",
+						ra_snes_addrlist_count());
+				}
+			}
 		} else {
-			// Normal frame processing from cache
+			// Phase 5: Normal frame processing from cache
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(g_ra_map);
 			if (resp_frame > g_neogeo_last_resp_frame) {
 				g_neogeo_last_resp_frame = resp_frame;
@@ -2616,8 +2714,8 @@ void achievements_poll(void)
 				g_frames_processed++;
 				g_neogeo_game_frames++;
 
-				// Re-collect every ~5 min to catch address changes
-				int re_collect = (g_neogeo_game_frames % 18000 == 0) && (g_neogeo_game_frames > 0);
+				// Re-collect every 600 frames (~10s) to track pointer changes
+				int re_collect = (g_neogeo_game_frames % 600 == 0) && (g_neogeo_game_frames > 0);
 				if (re_collect) {
 					g_neogeo_collecting = 1;
 					ra_snes_addrlist_begin_collect();
@@ -2630,6 +2728,7 @@ void achievements_poll(void)
 					if (ra_snes_addrlist_end_collect(g_ra_map)) {
 						RA_LOG("NeoGeo OptionC: Address list refreshed, %d addrs",
 							ra_snes_addrlist_count());
+						g_neogeo_cache_ready = 0; // wait for new FPGA data
 					}
 				}
 			}
@@ -2841,6 +2940,8 @@ void achievements_unload_game(void)
 	g_neogeo_optionc = 0;
 	g_neogeo_collecting = 0;
 	g_neogeo_cache_ready = 0;
+	g_neogeo_needs_recollect = 0;
+	g_neogeo_resolve_pass = 0;
 	g_neogeo_last_resp_frame = 0;
 	g_neogeo_game_frames = 0;
 	g_neogeo_poll_logged = 0;

--- a/achievements.h
+++ b/achievements.h
@@ -43,4 +43,7 @@ void achievements_info(void);
 // Returns 1 if hardcore mode is enabled in retroachievements.cfg
 int achievements_hardcore_active(void);
 
+// Update global frame counters (called by per-console poll handlers)
+void ra_frame_processed(uint32_t frame);
+
 #endif // ACHIEVEMENTS_H

--- a/achievements_atari2600.cpp
+++ b/achievements_atari2600.cpp
@@ -1,0 +1,175 @@
+// achievements_atari2600.cpp — RetroAchievements Atari 2600-specific implementation
+//
+// The Atari 2600 core lives inside the Atari7800_MiSTer. The FPGA copies
+// the RIOT (M6532) internal 128-byte RAM to DDRAM each TIA VBlank,
+// using the same "RACH" protocol as the NES mirror.
+//
+// Memory layout for rcheevos (RC_CONSOLE_ATARI_2600 = 25):
+//   $0080-$00FF: RIOT internal RAM (128 bytes), region 0
+//   The address range $0080-$00FF may appear mirrored at $0180-$01FF etc.
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "lib/md5/md5.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// Atari 2600 Implementation
+// ---------------------------------------------------------------------------
+
+static uint32_t s_poll_count = 0;
+
+static void atari2600_init(void)
+{
+	// No console-specific state
+}
+
+static void atari2600_reset(void)
+{
+	s_poll_count = 0;
+}
+
+static uint32_t atari2600_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	return ra_ramread_atari2600_read(map, address, buffer, num_bytes);
+}
+
+// Track last-seen values so we only log when something changes
+static uint32_t s_last_frame   = 0xFFFFFFFF;
+static int      s_last_nonzero = -1;
+
+static int atari2600_poll(void *map, void *client, int game_loaded)
+{
+	(void)client;
+	(void)game_loaded;
+
+	s_poll_count++;
+
+	// Log on first poll, then only when DDRAM state changes or every ~5 minutes
+	int force_log = (s_poll_count == 1) || ((s_poll_count % 18000) == 0);
+
+	const uint8_t *b = (const uint8_t *)map;
+	if (!b) return 0;
+
+	uint32_t frame_ctr = b[8]  | ((uint32_t)b[9]<<8)  | ((uint32_t)b[10]<<16) | ((uint32_t)b[11]<<24);
+
+	int nonzero = 0;
+	for (int i = 256; i < 384; i++) {
+		if (b[i] != 0) nonzero++;
+	}
+
+	int changed = (frame_ctr != s_last_frame) || (nonzero != s_last_nonzero);
+
+	if (force_log || changed) {
+		uint32_t magic     = b[0]  | ((uint32_t)b[1]<<8)  | ((uint32_t)b[2]<<16) | ((uint32_t)b[3]<<24);
+		uint16_t desc_size = b[20] | ((uint16_t)b[21]<<8);
+		uint16_t desc_offs = b[22] | ((uint16_t)b[23]<<8);
+
+		ra_log_write("A2600 poll=%u magic=0x%08X frame=%u desc_size=%u desc_offs=0x%04X RIOT=%d/128\n",
+			s_poll_count, magic, frame_ctr, desc_size, desc_offs, nonzero);
+
+		if (changed && nonzero == 0 && s_last_nonzero != 0) {
+			// RIOT data just became all-zeros: dump raw bytes for diagnosis
+			ra_log_write("A2600 DDRAM[0x00]: %02X%02X%02X%02X %02X%02X%02X%02X\n",
+				b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
+			ra_log_write("A2600 DDRAM[0x10]: %02X%02X%02X%02X %02X%02X%02X%02X\n",
+				b[16], b[17], b[18], b[19], b[20], b[21], b[22], b[23]);
+		}
+		if (nonzero > 0 && s_last_nonzero == 0) {
+			// RIOT data just became non-zero: dump first 16 bytes
+			ra_log_write("A2600 RIOT[0x100..]: %02X %02X %02X %02X %02X %02X %02X %02X "
+				"%02X %02X %02X %02X %02X %02X %02X %02X\n",
+				b[256],b[257],b[258],b[259],b[260],b[261],b[262],b[263],
+				b[264],b[265],b[266],b[267],b[268],b[269],b[270],b[271]);
+		}
+
+		s_last_frame   = frame_ctr;
+		s_last_nonzero = nonzero;
+	}
+
+	return 0;
+}
+
+static void atari2600_detect_protocol(void *map)
+{
+	(void)map;
+	// Region-based layout; no protocol detection needed
+}
+
+static int atari2600_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+	// Atari 2600: raw MD5 of the ROM file (no header to strip for plain .a26 ROMs)
+	// .a78 files (Atari 7800 format) are not used for 2600 mode; we always get raw .a26
+	FILE *f = fopen(rom_path, "rb");
+	if (!f) {
+		ra_log_write("ATARI2600: Failed to open ROM for hashing: %s\n", rom_path);
+		return 0;
+	}
+
+	fseek(f, 0, SEEK_END);
+	long file_size = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	if (file_size <= 0) {
+		fclose(f);
+		return 0;
+	}
+
+	uint8_t *rom_data = (uint8_t *)malloc(file_size);
+	if (!rom_data) {
+		fclose(f);
+		return 0;
+	}
+
+	size_t nread = fread(rom_data, 1, file_size, f);
+	fclose(f);
+
+	if ((long)nread != file_size) {
+		free(rom_data);
+		return 0;
+	}
+
+	MD5_CTX ctx;
+	MD5Init(&ctx);
+	MD5Update(&ctx, rom_data, file_size);
+	unsigned char md5_bin[16];
+	MD5Final(md5_bin, &ctx);
+
+	for (int i = 0; i < 16; i++) {
+		sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
+	}
+	md5_hex_out[32] = '\0';
+
+	free(rom_data);
+	return 1;
+}
+
+static void atari2600_set_hardcore(int enabled)
+{
+	// Atari 2600 has no cheat or savestate status bits to control
+	(void)enabled;
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_atari2600 = {
+	.init             = atari2600_init,
+	.reset            = atari2600_reset,
+	.read_memory      = atari2600_read_memory,
+	.poll             = atari2600_poll,
+	.calculate_hash   = atari2600_calculate_hash,
+	.set_hardcore     = atari2600_set_hardcore,
+	.detect_protocol  = atari2600_detect_protocol,
+	.console_id       = 25,  // RC_CONSOLE_ATARI_2600
+	.name             = "ATARI7800"  // matches user_io_get_core_name() for this core
+};

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -63,6 +63,8 @@ extern const console_handler_t g_console_gameboy;
 extern const console_handler_t g_console_sms;
 extern const console_handler_t g_console_neogeo;
 extern const console_handler_t g_console_gba;
+extern const console_handler_t g_console_megacd;
+extern const console_handler_t g_console_atari2600;
 
 // Get console handler by core name (returns NULL if not found)
 const console_handler_t *get_console_handler_by_name(const char *core_name);

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -13,7 +13,7 @@ typedef struct {
 	int optionc;              // 1 if FPGA has Option C protocol
 	int collecting;           // 1 during address collection do_frame
 	int cache_ready;          // 1 when FPGA response matches request
-	int needs_recollect;      // 1 if re-collection needed (PSX/N64)
+	int needs_recollect;      // 1 if re-collection needed (PSX/N64/NeoGeo)
 	uint32_t last_resp_frame; // Last processed response frame
 	uint32_t game_frames;     // Frames processed since cache active
 	uint32_t poll_logged;     // Last game_frames milestone logged
@@ -23,28 +23,33 @@ typedef struct {
 
 // Console-specific interface
 typedef struct {
-	// Initialize console-specific state
+	// Initialize console-specific state (called once at startup)
 	void (*init)(void);
-	
+
 	// Reset console state (called on load_game)
 	void (*reset)(void);
-	
+
 	// Read memory for this console
 	uint32_t (*read_memory)(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
-	
-	// Poll achievements for this console (called every frame)
-	void (*poll)(void *map, void *client, int game_loaded);
-	
-	// Calculate ROM hash (NULL = use default MD5)
+
+	// Poll achievements for this console (called every frame from achievements_poll).
+	// Returns 1 if this console handled the frame (achievements_poll should return immediately).
+	// Returns 0 to fall through to the default frame-tracking path (NES, SNES VBlank-gated).
+	int (*poll)(void *map, void *client, int game_loaded);
+
+	// Calculate ROM hash (returns 1 on success, 0 to use default MD5)
 	int (*calculate_hash)(const char *rom_path, char *md5_hex_out);
-	
-	// Set hardcore mode bits (NULL = no hardcore mode support)
+
+	// Set hardcore mode bits (NULL = no FPGA mapping for this console)
 	void (*set_hardcore)(int enabled);
-	
+
+	// Detect FPGA protocol type (called when DDRAM mirror first activates)
+	void (*detect_protocol)(void *map);
+
 	// Get console ID (RC_CONSOLE_*)
 	int console_id;
-	
-	// Console name
+
+	// Console name (matches user_io_get_core_name)
 	const char *name;
 } console_handler_t;
 
@@ -55,11 +60,11 @@ extern const console_handler_t g_console_genesis;
 extern const console_handler_t g_console_psx;
 extern const console_handler_t g_console_n64;
 extern const console_handler_t g_console_gameboy;
-extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_sms;
 extern const console_handler_t g_console_neogeo;
+extern const console_handler_t g_console_gba;
 
-// Get console handler by name (returns NULL if not found)
+// Get console handler by core name (returns NULL if not found)
 const console_handler_t *get_console_handler_by_name(const char *core_name);
 
 // Get console handler by ID (returns NULL if not found)
@@ -67,15 +72,5 @@ const console_handler_t *get_console_handler_by_id(int console_id);
 
 // Initialize all console handlers (called once at startup)
 void init_all_console_handlers(void);
-
-// Declare protocol detection functions (called from main achievements code)
-void snes_detect_protocol(void *map);
-void genesis_detect_protocol(void *map);
-void psx_detect_protocol(void *map);
-void n64_detect_protocol(void *map);
-void gameboy_detect_protocol(void *map);
-void gba_detect_protocol(void *map);
-void sms_detect_protocol(void *map);
-void neogeo_detect_protocol(void *map);
 
 #endif // ACHIEVEMENTS_CONSOLE_H

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -11,9 +11,9 @@ extern const console_handler_t g_console_genesis;
 extern const console_handler_t g_console_psx;
 extern const console_handler_t g_console_n64;
 extern const console_handler_t g_console_gameboy;
-extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_sms;
 extern const console_handler_t g_console_neogeo;
+extern const console_handler_t g_console_gba;
 
 // Master lookup table
 static const console_handler_t *g_console_handlers[] = {
@@ -23,9 +23,9 @@ static const console_handler_t *g_console_handlers[] = {
 	&g_console_psx,
 	&g_console_n64,
 	&g_console_gameboy,
-	&g_console_gba,
 	&g_console_sms,
 	&g_console_neogeo,
+	&g_console_gba,
 	NULL
 };
 

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -14,6 +14,8 @@ extern const console_handler_t g_console_gameboy;
 extern const console_handler_t g_console_sms;
 extern const console_handler_t g_console_neogeo;
 extern const console_handler_t g_console_gba;
+extern const console_handler_t g_console_megacd;
+extern const console_handler_t g_console_atari2600;
 
 // Master lookup table
 static const console_handler_t *g_console_handlers[] = {
@@ -26,6 +28,8 @@ static const console_handler_t *g_console_handlers[] = {
 	&g_console_sms,
 	&g_console_neogeo,
 	&g_console_gba,
+	&g_console_megacd,
+	&g_console_atari2600,
 	NULL
 };
 

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -22,8 +22,8 @@ static console_state_t g_gb_state = {};
 // Value-change watchers for debugging
 typedef struct {
 	uint32_t addr;
-	uint8_t last_val;
-	int initialized;
+	uint8_t  last_val;
+	int      initialized;
 	const char *name;
 } gb_watcher_t;
 
@@ -46,20 +46,15 @@ static gb_watcher_t g_gb_watchers[] = {
 static void gameboy_init(void)
 {
 	memset(&g_gb_state, 0, sizeof(g_gb_state));
-	memset(g_gb_watchers, 0, sizeof(g_gb_watchers));
-	ra_snes_addrlist_init();
+	for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+		g_gb_watchers[i].initialized = 0;
+		g_gb_watchers[i].last_val = 0;
+	}
 }
 
 static void gameboy_reset(void)
 {
-	g_gb_state.optionc = 0;
-	g_gb_state.collecting = 0;
-	g_gb_state.cache_ready = 0;
-	g_gb_state.last_resp_frame = 0;
-	g_gb_state.game_frames = 0;
-	g_gb_state.poll_logged = 0;
-	
-	// Reset watchers
+	memset(&g_gb_state, 0, sizeof(g_gb_state));
 	for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
 		g_gb_watchers[i].initialized = 0;
 		g_gb_watchers[i].last_val = 0;
@@ -84,62 +79,45 @@ static uint32_t gameboy_read_memory(void *map, uint32_t address, uint8_t *buffer
 	return 0;
 }
 
-static void gameboy_poll(void *map, void *client, int game_loaded)
+static int gameboy_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_gb_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_gb_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
 	if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
-		// Bootstrap
+		// Bootstrap: run one do_frame with zeros to discover needed addresses
 		g_gb_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_gb_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("GameBoy OptionC: Bootstrap collection done, %d addrs\n",
+			ra_log_write("GB OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("GB OptionC: No addresses collected — achievements may have no memory refs\n");
 		}
 	} else if (!g_gb_state.cache_ready) {
-		// Wait for cache
+		// Wait for FPGA to respond with cached values
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_gb_state.cache_ready = 1;
 			g_gb_state.last_resp_frame = 0;
 			g_gb_state.game_frames = 0;
 			g_gb_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_gb_state.cache_time);
-			ra_log_write("GameBoy OptionC: Cache active!\n");
+			ra_log_write("GB OptionC: Cache active! FPGA response matched request.\n");
 		}
 	} else {
-		// Normal processing
+		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_gb_state.last_resp_frame) {
 			g_gb_state.last_resp_frame = resp_frame;
 			g_gb_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Initialize watchers on first frame
-			if (g_gb_state.game_frames == 1) {
-				for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
-					g_gb_watchers[i].last_val = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
-					g_gb_watchers[i].initialized = 1;
-				}
-			}
-
-			// Check for value changes in watchers
-			for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
-				if (!g_gb_watchers[i].initialized) continue;
-				uint8_t cur_val = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
-				if (cur_val != g_gb_watchers[i].last_val) {
-					ra_log_write("GB Watch[%s @ 0x%04X]: 0x%02X -> 0x%02X (frame %u)\n",
-						g_gb_watchers[i].name, g_gb_watchers[i].addr,
-						g_gb_watchers[i].last_val, cur_val, g_gb_state.game_frames);
-					g_gb_watchers[i].last_val = cur_val;
-				}
-			}
-
-			// Re-collect every ~5 min
+			// Periodically re-collect to catch address changes (every ~5 min)
 			int re_collect = (g_gb_state.game_frames % 18000 == 0) && (g_gb_state.game_frames > 0);
 			if (re_collect) {
 				g_gb_state.collecting = 1;
@@ -148,10 +126,24 @@ static void gameboy_poll(void *map, void *client, int game_loaded)
 
 			rc_client_do_frame(rc_client);
 
+			// Value-change watchers
+			for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+				uint8_t cur = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
+				if (!g_gb_watchers[i].initialized) {
+					g_gb_watchers[i].last_val = cur;
+					g_gb_watchers[i].initialized = 1;
+				} else if (cur != g_gb_watchers[i].last_val) {
+					ra_log_write("GB Watch[%s @ 0x%04X]: 0x%02X -> 0x%02X (frame %u)\n",
+						g_gb_watchers[i].name, g_gb_watchers[i].addr,
+						g_gb_watchers[i].last_val, cur, g_gb_state.game_frames);
+					g_gb_watchers[i].last_val = cur;
+				}
+			}
+
 			if (re_collect) {
 				g_gb_state.collecting = 0;
 				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("GameBoy OptionC: Address list refreshed, %d addrs\n",
+					ra_log_write("GB OptionC: Address list refreshed, %d addrs\n",
 						ra_snes_addrlist_count());
 				}
 			}
@@ -166,10 +158,16 @@ static void gameboy_poll(void *map, void *client, int game_loaded)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_gb_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_gb_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(GB): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_gb_state.last_resp_frame, g_gb_state.game_frames, elapsed,
+		double ms_per_cycle = (g_gb_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_gb_state.game_frames) : 0.0;
+		ra_log_write("POLL(GB): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_gb_state.last_resp_frame, g_gb_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 	}
+
+	return 1; // GameBoy handled
+#else
+	return 0;
 #endif
 }
 
@@ -177,25 +175,21 @@ static int gameboy_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 	(void)rom_path;
 	(void)md5_hex_out;
-	// GameBoy uses standard MD5
-	return 0; // Let main code handle it
+	return 0; // use default MD5
 }
 
 static void gameboy_set_hardcore(int enabled)
 {
-	ra_log_write("GameBoy: Hardcore mode %s (no FPGA bits mapped yet)\n",
+	ra_log_write("GameBoy: Hardcore mode %s (no FPGA bits mapped)\n",
 		enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void gameboy_detect_protocol(void *map)
+static void gameboy_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_gb_state.optionc = 1;
-		ra_log_write("GameBoy FPGA protocol: Option C (selective address reading)\n");
-	}
+	(void)map;
+	// GameBoy always uses Option C
+	g_gb_state.optionc = 1;
+	ra_log_write("Gameboy FPGA protocol: Option C (selective address reading)\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +203,7 @@ const console_handler_t g_console_gameboy = {
 	.poll = gameboy_poll,
 	.calculate_hash = gameboy_calculate_hash,
 	.set_hardcore = gameboy_set_hardcore,
+	.detect_protocol = gameboy_detect_protocol,
 	.console_id = 4,  // RC_CONSOLE_GAMEBOY (also handles GBC with ID 6)
 	.name = "GAMEBOY"
 };

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -1,4 +1,4 @@
-// achievements_gba.cpp — RetroAchievements Game Boy Advance-specific implementation
+// achievements_gba.cpp — RetroAchievements GBA-specific implementation
 
 #include "achievements_console.h"
 #include "achievements.h"
@@ -11,6 +11,7 @@
 #ifdef HAS_RCHEEVOS
 #include "rc_client.h"
 #include "rc_consoles.h"
+#include "rc_hash.h"
 #endif
 
 // ---------------------------------------------------------------------------
@@ -20,135 +21,205 @@
 static console_state_t g_gba_state = {};
 
 // ---------------------------------------------------------------------------
+// GBA Option C Diagnostics
+// ---------------------------------------------------------------------------
+
+static void gba_optionc_dump_valcache(const char *label, void *map)
+{
+        if (!map) return;
+        const uint8_t *base = (const uint8_t *)map;
+        int addr_count = ra_snes_addrlist_count();
+        const uint32_t *addrs = ra_snes_addrlist_addrs();
+
+        const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
+        const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
+
+        int dump_len = addr_count < 32 ? addr_count : 32;
+        if (dump_len <= 0) dump_len = 32;
+        char hex[200];
+        int pos = 0, non_zero = 0;
+        for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+                pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+                if (vals[i]) non_zero++;
+        }
+
+        ra_log_write("GBA DUMP[%s] resp_id=%u resp_frame=%u addrs=%d non_zero=%d\n",
+                label, resp->response_id, resp->response_frame, addr_count, non_zero);
+        ra_log_write("GBA DUMP[%s] VALCACHE[0..%d]: %s\n", label, dump_len - 1, hex);
+
+        // FPGA debug words at 0x10 / 0x18
+        const uint8_t *dbg8 = base + 0x10;
+        uint16_t iwram_cnt   = dbg8[0] | (dbg8[1] << 8);
+        uint8_t  dispatch_cnt = dbg8[6];
+        uint8_t  fpga_ver     = dbg8[7];
+        const uint8_t *dbg8b = base + 0x18;
+        uint16_t ewram_cnt  = dbg8b[4] | (dbg8b[5] << 8);
+        uint16_t cart_cnt   = dbg8b[2] | (dbg8b[3] << 8);
+        uint16_t first_addr = dbg8b[6] | (dbg8b[7] << 8);
+
+        ra_log_write("GBA DUMP[%s] FPGA ver=0x%02X dispatch=%u iwram=%u ewram=%u cart=%u faddr=0x%04X\n",
+                label, fpga_ver, dispatch_cnt, iwram_cnt, ewram_cnt, cart_cnt, first_addr);
+
+        // Address+value pairs (first 10)
+        int show = addr_count < 10 ? addr_count : 10;
+        for (int i = 0; i < show; i++)
+                ra_log_write("GBA DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
+}
+
+// ---------------------------------------------------------------------------
 // GBA Implementation
 // ---------------------------------------------------------------------------
 
 static void gba_init(void)
 {
-	memset(&g_gba_state, 0, sizeof(g_gba_state));
-	ra_snes_addrlist_init();
+        memset(&g_gba_state, 0, sizeof(g_gba_state));
 }
 
 static void gba_reset(void)
 {
-	g_gba_state.optionc = 0;
-	g_gba_state.collecting = 0;
-	g_gba_state.cache_ready = 0;
-	g_gba_state.last_resp_frame = 0;
-	g_gba_state.game_frames = 0;
-	g_gba_state.poll_logged = 0;
+        memset(&g_gba_state, 0, sizeof(g_gba_state));
 }
 
 static uint32_t gba_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_gba_state.optionc) {
-		if (g_gba_state.collecting) {
-			for (uint32_t i = 0; i < num_bytes; i++)
-				ra_snes_addrlist_add(address + i);
-		}
-		if (g_gba_state.cache_ready) {
-			for (uint32_t i = 0; i < num_bytes; i++)
-				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
-			return num_bytes;
-		}
-		memset(buffer, 0, num_bytes);
-		return num_bytes;
-	}
-	return 0;
+        if (g_gba_state.optionc) {
+                if (g_gba_state.collecting) {
+                        for (uint32_t i = 0; i < num_bytes; i++)
+                                ra_snes_addrlist_add(address + i);
+                }
+                if (g_gba_state.cache_ready) {
+                        for (uint32_t i = 0; i < num_bytes; i++)
+                                buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+                        return num_bytes;
+                }
+                memset(buffer, 0, num_bytes);
+                return num_bytes;
+        }
+        return 0;
 }
 
-static void gba_poll(void *map, void *client, int game_loaded)
+static int gba_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_gba_state.optionc) return;
-	
-	rc_client_t *rc_client = (rc_client_t *)client;
+        if (!client || !game_loaded || !map || !g_gba_state.optionc)
+                return 0;
 
-	if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
-		// Bootstrap
-		g_gba_state.collecting = 1;
-		ra_snes_addrlist_begin_collect();
-		rc_client_do_frame(rc_client);
-		g_gba_state.collecting = 0;
-		int changed = ra_snes_addrlist_end_collect(map);
-		if (changed) {
-			ra_log_write("GBA OptionC: Bootstrap collection done, %d addrs\n",
-				ra_snes_addrlist_count());
-		}
-	} else if (!g_gba_state.cache_ready) {
-		// Wait for cache
-		if (ra_snes_addrlist_is_ready(map)) {
-			g_gba_state.cache_ready = 1;
-			g_gba_state.last_resp_frame = 0;
-			g_gba_state.game_frames = 0;
-			g_gba_state.poll_logged = 0;
-			clock_gettime(CLOCK_MONOTONIC, &g_gba_state.cache_time);
-			ra_log_write("GBA OptionC: Cache active!\n");
-		}
-	} else {
-		// Normal processing
-		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		if (resp_frame > g_gba_state.last_resp_frame) {
-			g_gba_state.last_resp_frame = resp_frame;
-			g_gba_state.game_frames++;
+        rc_client_t *rc_client = (rc_client_t *)client;
 
-			// Re-collect every ~5 min
-			int re_collect = (g_gba_state.game_frames % 18000 == 0) && (g_gba_state.game_frames > 0);
-			if (re_collect) {
-				g_gba_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+        if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
+                // Bootstrap: run one do_frame with zeros to discover needed addresses
+                g_gba_state.collecting = 1;
+                ra_snes_addrlist_begin_collect();
+                rc_client_do_frame(rc_client);
+                g_gba_state.collecting = 0;
+                int changed = ra_snes_addrlist_end_collect(map);
+                if (changed) {
+                        ra_log_write("GBA OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+                                ra_snes_addrlist_count());
+                        gba_optionc_dump_valcache("bootstrap", map);
+                } else {
+                        ra_log_write("GBA OptionC: No addresses collected\n");
+                }
+        } else if (!g_gba_state.cache_ready) {
+                // Wait for FPGA response
+                if (ra_snes_addrlist_is_ready(map)) {
+                        g_gba_state.cache_ready = 1;
+                        g_gba_state.last_resp_frame = 0;
+                        g_gba_state.game_frames = 0;
+                        g_gba_state.poll_logged = 0;
+                        clock_gettime(CLOCK_MONOTONIC, &g_gba_state.cache_time);
+                        ra_log_write("GBA OptionC: Cache active! FPGA response matched request.\n");
+                        gba_optionc_dump_valcache("cache-active", map);
+                }
+        } else {
+                // Normal frame processing from cache
+                uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+                if (resp_frame > g_gba_state.last_resp_frame) {
+                        g_gba_state.last_resp_frame = resp_frame;
+                        g_gba_state.game_frames++;
+                        ra_frame_processed(resp_frame);
 
-			rc_client_do_frame(rc_client);
+                        if (g_gba_state.game_frames <= 5) {
+                                ra_log_write("GBA OptionC: GameFrame %u (resp_frame=%u)\n",
+                                        g_gba_state.game_frames, resp_frame);
+                                gba_optionc_dump_valcache("early-frame", map);
+                        }
 
-			if (re_collect) {
-				g_gba_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("GBA OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
-				}
-			}
-		}
-	}
+                        // Re-collect every ~5 min
+                        int re_collect = (g_gba_state.game_frames % 18000 == 0) && (g_gba_state.game_frames > 0);
+                        if (re_collect) {
+                                g_gba_state.collecting = 1;
+                                ra_snes_addrlist_begin_collect();
+                        }
 
-	// Periodic log
-	uint32_t milestone = g_gba_state.game_frames / 300;
-	if (milestone > 0 && milestone != g_gba_state.poll_logged) {
-		g_gba_state.poll_logged = milestone;
-		struct timespec now;
-		clock_gettime(CLOCK_MONOTONIC, &now);
-		double elapsed = (now.tv_sec - g_gba_state.cache_time.tv_sec)
-			+ (now.tv_nsec - g_gba_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(GBA): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_gba_state.last_resp_frame, g_gba_state.game_frames, elapsed,
-			ra_snes_addrlist_count());
-	}
+                        rc_client_do_frame(rc_client);
+
+                        if (re_collect) {
+                                g_gba_state.collecting = 0;
+                                if (ra_snes_addrlist_end_collect(map)) {
+                                        ra_log_write("GBA OptionC: Address list refreshed, %d addrs\n",
+                                                ra_snes_addrlist_count());
+                                }
+                        }
+                }
+        }
+
+        // Periodic debug logging
+        uint32_t milestone = g_gba_state.game_frames / 300;
+        if (milestone > 0 && milestone != g_gba_state.poll_logged) {
+                g_gba_state.poll_logged = milestone;
+                struct timespec now;
+                clock_gettime(CLOCK_MONOTONIC, &now);
+                double elapsed = (now.tv_sec - g_gba_state.cache_time.tv_sec)
+                        + (now.tv_nsec - g_gba_state.cache_time.tv_nsec) / 1e9;
+                double ms_per_cycle = (g_gba_state.game_frames > 0) ?
+                        (elapsed * 1000.0 / g_gba_state.game_frames) : 0.0;
+                ra_log_write("POLL(GBA): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+                        g_gba_state.last_resp_frame, g_gba_state.game_frames, elapsed, ms_per_cycle,
+                        ra_snes_addrlist_count());
+                if ((g_gba_state.game_frames % 1800) < 300)
+                        gba_optionc_dump_valcache("periodic", map);
+        }
+
+        return 1; // GBA Option C handled
+#else
+        return 0;
 #endif
 }
 
 static int gba_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
-	(void)rom_path;
-	(void)md5_hex_out;
-	// GBA uses standard MD5
-	return 0; // Let main code handle it
+#ifdef HAS_RCHEEVOS
+        char abs_path[1024];
+        if (rom_path[0] == '/') {
+                snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
+        } else {
+                extern const char *getRootDir(void);
+                snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
+        }
+
+        if (rc_hash_generate_from_file(md5_hex_out, 5, abs_path)) {
+                ra_log_write("GBA hash: %s\n", md5_hex_out);
+                return 1;
+        }
+        ra_log_write("GBA: rc_hash_generate_from_file failed for %s\n", abs_path);
+#endif
+        return 0;
 }
 
 static void gba_set_hardcore(int enabled)
 {
-	ra_log_write("GBA: Hardcore mode %s (no FPGA bits mapped yet)\n",
-		enabled ? "enabled" : "disabled");
+        // GBA: disable cheats and save states in hardcore mode
+        // TODO: verify correct status bit indices for GBA core
+        ra_log_write("GBA: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void gba_detect_protocol(void *map)
+static void gba_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_gba_state.optionc = 1;
-		ra_log_write("GBA FPGA protocol: Option C\n");
-	}
+        if (!map) return;
+        // GBA always uses Option C
+        g_gba_state.optionc = 1;
+        ra_log_write("GBA FPGA protocol: Option C (selective address reading)\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -156,12 +227,13 @@ void gba_detect_protocol(void *map)
 // ---------------------------------------------------------------------------
 
 const console_handler_t g_console_gba = {
-	.init = gba_init,
-	.reset = gba_reset,
-	.read_memory = gba_read_memory,
-	.poll = gba_poll,
-	.calculate_hash = gba_calculate_hash,
-	.set_hardcore = gba_set_hardcore,
-	.console_id = 5,  // RC_CONSOLE_GAMEBOY_ADVANCE
-	.name = "GBA"
+        .init = gba_init,
+        .reset = gba_reset,
+        .read_memory = gba_read_memory,
+        .poll = gba_poll,
+        .calculate_hash = gba_calculate_hash,
+        .set_hardcore = gba_set_hardcore,
+        .detect_protocol = gba_detect_protocol,
+        .console_id = 5,  // RC_CONSOLE_GAME_BOY_ADVANCE
+        .name = "GBA"
 };

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -26,17 +26,11 @@ static console_state_t g_md_state = {};
 static void genesis_init(void)
 {
 	memset(&g_md_state, 0, sizeof(g_md_state));
-	ra_snes_addrlist_init();
 }
 
 static void genesis_reset(void)
 {
-	g_md_state.optionc = 0;
-	g_md_state.collecting = 0;
-	g_md_state.cache_ready = 0;
-	g_md_state.last_resp_frame = 0;
-	g_md_state.game_frames = 0;
-	g_md_state.poll_logged = 0;
+	memset(&g_md_state, 0, sizeof(g_md_state));
 }
 
 static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
@@ -57,66 +51,68 @@ static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer
 	return 0;
 }
 
-static void genesis_poll(void *map, void *client, int game_loaded)
+static int genesis_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_md_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_md_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
 	if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
-		// Bootstrap collection
+		// Bootstrap: run one do_frame with zeros to discover needed addresses
 		g_md_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_md_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("Genesis OptionC: Bootstrap collection done, %d addrs\n",
+			ra_log_write("MD OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("MD OptionC: No addresses collected\n");
 		}
 	} else if (!g_md_state.cache_ready) {
-		// Wait for cache
+		// Wait for FPGA to respond with cached values
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_md_state.cache_ready = 1;
 			g_md_state.last_resp_frame = 0;
 			g_md_state.game_frames = 0;
 			g_md_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_md_state.cache_time);
-			ra_log_write("Genesis OptionC: Cache active!\n");
+			ra_log_write("MD OptionC: Cache active! FPGA response matched request.\n");
+			// Dump address list once on activation
+			const uint32_t *a0 = ra_snes_addrlist_addrs();
+			int ac = ra_snes_addrlist_count();
+			int ad = ac < 20 ? ac : 20;
+			char ah[256]; int ap = 0;
+			for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
+				ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
+			ra_log_write("MD ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
 		}
 	} else {
-		// Normal frame processing
+		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_md_state.last_resp_frame) {
 			g_md_state.last_resp_frame = resp_frame;
 			g_md_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Dump first 5 frames with Sonic 1 addresses
+			// Early-frame valcache dump (first 5 frames)
 			if (g_md_state.game_frames <= 5) {
-				const uint8_t *vals = (const uint8_t *)map + 0x48000 + 8;
-				int cnt = ra_snes_addrlist_count();
-				int dump_len = cnt < 32 ? cnt : 32;
-				int non_zero = 0;
-				char hex[256];
-				int pos = 0;
-				for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
-					pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
-					if (vals[i]) non_zero++;
+				const uint8_t *ev = (const uint8_t *)map + 0x48000 + 8;
+				int ec = ra_snes_addrlist_count();
+				int ed = ec < 45 ? ec : 45;
+				int enz = 0;
+				char eh[256]; int ep = 0;
+				for (int i = 0; i < ed && ep < (int)sizeof(eh) - 4; i++) {
+					ep += snprintf(eh + ep, sizeof(eh) - ep, "%02X ", ev[i]);
+					if (ev[i]) enz++;
 				}
-				ra_log_write("Genesis Frame %u: VALCACHE[0..%d]: %s (%d non-zero)\n", 
-					g_md_state.game_frames, dump_len - 1, hex, non_zero);
-				
-				// Sonic 1 key addresses
-				uint8_t gs   = ra_snes_addrlist_read_cached(map, 0xF601);
-				uint8_t act  = ra_snes_addrlist_read_cached(map, 0xFE10);
-				uint8_t zone = ra_snes_addrlist_read_cached(map, 0xFE11);
-				uint8_t lives= ra_snes_addrlist_read_cached(map, 0xFE13);
-				ra_log_write("  Sonic1: state=%02X act=%02X zone=%02X lives=%02X\n",
-					gs, act, zone, lives);
+				ra_log_write("MD early[%u]: VALCACHE %s (%d nz)\n",
+					g_md_state.game_frames, eh, enz);
 			}
 
-			// Re-collect every ~5 min
+			// Re-collect every ~5 min to catch address changes
 			int re_collect = (g_md_state.game_frames % 18000 == 0) && (g_md_state.game_frames > 0);
 			if (re_collect) {
 				g_md_state.collecting = 1;
@@ -128,7 +124,7 @@ static void genesis_poll(void *map, void *client, int game_loaded)
 			if (re_collect) {
 				g_md_state.collecting = 0;
 				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("Genesis OptionC: Address list refreshed, %d addrs\n",
+					ra_log_write("MD OptionC: Address list refreshed, %d addrs\n",
 						ra_snes_addrlist_count());
 				}
 			}
@@ -143,10 +139,16 @@ static void genesis_poll(void *map, void *client, int game_loaded)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_md_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_md_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(Genesis): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_md_state.last_resp_frame, g_md_state.game_frames, elapsed,
+		double ms_per_cycle = (g_md_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_md_state.game_frames) : 0.0;
+		ra_log_write("POLL(MD): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_md_state.last_resp_frame, g_md_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 	}
+
+	return 1; // MegaDrive handled
+#else
+	return 0;
 #endif
 }
 
@@ -154,32 +156,22 @@ static int genesis_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 	(void)rom_path;
 	(void)md5_hex_out;
-	// Genesis uses standard MD5
-	return 0; // Let main code handle it
+	return 0; // use default MD5
 }
 
 static void genesis_set_hardcore(int enabled)
 {
-	if (enabled) {
-		user_io_status_set("[64]", 1);  // Disable cheats
-		user_io_status_set("[24]", 1);  // Disable save states
-		ra_log_write("Genesis: Hardcore mode enabled\n");
-	} else {
-		user_io_status_set("[64]", 0);
-		user_io_status_set("[24]", 0);
-		ra_log_write("Genesis: Hardcore mode disabled\n");
-	}
+	user_io_status_set("[64]", enabled ? 1 : 0); // disable cheats
+	user_io_status_set("[24]", enabled ? 1 : 0); // disable save states
+	ra_log_write("Genesis: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void genesis_detect_protocol(void *map)
+static void genesis_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_md_state.optionc = 1;
-		ra_log_write("Genesis FPGA protocol: Option C\n");
-	}
+	(void)map;
+	// Genesis always uses Option C (no VBlank-gated mode)
+	g_md_state.optionc = 1;
+	ra_log_write("MegaDrive FPGA protocol: Option C (selective address reading)\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +185,7 @@ const console_handler_t g_console_genesis = {
 	.poll = genesis_poll,
 	.calculate_hash = genesis_calculate_hash,
 	.set_hardcore = genesis_set_hardcore,
+	.detect_protocol = genesis_detect_protocol,
 	.console_id = 1,  // RC_CONSOLE_MEGA_DRIVE
 	.name = "Genesis"
 };

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -1,0 +1,229 @@
+// achievements_megacd.cpp — RetroAchievements MegaCD/MegaCD-specific implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// MegaCD/MegaCD State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_mcd_state = {};
+
+// ---------------------------------------------------------------------------
+// MegaCD/MegaCD Implementation
+// ---------------------------------------------------------------------------
+
+static void megacd_init(void)
+{
+	memset(&g_mcd_state, 0, sizeof(g_mcd_state));
+}
+
+static void megacd_reset(void)
+{
+	memset(&g_mcd_state, 0, sizeof(g_mcd_state));
+}
+
+static uint32_t megacd_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	if (g_mcd_state.optionc) {
+		if (g_mcd_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_mcd_state.cache_ready) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	}
+	return 0;
+}
+
+static int megacd_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_mcd_state.optionc) return 0;
+
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	if (ra_snes_addrlist_count() == 0 && !g_mcd_state.cache_ready) {
+		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		g_mcd_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_mcd_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("MCD OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("MCD OptionC: No addresses collected\n");
+		}
+	} else if (!g_mcd_state.cache_ready) {
+		// Wait for FPGA to respond with cached values
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_mcd_state.cache_ready = 1;
+			g_mcd_state.last_resp_frame = 0;
+			g_mcd_state.game_frames = 0;
+			g_mcd_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_mcd_state.cache_time);
+			ra_log_write("MCD OptionC: Cache active! FPGA response matched request.\n");
+			// Dump address list once on activation
+			const uint32_t *a0 = ra_snes_addrlist_addrs();
+			int ac = ra_snes_addrlist_count();
+			int ad = ac < 20 ? ac : 20;
+			char ah[256]; int ap = 0;
+			for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
+				ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
+			ra_log_write("MCD ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
+		}
+	} else {
+		// Normal frame processing from cache
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_mcd_state.last_resp_frame) {
+			g_mcd_state.last_resp_frame = resp_frame;
+			g_mcd_state.game_frames++;
+			ra_frame_processed(resp_frame);
+
+			// Early-frame valcache dump (first 5 frames)
+			if (g_mcd_state.game_frames <= 5) {
+				const uint8_t *ev = (const uint8_t *)map + 0x48000 + 8;
+				int ec = ra_snes_addrlist_count();
+				int ed = ec < 45 ? ec : 45;
+				int enz = 0;
+				char eh[256]; int ep = 0;
+				for (int i = 0; i < ed && ep < (int)sizeof(eh) - 4; i++) {
+					ep += snprintf(eh + ep, sizeof(eh) - ep, "%02X ", ev[i]);
+					if (ev[i]) enz++;
+				}
+				ra_log_write("MCD early[%u]: VALCACHE %s (%d nz)\n",
+					g_mcd_state.game_frames, eh, enz);
+			}
+
+                        // Periodic diagnostic (every ~30s = ~1800 frames)
+                        if (g_mcd_state.game_frames % 1800 == 0 && g_mcd_state.game_frames > 0) {
+                                // Read FPGA debug word at DDRAM_BASE+2 (byte offset 0x10)
+                                const uint8_t *dbg = (const uint8_t *)map + 0x10;
+                                uint8_t ver = dbg[7], disp = dbg[6];
+                                uint16_t ok = (dbg[5] << 8) | dbg[4];
+                                uint16_t oob = (dbg[3] << 8) | dbg[2];
+                                uint16_t first_sdram = (dbg[1] << 8) | dbg[0];
+                                // Read first 16 VALCACHE bytes
+                                const uint8_t *vc = (const uint8_t *)map + 0x48000 + 8;
+                                int ac = ra_snes_addrlist_count();
+                                int cnt = ac < 16 ? ac : 16;
+                                int nz = 0;
+                                char vbuf[128]; int vp = 0;
+                                for (int i = 0; i < cnt && vp < (int)sizeof(vbuf) - 4; i++) {
+                                        vp += snprintf(vbuf + vp, sizeof(vbuf) - vp, "%02X ", vc[i]);
+                                        if (vc[i]) nz++;
+                                }
+                                ra_log_write("MCD DIAG: frame=%u ver=0x%02X disp=%u ok=%u oob=%u sdram0=0x%04X\n",
+                                        g_mcd_state.last_resp_frame, ver, disp, ok, oob, first_sdram);
+                                ra_log_write("MCD DIAG: VALCACHE[0..%d]: %s(%d nz)\n",
+                                        cnt - 1, vbuf, nz);
+                        }
+
+			// Re-collect every ~5 min to catch address changes
+			int re_collect = (g_mcd_state.game_frames % 18000 == 0) && (g_mcd_state.game_frames > 0);
+			if (re_collect) {
+				g_mcd_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_mcd_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("MCD OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		}
+	}
+
+	// Periodic log
+	uint32_t milestone = g_mcd_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_mcd_state.poll_logged) {
+		g_mcd_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_mcd_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_mcd_state.cache_time.tv_nsec) / 1e9;
+		double ms_per_cycle = (g_mcd_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_mcd_state.game_frames) : 0.0;
+		ra_log_write("POLL(MD): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_mcd_state.last_resp_frame, g_mcd_state.game_frames, elapsed, ms_per_cycle,
+			ra_snes_addrlist_count());
+	}
+
+	return 1; // MegaCD handled
+#else
+	return 0;
+#endif
+}
+
+static int megacd_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+#ifdef HAS_RCHEEVOS
+	char abs_path[1024];
+	if (rom_path[0] == '/') {
+		snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
+	} else {
+		extern const char *getRootDir(void);
+		snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
+	}
+
+	if (rc_hash_generate_from_file(md5_hex_out, 9, abs_path)) {
+		ra_log_write("MCD hash: %s\n", md5_hex_out);
+		return 1;
+	}
+	ra_log_write("MCD: rc_hash_generate_from_file failed for %s\n", abs_path);
+#endif
+	return 0;
+}
+
+static void megacd_set_hardcore(int enabled)
+{
+	user_io_status_set("[64]", enabled ? 1 : 0); // disable cheats
+	user_io_status_set("[24]", enabled ? 1 : 0); // disable save states
+	ra_log_write("MegaCD: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
+}
+
+static void megacd_detect_protocol(void *map)
+{
+	(void)map;
+	// MegaCD always uses Option C (no VBlank-gated mode)
+	g_mcd_state.optionc = 1;
+	ra_log_write("MegaCD FPGA protocol: Option C (selective address reading)\n");
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_megacd = {
+	.init = megacd_init,
+	.reset = megacd_reset,
+	.read_memory = megacd_read_memory,
+	.poll = megacd_poll,
+	.calculate_hash = megacd_calculate_hash,
+	.set_hardcore = megacd_set_hardcore,
+	.detect_protocol = megacd_detect_protocol,
+	.console_id = 9,  // RC_CONSOLE_SEGA_CD
+	.name = "MegaCD"
+};

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -4,6 +4,7 @@
 #include "achievements.h"
 #include "ra_ramread.h"
 #include "user_io.h"
+#include "shmem.h"
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
@@ -20,8 +21,10 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_n64_state = {};
-static uint8_t *g_n64_progress_buf = NULL;
+static void    *g_n64_rdram_direct  = NULL; // direct RDRAM mmap for fallback reads
+static uint8_t *g_n64_progress_buf  = NULL;
 static size_t   g_n64_progress_size = 0;
+static int      g_n64_resolve_cooldown = 0; // frames after resolution before re-enabling collection
 
 // ---------------------------------------------------------------------------
 // N64 Implementation
@@ -30,41 +33,54 @@ static size_t   g_n64_progress_size = 0;
 static void n64_init(void)
 {
 	memset(&g_n64_state, 0, sizeof(g_n64_state));
-	g_n64_progress_buf = NULL;
-	g_n64_progress_size = 0;
-	ra_snes_addrlist_init();
-	
-	// N64 uses special DDRAM base to avoid save state collision
+	g_n64_rdram_direct    = NULL;
+	g_n64_progress_buf    = NULL;
+	g_n64_progress_size   = 0;
+	g_n64_resolve_cooldown = 0;
+
+	// N64 savestates occupy 0x3C000000-0x3FFFFFFF (4 slots × 16MB),
+	// colliding with the default RA base at 0x3D000000.
+	// Move N64 RA mirror to the unused gap at 0x38000000.
 	ra_ramread_set_base(0x38000000);
 	ra_log_write("N64: Using RA DDRAM base 0x38000000 (avoiding SS slot collision)\n");
 }
 
 static void n64_reset(void)
 {
-	g_n64_state.optionc = 0;
-	g_n64_state.collecting = 0;
-	g_n64_state.cache_ready = 0;
-	g_n64_state.needs_recollect = 0;
-	g_n64_state.last_resp_frame = 0;
-	g_n64_state.game_frames = 0;
-	g_n64_state.poll_logged = 0;
-	g_n64_state.resolve_pass = 0;
-	if (g_n64_progress_buf) { free(g_n64_progress_buf); g_n64_progress_buf = NULL; }
+	memset(&g_n64_state, 0, sizeof(g_n64_state));
+	g_n64_resolve_cooldown = 0;
+	if (g_n64_rdram_direct) {
+		shmem_unmap(g_n64_rdram_direct, 0x800000);
+		g_n64_rdram_direct = NULL;
+	}
+	if (g_n64_progress_buf) {
+		free(g_n64_progress_buf);
+		g_n64_progress_buf = NULL;
+	}
 	g_n64_progress_size = 0;
 }
 
 static uint32_t n64_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
 	if (g_n64_state.optionc) {
-		// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is little-endian
-		// within 32-bit words. XOR 3 on the low 2 bits converts between byte orders.
+		// N64 rcheevos addresses are big-endian; RDRAM in DDR3 is
+		// little-endian within 32-bit words.  XOR 3 on the low 2 bits converts.
 		if (g_n64_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
-				ra_snes_addrlist_add(((address + i) ^ 3));  // XOR 3 for byte-order
+				ra_snes_addrlist_add((address + i) ^ 3);
+		}
+		// Always prefer direct RDRAM reads for consistency
+		if (g_n64_rdram_direct) {
+			const uint8_t *rdram = (const uint8_t *)g_n64_rdram_direct;
+			for (uint32_t i = 0; i < num_bytes; i++) {
+				uint32_t ddr_addr = (address + i) ^ 3;
+				buffer[i] = (ddr_addr < 0x800000) ? rdram[ddr_addr] : 0;
+			}
+			return num_bytes;
 		}
 		if (g_n64_state.cache_ready) {
 			for (uint32_t i = 0; i < num_bytes; i++)
-				buffer[i] = ra_snes_addrlist_read_cached(map, ((address + i) ^ 3));
+				buffer[i] = ra_snes_addrlist_read_cached(map, (address + i) ^ 3);
 			return num_bytes;
 		}
 		memset(buffer, 0, num_bytes);
@@ -73,16 +89,24 @@ static uint32_t n64_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 	return 0;
 }
 
-static void n64_poll(void *map, void *client, int game_loaded)
+static int n64_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_n64_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_n64_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
-	// N64 has 5 phases like PSX: bootstrap, wait, pointer-resolution, wait, normal
+	// Ensure direct RDRAM mapping is available
+	if (!g_n64_rdram_direct) {
+		g_n64_rdram_direct = shmem_map(0x30000000, 0x800000);
+		if (g_n64_rdram_direct)
+			ra_log_write("N64 OptionC: Direct RDRAM mapped for fallback reads\n");
+		else
+			ra_log_write("N64 OptionC: WARNING - failed to map RDRAM for fallback!\n");
+	}
+
 	if (ra_snes_addrlist_count() == 0 && !g_n64_state.cache_ready) {
-		// Phase 1: Bootstrap
+		// Phase 1: Bootstrap — collect addresses with zero values
 		// Save rcheevos state before collection to prevent delta corruption
 		size_t psize = rc_client_progress_size(rc_client);
 		if (psize > g_n64_progress_size) {
@@ -92,75 +116,94 @@ static void n64_poll(void *map, void *client, int game_loaded)
 		}
 		if (g_n64_progress_buf)
 			rc_client_serialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+
 		g_n64_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_n64_state.collecting = 0;
+
 		// Restore state (undo delta/hit changes from zero-value reads)
 		if (g_n64_progress_buf)
 			rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("N64 OptionC: Bootstrap collection done, %d addrs\n",
-				ra_snes_addrlist_count());
 			g_n64_state.needs_recollect = 1;
 			g_n64_state.resolve_pass = 0;
-		}
-	} else if (!g_n64_state.cache_ready && g_n64_state.needs_recollect) {
-		// Phase 2 & 3: Iterative pointer-resolution for multi-level AddAddress
-		if (ra_snes_addrlist_is_ready(map)) {
-			g_n64_state.resolve_pass++;
-			ra_log_write("N64 OptionC: Pointer resolution pass %d\n", g_n64_state.resolve_pass);
-			g_n64_state.collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(rc_client);
-			g_n64_state.collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(map);
-			if (changed && g_n64_state.resolve_pass < 4) {
-				ra_log_write("N64 OptionC: Pass %d found new addrs, %d total - re-resolving\n",
-					g_n64_state.resolve_pass, ra_snes_addrlist_count());
-				// Stay in needs_recollect to do another pass once cache is ready
-			} else {
-				ra_log_write("N64 OptionC: Pointer-resolution %s after %d passes, %d addrs\n",
-					changed ? "done (max passes)" : "stable",
-					g_n64_state.resolve_pass, ra_snes_addrlist_count());
-				g_n64_state.needs_recollect = 0;
-			}
+			ra_log_write("N64 OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("N64 OptionC: No addresses collected\n");
 		}
 	} else if (!g_n64_state.cache_ready) {
-		// Phase 4: Final cache wait
+		// Phase 2/4: Wait for FPGA cache
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_n64_state.cache_ready = 1;
-			g_n64_state.last_resp_frame = 0;
-			g_n64_state.game_frames = 0;
-			g_n64_state.poll_logged = 0;
-			clock_gettime(CLOCK_MONOTONIC, &g_n64_state.cache_time);
-			ra_log_write("N64 OptionC: Cache active!\n");
-			// Restore rcheevos state saved before resolution began
-			if (g_n64_progress_buf)
-				rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+			if (g_n64_state.needs_recollect) {
+				ra_log_write("N64 OptionC: Cache active (pre-recollect). Will resolve pointers.\n");
+			} else {
+				if (g_n64_state.game_frames == 0) {
+					// First activation after bootstrap
+					g_n64_state.last_resp_frame = 0;
+					g_n64_state.poll_logged = 0;
+					clock_gettime(CLOCK_MONOTONIC, &g_n64_state.cache_time);
+					ra_log_write("N64 OptionC: Cache active! FPGA response matched request.\n");
+				} else {
+					ra_log_write("N64 OptionC: Resolution complete, resuming (%d addrs)\n",
+						ra_snes_addrlist_count());
+				}
+				if (g_n64_progress_buf)
+					rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+				g_n64_resolve_cooldown = 30;
+				ra_log_write("N64 OptionC: State restored via Phase 2, cooldown=30\n");
+			}
+		}
+	} else if (g_n64_state.needs_recollect) {
+		// Phase 3: Iterative pointer-resolution (multi-pass for AddAddress chains)
+		g_n64_state.resolve_pass++;
+		g_n64_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_n64_state.collecting = 0;
+
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed && g_n64_state.resolve_pass < 4) {
+			ra_log_write("N64 OptionC: Pass %d found new addrs, %d total - re-resolving\n",
+				g_n64_state.resolve_pass, ra_snes_addrlist_count());
+			g_n64_state.cache_ready = 0; // wait for FPGA to respond with new addresses
+		} else {
+			ra_log_write("N64 OptionC: Pointer-resolution %s after %d passes, %d addrs\n",
+				changed ? "done (max passes)" : "stable",
+				g_n64_state.resolve_pass, ra_snes_addrlist_count());
+			g_n64_state.needs_recollect = 0;
+			if (changed) {
+				g_n64_state.cache_ready = 0; // need final FPGA response (Phase 2 will deserialize)
+			} else {
+				// Stable: restore state directly since Phase 2 is skipped
+				if (g_n64_progress_buf)
+					rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+				g_n64_resolve_cooldown = 30;
+				ra_log_write("N64 OptionC: State restored after stable resolution, cooldown=30\n");
+			}
 		}
 	} else {
-		// Phase 5: Normal processing
+		// Phase 5: Normal frame processing
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_n64_state.last_resp_frame) {
 			g_n64_state.last_resp_frame = resp_frame;
 			g_n64_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Byte-order diagnostic at frames 30 and 300
-			if (g_n64_state.game_frames == 30 || g_n64_state.game_frames == 300) {
-				ra_log_write("N64: Byte-order diagnostic at frame %u\n", g_n64_state.game_frames);
-				// Sample Super Mario 64 addresses
-				uint8_t map_id = ra_snes_addrlist_read_cached(map, 0x0033b24a ^ 3);
-				uint8_t hp = ra_snes_addrlist_read_cached(map, 0x0033b21d ^ 3);
-				uint8_t lives = ra_snes_addrlist_read_cached(map, 0x0033b21e ^ 3);
-				ra_log_write("  SM64: MapID=%02X HP=%02X Lives=%02X\n", map_id, hp, lives);
-			}
+			if (g_n64_state.game_frames <= 5)
+				ra_log_write("N64 OptionC: GameFrame %u (resp_frame=%u)\n",
+					g_n64_state.game_frames, resp_frame);
 
-			// Re-collect every 600 frames (~10s) with multi-pass for AddAddress
-			int re_collect = (g_n64_state.game_frames % 600 == 0) && (g_n64_state.game_frames > 0);
-			if (re_collect) {
-				// Save state before re-collection
+			if (g_n64_resolve_cooldown > 0) {
+				// Cooldown: evaluate normally without collection to avoid oscillation
+				g_n64_resolve_cooldown--;
+				rc_client_do_frame(rc_client);
+			} else {
+				// Per-frame collection: detect pointer changes
 				size_t psize = rc_client_progress_size(rc_client);
 				if (psize > g_n64_progress_size) {
 					free(g_n64_progress_buf);
@@ -169,80 +212,78 @@ static void n64_poll(void *map, void *client, int game_loaded)
 				}
 				if (g_n64_progress_buf)
 					rc_client_serialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+
 				g_n64_state.collecting = 1;
 				ra_snes_addrlist_begin_collect();
-			}
-
-			rc_client_do_frame(rc_client);
-
-			if (re_collect) {
+				rc_client_do_frame(rc_client);
 				g_n64_state.collecting = 0;
+
 				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("N64 OptionC: Address list refreshed, %d addrs - scheduling re-resolve\n",
-						ra_snes_addrlist_count());
+					// Pointer change detected: roll back and re-resolve
+					if (g_n64_progress_buf)
+						rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
+					ra_log_write("N64 OptionC: Pointer change at game_frame=%u, %d addrs\n",
+						g_n64_state.game_frames, ra_snes_addrlist_count());
 					g_n64_state.cache_ready = 0;
 					g_n64_state.needs_recollect = 1;
 					g_n64_state.resolve_pass = 0;
-				} else {
-					// No change, restore state
-					if (g_n64_progress_buf)
-						rc_client_deserialize_progress_sized(rc_client, g_n64_progress_buf, g_n64_progress_size);
 				}
 			}
 		}
 	}
 
-	// Periodic log every 100 frames (more frequent than other consoles)
-	uint32_t milestone = g_n64_state.game_frames / 100;
+	uint32_t milestone = g_n64_state.game_frames / 300;
 	if (milestone > 0 && milestone != g_n64_state.poll_logged) {
 		g_n64_state.poll_logged = milestone;
 		struct timespec now;
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_n64_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_n64_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(N64): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_n64_state.last_resp_frame, g_n64_state.game_frames, elapsed,
+		double ms_per_cycle = (g_n64_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_n64_state.game_frames) : 0.0;
+		ra_log_write("POLL(N64): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_n64_state.last_resp_frame, g_n64_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 	}
+
+	return 1; // N64 handled
+#else
+	return 0;
 #endif
 }
 
 static int n64_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 #ifdef HAS_RCHEEVOS
-	// N64 requires rc_hash_generate_from_file due to variable byte-order
 	char abs_path[1024];
-	if (rom_path[0] != '/') {
-		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	if (rom_path[0] == '/') {
+		snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
 	} else {
-		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
-		abs_path[sizeof(abs_path) - 1] = '\0';
+		extern const char *getRootDir(void);
+		snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
 	}
 
 	if (rc_hash_generate_from_file(md5_hex_out, 2, abs_path)) {
 		ra_log_write("N64 hash: %s\n", md5_hex_out);
 		return 1;
 	}
-	ra_log_write("N64 hash failed\n");
+	ra_log_write("N64: rc_hash_generate_from_file failed for %s\n", abs_path);
 #endif
 	return 0;
 }
 
 static void n64_set_hardcore(int enabled)
 {
-	ra_log_write("N64: Hardcore mode %s (no FPGA bits mapped yet)\n", 
+	ra_log_write("N64: Hardcore mode %s (no FPGA bits mapped)\n",
 		enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void n64_detect_protocol(void *map)
+static void n64_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_n64_state.optionc = 1;
-		ra_log_write("N64 FPGA protocol: Option C\n");
-	}
+	(void)map;
+	// N64 always uses Option C
+	g_n64_state.optionc = 1;
+	ra_log_write("N64 FPGA protocol: Option C (selective address reading)\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +297,7 @@ const console_handler_t g_console_n64 = {
 	.poll = n64_poll,
 	.calculate_hash = n64_calculate_hash,
 	.set_hardcore = n64_set_hardcore,
+	.detect_protocol = n64_detect_protocol,
 	.console_id = 2,  // RC_CONSOLE_NINTENDO_64
 	.name = "N64"
 };

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -1,4 +1,4 @@
-// achievements_neogeo.cpp — RetroAchievements NeoGeo-specific implementation
+// achievements_neogeo.cpp — RetroAchievements NeoGeo (MVS/CD) implementation
 
 #include "achievements_console.h"
 #include "achievements.h"
@@ -19,6 +19,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_neogeo_state = {};
+static int g_neogeo_is_cd = 0; // 1 = NeoGeoCD (no byte-swap), 0 = MVS (XOR addr^1)
 
 // ---------------------------------------------------------------------------
 // NeoGeo Implementation
@@ -27,29 +28,31 @@ static console_state_t g_neogeo_state = {};
 static void neogeo_init(void)
 {
 	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
-	ra_snes_addrlist_init();
+	g_neogeo_is_cd = 0;
 }
 
 static void neogeo_reset(void)
 {
-	g_neogeo_state.optionc = 0;
-	g_neogeo_state.collecting = 0;
-	g_neogeo_state.cache_ready = 0;
-	g_neogeo_state.last_resp_frame = 0;
-	g_neogeo_state.game_frames = 0;
-	g_neogeo_state.poll_logged = 0;
+	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
+	g_neogeo_is_cd = 0;
 }
 
 static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
 	if (g_neogeo_state.optionc) {
 		if (g_neogeo_state.collecting) {
-			for (uint32_t i = 0; i < num_bytes; i++)
-				ra_snes_addrlist_add(address + i);
+			for (uint32_t i = 0; i < num_bytes; i++) {
+				// NeoGeoCD: natural 68K big-endian order, no XOR needed.
+				// NeoGeo MVS (fbneo): 16-bit words in host little-endian order, XOR addr bit 0.
+				uint32_t a = g_neogeo_is_cd ? (address + i) : ((address + i) ^ 1);
+				ra_snes_addrlist_add(a);
+			}
 		}
 		if (g_neogeo_state.cache_ready) {
-			for (uint32_t i = 0; i < num_bytes; i++)
-				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			for (uint32_t i = 0; i < num_bytes; i++) {
+				uint32_t a = g_neogeo_is_cd ? (address + i) : ((address + i) ^ 1);
+				buffer[i] = ra_snes_addrlist_read_cached(map, a);
+			}
 			return num_bytes;
 		}
 		memset(buffer, 0, num_bytes);
@@ -58,42 +61,82 @@ static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer,
 	return 0;
 }
 
-static void neogeo_poll(void *map, void *client, int game_loaded)
+static int neogeo_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_neogeo_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_neogeo_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
 	if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
-		// Bootstrap
+		// Phase 1: Bootstrap — collect addresses with zeros
 		g_neogeo_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_neogeo_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("NeoGeo OptionC: Bootstrap collection done, %d addrs\n",
+			g_neogeo_state.needs_recollect = 1;
+			g_neogeo_state.resolve_pass = 0;
+			ra_log_write("NeoGeo OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("NeoGeo OptionC: No addresses collected\n");
 		}
 	} else if (!g_neogeo_state.cache_ready) {
-		// Wait for cache
+		// Phase 2/4: Wait for FPGA cache
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_neogeo_state.cache_ready = 1;
 			g_neogeo_state.last_resp_frame = 0;
 			g_neogeo_state.game_frames = 0;
 			g_neogeo_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.cache_time);
-			ra_log_write("NeoGeo OptionC: Cache active!\n");
+			if (g_neogeo_state.needs_recollect) {
+				ra_log_write("NeoGeo OptionC: Cache active (pre-recollect). Will resolve pointers.\n");
+			} else {
+				ra_log_write("NeoGeo OptionC: Cache active! FPGA response matched request.\n");
+			}
+			const uint32_t *a0 = ra_snes_addrlist_addrs();
+			int ac = ra_snes_addrlist_count();
+			int ad = ac < 20 ? ac : 20;
+			char ah[256]; int ap = 0;
+			for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
+				ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
+			ra_log_write("NeoGeo ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
+		}
+	} else if (g_neogeo_state.needs_recollect) {
+		// Phase 3: Pointer-resolution re-collection
+		g_neogeo_state.resolve_pass++;
+		g_neogeo_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_neogeo_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed && g_neogeo_state.resolve_pass < 4) {
+			ra_log_write("NeoGeo OptionC: Pointer-resolve pass %d, %d addrs (changed, retrying)\n",
+				g_neogeo_state.resolve_pass, ra_snes_addrlist_count());
+			g_neogeo_state.cache_ready = 0; // wait for new FPGA data
+		} else {
+			g_neogeo_state.needs_recollect = 0;
+			if (changed) {
+				ra_log_write("NeoGeo OptionC: Pointer-resolve done (max passes), %d addrs\n",
+					ra_snes_addrlist_count());
+				g_neogeo_state.cache_ready = 0;
+			} else {
+				ra_log_write("NeoGeo OptionC: Pointer-resolve complete, no address changes (%d addrs)\n",
+					ra_snes_addrlist_count());
+			}
 		}
 	} else {
-		// Normal processing
+		// Phase 5: Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_neogeo_state.last_resp_frame) {
 			g_neogeo_state.last_resp_frame = resp_frame;
 			g_neogeo_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Re-collect every ~5 min
+			// Re-collect every 18000 frames (~5min).
+			// Do NOT invalidate cache: avoids zeros during active gameplay.
 			int re_collect = (g_neogeo_state.game_frames % 18000 == 0) && (g_neogeo_state.game_frames > 0);
 			if (re_collect) {
 				g_neogeo_state.collecting = 1;
@@ -112,7 +155,6 @@ static void neogeo_poll(void *map, void *client, int game_loaded)
 		}
 	}
 
-	// Periodic log
 	uint32_t milestone = g_neogeo_state.game_frames / 300;
 	if (milestone > 0 && milestone != g_neogeo_state.poll_logged) {
 		g_neogeo_state.poll_logged = milestone;
@@ -120,49 +162,58 @@ static void neogeo_poll(void *map, void *client, int game_loaded)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_neogeo_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_neogeo_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(NeoGeo): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_neogeo_state.last_resp_frame, g_neogeo_state.game_frames, elapsed,
+		double ms_per_cycle = (g_neogeo_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_neogeo_state.game_frames) : 0.0;
+		ra_log_write("POLL(NeoGeo%s): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_neogeo_is_cd ? "CD" : "",
+			g_neogeo_state.last_resp_frame, g_neogeo_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 	}
+
+	return 1; // NeoGeo handled
+#else
+	return 0;
 #endif
 }
 
 static int neogeo_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 #ifdef HAS_RCHEEVOS
-	// NeoGeo requires rc_hash_generate_from_file for filename-based hashing
 	char abs_path[1024];
-	if (rom_path[0] != '/') {
-		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	if (rom_path[0] == '/') {
+		snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
 	} else {
-		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
-		abs_path[sizeof(abs_path) - 1] = '\0';
+		extern const char *getRootDir(void);
+		snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
 	}
 
-	if (rc_hash_generate_from_file(md5_hex_out, 27, abs_path)) {
-		ra_log_write("NeoGeo hash: %s\n", md5_hex_out);
+	// NeoGeoCD uses console_id=56, MVS uses console_id=27
+	int cid = g_neogeo_is_cd ? 56 : 27;
+	const char *cname = g_neogeo_is_cd ? "NeoGeoCD" : "NeoGeo";
+
+	if (rc_hash_generate_from_file(md5_hex_out, cid, abs_path)) {
+		ra_log_write("%s hash: %s\n", cname, md5_hex_out);
 		return 1;
 	}
-	ra_log_write("NeoGeo hash failed\n");
+	ra_log_write("%s: rc_hash_generate_from_file failed\n", cname);
 #endif
 	return 0;
 }
 
 static void neogeo_set_hardcore(int enabled)
 {
-	ra_log_write("NeoGeo: Hardcore mode %s (no FPGA bits mapped yet)\n",
+	ra_log_write("NeoGeo: Hardcore mode %s (no FPGA bits mapped)\n",
 		enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void neogeo_detect_protocol(void *map)
+static void neogeo_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_neogeo_state.optionc = 1;
-		ra_log_write("NeoGeo FPGA protocol: Option C\n");
-	}
+	(void)map;
+	// NeoGeo always uses Option C; detect CD vs MVS for byte-ordering
+	g_neogeo_state.optionc = 1;
+	g_neogeo_is_cd = is_neogeo_cd();
+	ra_log_write("%s FPGA protocol: Option C (selective address reading)\n",
+		g_neogeo_is_cd ? "NeoGeoCD" : "NeoGeo");
 }
 
 // ---------------------------------------------------------------------------
@@ -176,6 +227,7 @@ const console_handler_t g_console_neogeo = {
 	.poll = neogeo_poll,
 	.calculate_hash = neogeo_calculate_hash,
 	.set_hardcore = neogeo_set_hardcore,
-	.console_id = 27,  // RC_CONSOLE_ARCADE
+	.detect_protocol = neogeo_detect_protocol,
+	.console_id = 27,  // RC_CONSOLE_ARCADE (also handles NeoGeoCD with ID 56)
 	.name = "NEOGEO"
 };

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -37,21 +37,26 @@ static void neogeo_reset(void)
 	g_neogeo_is_cd = 0;
 }
 
+
 static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
 	if (g_neogeo_state.optionc) {
 		if (g_neogeo_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++) {
-				// NeoGeoCD: natural 68K big-endian order, no XOR needed.
-				// NeoGeo MVS (fbneo): 16-bit words in host little-endian order, XOR addr bit 0.
-				uint32_t a = g_neogeo_is_cd ? (address + i) : ((address + i) ^ 1);
-				ra_snes_addrlist_add(a);
+				// MVS (FBNeo): XOR^1 to match FBNeo byte-swap convention.
+				// NeoGeoCD shadow RAM is sampled in native 68K byte order.
+				// Both MVS and CD use BIGENDIAN XOR (neocd_libretro sets RETRO_MEMDESC_BIGENDIAN;
+				// P1 shadow is in native 68K order, same convention as MVS WRAMU/WRAML).
+				uint32_t a = (address + i);
+                                if (!g_neogeo_is_cd) a ^= 1;
+                                ra_snes_addrlist_add(a);
 			}
 		}
 		if (g_neogeo_state.cache_ready) {
 			for (uint32_t i = 0; i < num_bytes; i++) {
-				uint32_t a = g_neogeo_is_cd ? (address + i) : ((address + i) ^ 1);
-				buffer[i] = ra_snes_addrlist_read_cached(map, a);
+				uint32_t a = (address + i);
+                                if (!g_neogeo_is_cd) a ^= 1;
+                                buffer[i] = ra_snes_addrlist_read_cached(map, a);
 			}
 			return num_bytes;
 		}
@@ -168,6 +173,45 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			g_neogeo_is_cd ? "CD" : "",
 			g_neogeo_state.last_resp_frame, g_neogeo_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
+
+		// KEY VALS diagnostic
+		{
+			static const uint32_t key_ra[] = {
+				0x0320,0x0321,0x0322,0x0323,
+				0x6EF0,0x6EF1,0x6EF2,0x6EF3,0x6EF4,0x6EF5,0x6EF6,0x6EF7,
+				0xFD88,0xFD89,0xFD8A,0xFD8B,0xFD8C,0xFD8D,0xFD8E,0xFD8F,
+				0xFDB6,0xFDB7,0x700F,0x7011
+			};
+			static const char *key_n[] = {
+				"320","321","322","323",
+				"ef0","ef1","ef2","ef3","ef4","ef5","ef6","ef7",
+				"d88","d89","d8a","d8b","d8c","d8d","d8e","d8f",
+				"db6","db7","70f","711"
+			};
+			char kvbuf[900]; int kvp = 0;
+			for (int ki = 0; ki < 24; ki++) {
+				uint32_t phys = key_ra[ki];
+				if (!g_neogeo_is_cd) phys ^= 1;
+				uint8_t kv = ra_snes_addrlist_read_cached(map, phys);
+				kvp += snprintf(kvbuf + kvp, sizeof(kvbuf) - kvp,
+					" %s(%04X)=%02X", key_n[ki], phys, kv);
+			}
+			ra_log_write("CD KEY VALS:%s\n", kvbuf);
+		}
+		// ADDRLIST + VALCACHE dump
+		{
+			int nac = ra_snes_addrlist_count();
+			const uint32_t *naa = ra_snes_addrlist_addrs();
+			char nabuf[512]; int nap = 0;
+			char nvbuf[512]; int nvp = 0;
+			for (int i = 0; i < nac && i < 48 && nap < 490 && nvp < 490; i++) {
+				uint8_t v = ra_snes_addrlist_read_cached(map, naa[i]);
+				nap += snprintf(nabuf + nap, sizeof(nabuf) - nap, "%04X ", naa[i]);
+				nvp += snprintf(nvbuf + nvp, sizeof(nvbuf) - nvp, "%02X ", v);
+			}
+			ra_log_write("CD ADDRLIST: %s\n", nabuf);
+			ra_log_write("CD VALCACHE: %s\n", nvbuf);
+		}
 	}
 
 	return 1; // NeoGeo handled

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -33,13 +33,19 @@ static uint32_t nes_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 	return ra_ramread_nes_read(map, address, buffer, num_bytes);
 }
 
-static void nes_poll(void *map, void *client, int game_loaded)
+static int nes_poll(void *map, void *client, int game_loaded)
 {
 	(void)map;
 	(void)client;
 	(void)game_loaded;
 	// NES uses default frame tracking (no Option C)
-	// All polling logic is handled in main achievements_poll()
+	return 0; // fall through to achievements_poll default path
+}
+
+static void nes_detect_protocol(void *map)
+{
+	(void)map;
+	// NES uses region-based layout; no protocol detection needed
 }
 
 static int nes_calculate_hash(const char *rom_path, char *md5_hex_out)
@@ -129,6 +135,7 @@ const console_handler_t g_console_nes = {
 	.poll = nes_poll,
 	.calculate_hash = nes_calculate_hash,
 	.set_hardcore = nes_set_hardcore,
+	.detect_protocol = nes_detect_protocol,
 	.console_id = 7,  // RC_CONSOLE_NINTENDO
 	.name = "NES"
 };

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -19,6 +19,36 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_psx_state = {};
+static int g_psx_rtquery = 0; // 1 if FPGA supports realtime queries
+
+// ---------------------------------------------------------------------------
+// PSX Option C Diagnostics
+// ---------------------------------------------------------------------------
+
+static void psx_optionc_dump_valcache(const char *label, void *map)
+{
+	if (!map) return;
+	const uint8_t *base = (const uint8_t *)map;
+	int addr_count = ra_snes_addrlist_count();
+	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
+	const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
+
+	int dump_len = addr_count < 45 ? addr_count : 45;
+	int non_zero = 0;
+	char hex[256]; int pos = 0;
+	for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+		pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+		if (vals[i]) non_zero++;
+	}
+	ra_log_write("PSX DUMP[%s] resp_id=%u resp_frame=%u addrs=%d non_zero=%d\n",
+		label, resp->response_id, resp->response_frame, addr_count, non_zero);
+	ra_log_write("PSX DUMP[%s] VALCACHE[0..%d]: %s\n", label, dump_len - 1, hex);
+
+	const uint32_t *addrs = ra_snes_addrlist_addrs();
+	int show = addr_count < 6 ? addr_count : 6;
+	for (int i = 0; i < show; i++)
+		ra_log_write("PSX DUMP[%s]   [%d] addr=0x%06X val=0x%02X\n", label, i, addrs[i], vals[i]);
+}
 
 // ---------------------------------------------------------------------------
 // PSX Implementation
@@ -27,18 +57,13 @@ static console_state_t g_psx_state = {};
 static void psx_init(void)
 {
 	memset(&g_psx_state, 0, sizeof(g_psx_state));
-	ra_snes_addrlist_init();
+	g_psx_rtquery = 0;
 }
 
 static void psx_reset(void)
 {
-	g_psx_state.optionc = 0;
-	g_psx_state.collecting = 0;
-	g_psx_state.cache_ready = 0;
-	g_psx_state.needs_recollect = 0;
-	g_psx_state.last_resp_frame = 0;
-	g_psx_state.game_frames = 0;
-	g_psx_state.poll_logged = 0;
+	memset(&g_psx_state, 0, sizeof(g_psx_state));
+	g_psx_rtquery = 0;
 }
 
 static uint32_t psx_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
@@ -53,65 +78,90 @@ static uint32_t psx_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
 			return num_bytes;
 		}
+		// Realtime query fallback for addresses not in batch cache
+		if (g_psx_rtquery && !g_psx_state.collecting && num_bytes <= 4) {
+			uint32_t val = ra_rtquery_read(map, address, num_bytes);
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = (uint8_t)(val >> (i * 8));
+			return num_bytes;
+		}
 		memset(buffer, 0, num_bytes);
 		return num_bytes;
 	}
 	return 0;
 }
 
-static void psx_poll(void *map, void *client, int game_loaded)
+static int psx_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_psx_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_psx_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
-	// PSX has 5 phases: bootstrap, wait, pointer-resolution re-collect, wait again, normal
 	if (ra_snes_addrlist_count() == 0 && !g_psx_state.cache_ready) {
-		// Phase 1: Bootstrap collection
+		// Phase 1: Bootstrap — collect addresses with zero values
 		g_psx_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_psx_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("PSX OptionC: Bootstrap collection done, %d addrs\n",
-				ra_snes_addrlist_count());
 			g_psx_state.needs_recollect = 1;
-		}
-	} else if (!g_psx_state.cache_ready && g_psx_state.needs_recollect) {
-		// Phase 2: Wait for first cache
-		if (ra_snes_addrlist_is_ready(map)) {
-			ra_log_write("PSX OptionC: Pre-recollect cache ready, doing pointer resolution pass\n");
-			// Phase 3: Pointer-resolution re-collection
-			g_psx_state.collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(rc_client);
-			g_psx_state.collecting = 0;
-			if (ra_snes_addrlist_end_collect(map)) {
-				ra_log_write("PSX OptionC: Pointer-resolution done, %d addrs\n",
-					ra_snes_addrlist_count());
-			}
-			g_psx_state.needs_recollect = 0;
+			ra_log_write("PSX OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+				ra_snes_addrlist_count());
+			psx_optionc_dump_valcache("bootstrap", map);
+		} else {
+			ra_log_write("PSX OptionC: No addresses collected\n");
 		}
 	} else if (!g_psx_state.cache_ready) {
-		// Phase 4: Wait for final cache
+		// Phase 2/4: Wait for FPGA cache
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_psx_state.cache_ready = 1;
 			g_psx_state.last_resp_frame = 0;
 			g_psx_state.game_frames = 0;
 			g_psx_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_psx_state.cache_time);
-			ra_log_write("PSX OptionC: Final cache active!\n");
+			if (g_psx_state.needs_recollect) {
+				ra_log_write("PSX OptionC: Cache active (pre-recollect). Will resolve pointers.\n");
+				psx_optionc_dump_valcache("pre-recollect", map);
+			} else {
+				ra_log_write("PSX OptionC: Cache active! FPGA response matched request.\n");
+				psx_optionc_dump_valcache("cache-active", map);
+			}
+		}
+	} else if (g_psx_state.needs_recollect) {
+		// Phase 3: Pointer-resolution re-collection
+		// Now that cache has real values, AddAddress conditions will
+		// compute correct derived addresses from pointer base values.
+		g_psx_state.needs_recollect = 0;
+		g_psx_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_psx_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("PSX OptionC: Pointer-resolve re-collection done, %d addrs (changed)\n",
+				ra_snes_addrlist_count());
+			g_psx_state.cache_ready = 0; // wait for new FPGA data with correct addresses
+			psx_optionc_dump_valcache("ptr-resolve", map);
+		} else {
+			ra_log_write("PSX OptionC: Pointer-resolve complete, no address changes\n");
 		}
 	} else {
-		// Phase 5: Normal processing
+		// Phase 5: Normal frame processing
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_psx_state.last_resp_frame) {
 			g_psx_state.last_resp_frame = resp_frame;
 			g_psx_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Re-collect more frequently for PSX (every 600 frames ~10s)
+			if (g_psx_state.game_frames <= 5) {
+				ra_log_write("PSX OptionC: GameFrame %u (resp_frame=%u)\n",
+					g_psx_state.game_frames, resp_frame);
+				psx_optionc_dump_valcache("early-frame", map);
+			}
+
+			// Re-collect every 600 frames (~10s) to track pointer changes
 			int re_collect = (g_psx_state.game_frames % 600 == 0) && (g_psx_state.game_frames > 0);
 			if (re_collect) {
 				g_psx_state.collecting = 1;
@@ -125,12 +175,12 @@ static void psx_poll(void *map, void *client, int game_loaded)
 				if (ra_snes_addrlist_end_collect(map)) {
 					ra_log_write("PSX OptionC: Address list refreshed, %d addrs\n",
 						ra_snes_addrlist_count());
+					g_psx_state.cache_ready = 0; // wait for new FPGA data
 				}
 			}
 		}
 	}
 
-	// Periodic log
 	uint32_t milestone = g_psx_state.game_frames / 300;
 	if (milestone > 0 && milestone != g_psx_state.poll_logged) {
 		g_psx_state.poll_logged = milestone;
@@ -138,55 +188,61 @@ static void psx_poll(void *map, void *client, int game_loaded)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_psx_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_psx_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(PSX): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_psx_state.last_resp_frame, g_psx_state.game_frames, elapsed,
+		double ms_per_cycle = (g_psx_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_psx_state.game_frames) : 0.0;
+		ra_log_write("POLL(PSX): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_psx_state.last_resp_frame, g_psx_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
+		if ((g_psx_state.game_frames % 1800) < 300)
+			psx_optionc_dump_valcache("periodic", map);
 	}
+
+	return 1; // PSX handled
+#else
+	return 0;
 #endif
 }
 
 static int psx_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 #ifdef HAS_RCHEEVOS
-	// PSX requires rc_hash_generate_from_file for CD/ISO images
 	char abs_path[1024];
-	if (rom_path[0] != '/') {
-		snprintf(abs_path, sizeof(abs_path), "/media/fat/%s", rom_path);
+	if (rom_path[0] == '/') {
+		snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
 	} else {
-		strncpy(abs_path, rom_path, sizeof(abs_path) - 1);
-		abs_path[sizeof(abs_path) - 1] = '\0';
+		extern const char *getRootDir(void);
+		snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
 	}
 
 	if (rc_hash_generate_from_file(md5_hex_out, 12, abs_path)) {
 		ra_log_write("PSX hash: %s\n", md5_hex_out);
 		return 1;
 	}
-	ra_log_write("PSX hash failed\n");
+	ra_log_write("PSX: rc_hash_generate_from_file failed for %s\n", abs_path);
 #endif
 	return 0;
 }
 
 static void psx_set_hardcore(int enabled)
 {
-	if (enabled) {
-		user_io_status_set("[93]", 1);  // Disable cheats
-		user_io_status_set("[6]", 1);   // Disable save states
-		ra_log_write("PSX: Hardcore mode enabled\n");
-	} else {
-		user_io_status_set("[93]", 0);
-		user_io_status_set("[6]", 0);
-		ra_log_write("PSX: Hardcore mode disabled\n");
-	}
+	user_io_status_set("[93]", enabled ? 1 : 0); // disable cheats
+	user_io_status_set("[6]",  enabled ? 1 : 0); // disable save states
+	ra_log_write("PSX: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void psx_detect_protocol(void *map)
+static void psx_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_psx_state.optionc = 1;
-		ra_log_write("PSX FPGA protocol: Option C\n");
+	// PSX always uses Option C (no VBlank-gated mode)
+	g_psx_state.optionc = 1;
+	ra_log_write("PSX FPGA protocol: Option C (selective address reading)\n");
+
+	if (map && ra_rtquery_supported(map)) {
+		g_psx_rtquery = 1;
+		ra_rtquery_init(map);
+		ra_log_write("PSX: Realtime queries supported (FPGA v2+)\n");
+	} else {
+		g_psx_rtquery = 0;
+		ra_log_write("PSX: Realtime queries NOT supported (FPGA v1)\n");
 	}
 }
 
@@ -201,6 +257,7 @@ const console_handler_t g_console_psx = {
 	.poll = psx_poll,
 	.calculate_hash = psx_calculate_hash,
 	.set_hardcore = psx_set_hardcore,
+	.detect_protocol = psx_detect_protocol,
 	.console_id = 12,  // RC_CONSOLE_PLAYSTATION
 	.name = "PSX"
 };

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -26,17 +26,11 @@ static console_state_t g_sms_state = {};
 static void sms_init(void)
 {
 	memset(&g_sms_state, 0, sizeof(g_sms_state));
-	ra_snes_addrlist_init();
 }
 
 static void sms_reset(void)
 {
-	g_sms_state.optionc = 0;
-	g_sms_state.collecting = 0;
-	g_sms_state.cache_ready = 0;
-	g_sms_state.last_resp_frame = 0;
-	g_sms_state.game_frames = 0;
-	g_sms_state.poll_logged = 0;
+	memset(&g_sms_state, 0, sizeof(g_sms_state));
 }
 
 static uint32_t sms_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
@@ -57,42 +51,53 @@ static uint32_t sms_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 	return 0;
 }
 
-static void sms_poll(void *map, void *client, int game_loaded)
+static int sms_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_sms_state.optionc) return;
-	
+	if (!client || !game_loaded || !map || !g_sms_state.optionc) return 0;
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
 	if (ra_snes_addrlist_count() == 0 && !g_sms_state.cache_ready) {
-		// Bootstrap
+		// Bootstrap: run one do_frame with zeros to discover needed addresses
 		g_sms_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_sms_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("SMS OptionC: Bootstrap collection done, %d addrs\n",
+			ra_log_write("SMS OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
+		} else {
+			ra_log_write("SMS OptionC: No addresses collected\n");
 		}
 	} else if (!g_sms_state.cache_ready) {
-		// Wait for cache
+		// Wait for FPGA to respond with cached values
 		if (ra_snes_addrlist_is_ready(map)) {
 			g_sms_state.cache_ready = 1;
 			g_sms_state.last_resp_frame = 0;
 			g_sms_state.game_frames = 0;
 			g_sms_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_sms_state.cache_time);
-			ra_log_write("SMS OptionC: Cache active!\n");
+			ra_log_write("SMS OptionC: Cache active! FPGA response matched request.\n");
+			// Dump address list on activation
+			const uint32_t *a0 = ra_snes_addrlist_addrs();
+			int ac = ra_snes_addrlist_count();
+			int ad = ac < 20 ? ac : 20;
+			char ah[256]; int ap = 0;
+			for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
+				ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
+			ra_log_write("SMS ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
 		}
 	} else {
-		// Normal processing
+		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
 		if (resp_frame > g_sms_state.last_resp_frame) {
 			g_sms_state.last_resp_frame = resp_frame;
 			g_sms_state.game_frames++;
+			ra_frame_processed(resp_frame);
 
-			// Re-collect every ~5 min
+			// Re-collect every ~5 min to catch address changes
 			int re_collect = (g_sms_state.game_frames % 18000 == 0) && (g_sms_state.game_frames > 0);
 			if (re_collect) {
 				g_sms_state.collecting = 1;
@@ -111,7 +116,6 @@ static void sms_poll(void *map, void *client, int game_loaded)
 		}
 	}
 
-	// Periodic log
 	uint32_t milestone = g_sms_state.game_frames / 300;
 	if (milestone > 0 && milestone != g_sms_state.poll_logged) {
 		g_sms_state.poll_logged = milestone;
@@ -119,10 +123,16 @@ static void sms_poll(void *map, void *client, int game_loaded)
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		double elapsed = (now.tv_sec - g_sms_state.cache_time.tv_sec)
 			+ (now.tv_nsec - g_sms_state.cache_time.tv_nsec) / 1e9;
-		ra_log_write("POLL(SMS): resp_frame=%u game_frames=%u elapsed=%.1fs addrs=%d\n",
-			g_sms_state.last_resp_frame, g_sms_state.game_frames, elapsed,
+		double ms_per_cycle = (g_sms_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_sms_state.game_frames) : 0.0;
+		ra_log_write("POLL(SMS): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_sms_state.last_resp_frame, g_sms_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 	}
+
+	return 1; // SMS handled
+#else
+	return 0;
 #endif
 }
 
@@ -130,30 +140,21 @@ static int sms_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 	(void)rom_path;
 	(void)md5_hex_out;
-	// SMS uses standard MD5
-	return 0; // Let main code handle it
+	return 0; // use default MD5
 }
 
 static void sms_set_hardcore(int enabled)
 {
-	if (enabled) {
-		user_io_status_set("[24]", 1);  // Disable cheats
-		ra_log_write("SMS: Hardcore mode enabled (cheats disabled)\n");
-	} else {
-		user_io_status_set("[24]", 0);
-		ra_log_write("SMS: Hardcore mode disabled\n");
-	}
+	user_io_status_set("[24]", enabled ? 1 : 0); // disable cheats
+	ra_log_write("SMS: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol
-void sms_detect_protocol(void *map)
+static void sms_detect_protocol(void *map)
 {
-	if (!map) return;
-	const ra_header_t *hdr = (const ra_header_t *)map;
-	if (hdr->region_count == 0) {
-		g_sms_state.optionc = 1;
-		ra_log_write("SMS FPGA protocol: Option C\n");
-	}
+	(void)map;
+	// SMS always uses Option C
+	g_sms_state.optionc = 1;
+	ra_log_write("SMS FPGA protocol: Option C (selective address reading)\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -167,6 +168,7 @@ const console_handler_t g_console_sms = {
 	.poll = sms_poll,
 	.calculate_hash = sms_calculate_hash,
 	.set_hardcore = sms_set_hardcore,
+	.detect_protocol = sms_detect_protocol,
 	.console_id = 11,  // RC_CONSOLE_MASTER_SYSTEM (also handles Game Gear ID 15)
 	.name = "SMS"
 };

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -32,91 +32,40 @@ static void snes_optionc_dump_valcache(const char *label, void *map)
 	int addr_count = ra_snes_addrlist_count();
 	const uint32_t *addrs = ra_snes_addrlist_addrs();
 
-	// Response header
 	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
-	ra_log_write("DUMP[%s] VALCACHE hdr: resp_id=%u resp_frame=%u\n",
-		label, resp->response_id, resp->response_frame);
-
-	// Raw VALCACHE bytes (first 32)
 	const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
+
 	int dump_len = addr_count < 32 ? addr_count : 32;
 	if (dump_len <= 0) dump_len = 32;
 	char hex[200];
-	int pos = 0;
-	int non_zero = 0;
+	int pos = 0, non_zero = 0;
 	for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
 		pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
 		if (vals[i]) non_zero++;
 	}
-	ra_log_write("DUMP[%s] VALCACHE raw[0..%d]: %s\n", label, dump_len - 1, hex);
 
-	// Count non-zero in full address range
-	int nz_all = 0;
-	for (int i = 0; i < addr_count; i++)
-		if (vals[i]) nz_all++;
-	ra_log_write("DUMP[%s] non-zero: %d/%d\n", label, nz_all, addr_count);
+	ra_log_write("SNES DUMP[%s] resp_id=%u resp_frame=%u addrs=%d non_zero=%d\n",
+		label, resp->response_id, resp->response_frame, addr_count, non_zero);
+	ra_log_write("SNES DUMP[%s] VALCACHE[0..%d]: %s\n", label, dump_len - 1, hex);
+
+	// FPGA debug words at 0x10 / 0x18
+	const uint8_t *dbg8 = base + 0x10;
+	uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
+	uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
+	uint8_t  dispatch_cnt = dbg8[6];
+	uint8_t  fpga_ver     = dbg8[7];
+	const uint8_t *dbg8b = base + 0x18;
+	uint16_t wram_cnt = dbg8b[4] | (dbg8b[5] << 8);
+	uint16_t bsram_cnt = dbg8b[2] | (dbg8b[3] << 8);
+	uint16_t first_addr = dbg8b[6] | (dbg8b[7] << 8);
+
+	ra_log_write("SNES DUMP[%s] FPGA ver=0x%02X ok=%u timeout=%u dispatch=%u wram=%u bsram=%u faddr=0x%04X\n",
+		label, fpga_ver, ok_cnt, timeout_cnt, dispatch_cnt, wram_cnt, bsram_cnt, first_addr);
 
 	// Address+value pairs (first 10)
 	int show = addr_count < 10 ? addr_count : 10;
-	for (int i = 0; i < show; i++) {
-		ra_log_write("DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
-	}
-	
-	// Also show a few known SMW addresses if present
-	const uint32_t smw_addrs[] = {0x00019, 0x00DBF, 0x00F06, 0x00F31, 0x01490};
-	const char *smw_names[] = {"playerSts", "dragonCoin", "lives", "coinCnt", "score"};
-	for (int j = 0; j < 5; j++) {
-		for (int i = 0; i < addr_count; i++) {
-			if (addrs[i] == smw_addrs[j]) {
-				ra_log_write("DUMP[%s]   SMW:%s(0x%05X)=0x%02X\n", 
-					label, smw_names[j], smw_addrs[j], vals[i]);
-				break;
-			}
-		}
-	}
-
-	// ADDRLIST header readback
-	const ra_addr_req_hdr_t *ahdr = (const ra_addr_req_hdr_t *)(base + RA_SNES_ADDRLIST_OFFSET);
-	ra_log_write("DUMP[%s] ADDRLIST hdr readback: addr_count=%u request_id=%u\n",
-		label, ahdr->addr_count, ahdr->request_id);
-
-	// ADDRLIST address readback (first 5 from DDRAM)
-	const uint32_t *ddram_addrs = (const uint32_t *)(base + RA_SNES_ADDRLIST_OFFSET + 8);
-	int rshow = addr_count < 5 ? addr_count : 5;
-	for (int i = 0; i < rshow; i++) {
-		ra_log_write("DUMP[%s]   DDRAM_ADDR[%d]=0x%08X (local=0x%05X)\n", 
-			label, i, ddram_addrs[i], addrs[i]);
-	}
-
-	// FPGA debug words
-	const uint8_t *dbg8 = (const uint8_t *)(base + 0x10);
-	uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
-	uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
-	uint16_t first_dout  = dbg8[4] | (dbg8[5] << 8);
-	uint8_t  dispatch_cnt = dbg8[6];
-	uint8_t  fpga_ver     = dbg8[7];
-
-	const uint8_t *dbg8b = (const uint8_t *)(base + 0x18);
-	uint16_t max_timeout  = dbg8b[0] | (dbg8b[1] << 8);
-	uint16_t bsram_cnt    = dbg8b[2] | (dbg8b[3] << 8);
-	uint16_t wram_cnt     = dbg8b[4] | (dbg8b[5] << 8);
-	uint16_t first_addr   = dbg8b[6] | (dbg8b[7] << 8);
-
-	ra_log_write("DUMP[%s] FPGA_DBG: ver=0x%02X ok=%u timeout=%u first_dout=0x%04X dispatch=%u\n",
-		label, fpga_ver, ok_cnt, timeout_cnt, first_dout, dispatch_cnt);
-	ra_log_write("DUMP[%s] FPGA_DBG2: wram=%u bsram=%u first_addr=0x%04X max_timeout=%u\n",
-		label, wram_cnt, bsram_cnt, first_addr, max_timeout);
-
-	// Bypass check: addresses should match pattern: addr[7:0] ^ 0xA5
-	int bypass_fail = 0;
-	for (int i = 0; i < addr_count && i < 16; i++) {
-		uint8_t expected = (addrs[i] & 0xFF) ^ 0xA5;
-		if (vals[i] != expected) bypass_fail++;
-	}
-	if (bypass_fail > 0) {
-		ra_log_write("DUMP[%s] Bypass check: %d/%d mismatches (expected addr[7:0]^0xA5)\n",
-			label, bypass_fail, addr_count < 16 ? addr_count : 16);
-	}
+	for (int i = 0; i < show; i++)
+		ra_log_write("SNES DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
 }
 
 // ---------------------------------------------------------------------------
@@ -126,23 +75,16 @@ static void snes_optionc_dump_valcache(const char *label, void *map)
 static void snes_init(void)
 {
 	memset(&g_snes_state, 0, sizeof(g_snes_state));
-	ra_snes_addrlist_init();
 }
 
 static void snes_reset(void)
 {
-	g_snes_state.optionc = 0;
-	g_snes_state.collecting = 0;
-	g_snes_state.cache_ready = 0;
-	g_snes_state.last_resp_frame = 0;
-	g_snes_state.game_frames = 0;
-	g_snes_state.poll_logged = 0;
+	memset(&g_snes_state, 0, sizeof(g_snes_state));
 }
 
 static uint32_t snes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
 	if (g_snes_state.optionc) {
-		// Option C: selective address reading
 		if (g_snes_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
@@ -160,94 +102,93 @@ static uint32_t snes_read_memory(void *map, uint32_t address, uint8_t *buffer, u
 	}
 }
 
-static void snes_poll(void *map, void *client, int game_loaded)
+static int snes_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map) return;
-	
+	if (!client || !game_loaded || !map || !g_snes_state.optionc)
+		return 0; // VBlank-gated path: fall through to default
+
 	rc_client_t *rc_client = (rc_client_t *)client;
 
-	if (g_snes_state.optionc) {
-		// Option C selective reading mode
-		if (ra_snes_addrlist_count() == 0 && !g_snes_state.cache_ready) {
-			// Bootstrap: run one do_frame with zeros to discover needed addresses
-			g_snes_state.collecting = 1;
-			ra_snes_addrlist_begin_collect();
-			rc_client_do_frame(rc_client);
-			g_snes_state.collecting = 0;
-			int changed = ra_snes_addrlist_end_collect(map);
-			if (changed) {
-				ra_log_write("SNES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
-					ra_snes_addrlist_count());
-				snes_optionc_dump_valcache("bootstrap", map);
-			} else {
-				ra_log_write("SNES OptionC: No addresses collected — achievements may have no memory refs\n");
-			}
-		} else if (!g_snes_state.cache_ready) {
-			// Wait for FPGA to respond with cached values
-			if (ra_snes_addrlist_is_ready(map)) {
-				g_snes_state.cache_ready = 1;
-				g_snes_state.last_resp_frame = 0;
-				g_snes_state.game_frames = 0;
-				g_snes_state.poll_logged = 0;
-				clock_gettime(CLOCK_MONOTONIC, &g_snes_state.cache_time);
-				ra_log_write("SNES OptionC: Cache active! FPGA response matched request.\n");
-				snes_optionc_dump_valcache("cache-active", map);
-			}
-		} else {
-			// Normal frame processing from cache
-			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			if (resp_frame > g_snes_state.last_resp_frame) {
-				g_snes_state.last_resp_frame = resp_frame;
-				g_snes_state.game_frames++;
-
-				// Dump first 5 frames after cache became active
-				if (g_snes_state.game_frames <= 5) {
-					ra_log_write("SNES OptionC: GameFrame %u (resp_frame=%u)\n",
-						g_snes_state.game_frames, resp_frame);
-					snes_optionc_dump_valcache("early-frame", map);
-				}
-
-				// Periodically re-collect to catch address changes (every ~5 min)
-				int re_collect = (g_snes_state.game_frames % 18000 == 0) && (g_snes_state.game_frames > 0);
-				if (re_collect) {
-					g_snes_state.collecting = 1;
-					ra_snes_addrlist_begin_collect();
-				}
-
-				rc_client_do_frame(rc_client);
-
-				if (re_collect) {
-					g_snes_state.collecting = 0;
-					if (ra_snes_addrlist_end_collect(map)) {
-						ra_log_write("SNES OptionC: Address list refreshed, %d addrs\n",
-							ra_snes_addrlist_count());
-					}
-				}
-			}
-		}
-
-		// Periodic SNES debug — log once per 300-frame milestone
-		uint32_t milestone = g_snes_state.game_frames / 300;
-		if (milestone > 0 && milestone != g_snes_state.poll_logged) {
-			g_snes_state.poll_logged = milestone;
-			struct timespec now;
-			clock_gettime(CLOCK_MONOTONIC, &now);
-			double elapsed = (now.tv_sec - g_snes_state.cache_time.tv_sec)
-				+ (now.tv_nsec - g_snes_state.cache_time.tv_nsec) / 1e9;
-			double ms_per_cycle = (g_snes_state.game_frames > 0) ?
-				(elapsed * 1000.0 / g_snes_state.game_frames) : 0.0;
-			ra_log_write("POLL(SNES): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
-				g_snes_state.last_resp_frame, g_snes_state.game_frames, elapsed, ms_per_cycle,
+	if (ra_snes_addrlist_count() == 0 && !g_snes_state.cache_ready) {
+		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		g_snes_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_snes_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("SNES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
-			
-			// Dump VALCACHE every 1800 game frames (~30s)
-			if ((g_snes_state.game_frames % 1800) == 0) {
-				snes_optionc_dump_valcache("periodic", map);
+			snes_optionc_dump_valcache("bootstrap", map);
+		} else {
+			ra_log_write("SNES OptionC: No addresses collected — achievements may have no memory refs\n");
+		}
+	} else if (!g_snes_state.cache_ready) {
+		// Wait for FPGA to respond with cached values
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_snes_state.cache_ready = 1;
+			g_snes_state.last_resp_frame = 0;
+			g_snes_state.game_frames = 0;
+			g_snes_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_snes_state.cache_time);
+			ra_log_write("SNES OptionC: Cache active! FPGA response matched request.\n");
+			snes_optionc_dump_valcache("cache-active", map);
+		}
+	} else {
+		// Normal frame processing from cache
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_snes_state.last_resp_frame) {
+			g_snes_state.last_resp_frame = resp_frame;
+			g_snes_state.game_frames++;
+			ra_frame_processed(resp_frame);
+
+			// Dump first 5 frames after cache became active
+			if (g_snes_state.game_frames <= 5) {
+				ra_log_write("SNES OptionC: GameFrame %u (resp_frame=%u)\n",
+					g_snes_state.game_frames, resp_frame);
+				snes_optionc_dump_valcache("early-frame", map);
+			}
+
+			// Periodically re-collect to catch address changes (every ~5 min)
+			int re_collect = (g_snes_state.game_frames % 18000 == 0) && (g_snes_state.game_frames > 0);
+			if (re_collect) {
+				g_snes_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_snes_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("SNES OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
 			}
 		}
 	}
-	// VBlank-gated mode uses default frame tracking in main achievements_poll()
+
+	// Periodic SNES debug — log once per 300-frame milestone
+	uint32_t milestone = g_snes_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_snes_state.poll_logged) {
+		g_snes_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_snes_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_snes_state.cache_time.tv_nsec) / 1e9;
+		double ms_per_cycle = (g_snes_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_snes_state.game_frames) : 0.0;
+		ra_log_write("POLL(SNES): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_snes_state.last_resp_frame, g_snes_state.game_frames, elapsed, ms_per_cycle,
+			ra_snes_addrlist_count());
+		if ((g_snes_state.game_frames % 1800) < 300)
+			snes_optionc_dump_valcache("periodic", map);
+	}
+
+	return 1; // SNES Option C handled
+#else
+	return 0;
 #endif
 }
 
@@ -264,45 +205,32 @@ static int snes_calculate_hash(const char *rom_path, char *md5_hex_out)
 	long file_size = ftell(f);
 	fseek(f, 0, SEEK_SET);
 
-	if (file_size <= 0) {
-		fclose(f);
-		return 0;
-	}
+	if (file_size <= 0) { fclose(f); return 0; }
 
 	uint8_t *rom_data = (uint8_t *)malloc(file_size);
-	if (!rom_data) {
-		fclose(f);
-		return 0;
-	}
+	if (!rom_data) { fclose(f); return 0; }
 
 	size_t nread = fread(rom_data, 1, file_size, f);
 	fclose(f);
-	
-	if ((long)nread != file_size) {
-		free(rom_data);
-		return 0;
-	}
+
+	if ((long)nread != file_size) { free(rom_data); return 0; }
 
 	const uint8_t *hash_data = rom_data;
 	long hash_size = file_size;
 
-	// SNES: skip optional 512-byte SMC/SWC copier header
 	if ((file_size % 1024) == 512 && file_size > 512) {
-		ra_log_write("SNES: SMC header detected (file_size %% 1024 == 512), skipping 512 bytes\n");
+		ra_log_write("SNES: SMC header detected, skipping 512 bytes\n");
 		hash_data = rom_data + 512;
 		hash_size = file_size - 512;
 	}
 
-	// Calculate MD5
 	MD5_CTX ctx;
 	MD5Init(&ctx);
 	MD5Update(&ctx, hash_data, hash_size);
 	unsigned char md5_bin[16];
 	MD5Final(md5_bin, &ctx);
-
-	for (int i = 0; i < 16; i++) {
+	for (int i = 0; i < 16; i++)
 		sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
-	}
 	md5_hex_out[32] = '\0';
 
 	free(rom_data);
@@ -311,29 +239,21 @@ static int snes_calculate_hash(const char *rom_path, char *md5_hex_out)
 
 static void snes_set_hardcore(int enabled)
 {
-	if (enabled) {
-		user_io_status_set("[58]", 1);  // Disable cheats
-		user_io_status_set("[24]", 1);  // Disable save states
-		ra_log_write("SNES: Hardcore mode enabled (cheats/states disabled)\n");
-	} else {
-		user_io_status_set("[58]", 0);
-		user_io_status_set("[24]", 0);
-		ra_log_write("SNES: Hardcore mode disabled\n");
-	}
+	user_io_status_set("[58]", enabled ? 1 : 0); // disable cheats
+	user_io_status_set("[24]", enabled ? 1 : 0); // disable save states
+	ra_log_write("SNES: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-// Called from main achievements code to detect protocol type
 void snes_detect_protocol(void *map)
 {
 	if (!map) return;
-	
 	const ra_header_t *hdr = (const ra_header_t *)map;
 	if (hdr->region_count == 0) {
 		g_snes_state.optionc = 1;
 		ra_log_write("SNES FPGA protocol: Option C (selective address reading)\n");
 	} else {
 		g_snes_state.optionc = 0;
-		ra_log_write("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n", 
+		ra_log_write("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n",
 			hdr->region_count);
 	}
 }
@@ -349,6 +269,7 @@ const console_handler_t g_console_snes = {
 	.poll = snes_poll,
 	.calculate_hash = snes_calculate_hash,
 	.set_hardcore = snes_set_hardcore,
+	.detect_protocol = snes_detect_protocol,
 	.console_id = 3,  // RC_CONSOLE_SUPER_NINTENDO
 	.name = "SNES"
 };

--- a/menu.cpp
+++ b/menu.cpp
@@ -2727,6 +2727,7 @@ void HandleUI(void)
 			{
 				neocd_set_en(1);
 				neocd_set_image(selPath);
+				achievements_load_game(selPath, 0);
 			}
 			else if (is_atari800())
 			{

--- a/menu.cpp
+++ b/menu.cpp
@@ -2698,6 +2698,8 @@ void HandleUI(void)
 			else if (is_megacd())
 			{
 				mcd_set_image(ioctl_index, selPath);
+				if (!ioctl_index)
+					achievements_load_game(selPath, 0);
 			}
 			else if (is_pce())
 			{

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -146,6 +146,35 @@ uint32_t ra_ramread_snes_read(const void *map, uint32_t address, uint8_t *buffer
 	return num_bytes;
 }
 
+uint8_t ra_ramread_atari2600_byte(const void *map, uint16_t addr)
+{
+	// Atari 2600 RIOT RAM: 128 bytes at CPU $0080-$00FF.
+	// rcheevos addresses this range as $0080-$00FF (and mirrors).
+	// We map any address with bit 7 set (and bit 9 clear) to region 0.
+	if ((addr & 0x0080) && !(addr & 0x0200)) {
+		uint8_t offset = addr & 0x007F;  // 0-127
+		if (!map) return 0;
+		const ra_header_t *hdr = (const ra_header_t *)map;
+		if (hdr->magic != RA_MAGIC) return 0;
+
+		// Bypass the region descriptor: ra_riot_mirror always writes RIOT data
+		// at a fixed DDRAM offset of 0x100 with size 128. The descriptor at
+		// offset 0x10 is sometimes stale (garbage from a previous core session),
+		// so we hardcode the layout here rather than trusting the descriptor.
+		const uint8_t *data = (const uint8_t *)map + 0x100;
+		return data[offset];
+	}
+	return 0;
+}
+
+uint32_t ra_ramread_atari2600_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	for (uint32_t i = 0; i < num_bytes; i++) {
+		buffer[i] = ra_ramread_atari2600_byte(map, (uint16_t)(address + i));
+	}
+	return num_bytes;
+}
+
 void ra_ramread_debug_dump(const void *map)
 {
 	RA_DBG("=== DDRAM Mirror Diagnostic Dump ===");

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -397,3 +397,83 @@ void ra_snes_addrlist_diag_dump(const void *map)
 	const ra_addr_req_hdr_t *ahdr = (const ra_addr_req_hdr_t *)(base + RA_SNES_ADDRLIST_OFFSET);
 	RA_DBG("ADDRLIST hdr in DDRAM: count=%u req_id=%u", ahdr->addr_count, ahdr->request_id);
 }
+
+// ======================================================================
+// Realtime Query Mailbox (Option C "on steroids")
+// ======================================================================
+
+static uint8_t s_rtquery_seq = 0;
+
+void ra_rtquery_init(void *map)
+{
+        s_rtquery_seq = 0;
+        if (!map) return;
+
+        // Clear the control word so FPGA sees no pending request
+        uint8_t *base = (uint8_t *)map;
+        ra_query_ctrl_t *ctrl = (ra_query_ctrl_t *)(base + RA_QUERY_CTRL_OFFSET);
+        memset(ctrl, 0, sizeof(*ctrl));
+        __sync_synchronize();
+        RA_DBG("RTQuery: initialized (mailbox at offset 0x%X)", RA_QUERY_CTRL_OFFSET);
+}
+
+uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes)
+{
+        if (!map || num_bytes == 0 || num_bytes > 4) return 0;
+
+        uint8_t *base = (uint8_t *)map;
+        ra_query_ctrl_t *ctrl = (ra_query_ctrl_t *)(base + RA_QUERY_CTRL_OFFSET);
+        ra_query_req_t  *req  = (ra_query_req_t *)(base + RA_QUERY_REQ_OFFSET);
+        ra_query_resp_t *resp = (ra_query_resp_t *)(base + RA_QUERY_RESP_OFFSET);
+
+        // Fill single query slot
+        req[0].address   = address;
+        req[0].num_bytes = (uint8_t)num_bytes;
+        __sync_synchronize();
+
+        // Increment sequence and write control
+        s_rtquery_seq++;
+        if (s_rtquery_seq == 0) s_rtquery_seq = 1;  // Never use 0
+
+        ctrl->num_queries = 1;
+        ctrl->request_seq = s_rtquery_seq;
+        __sync_synchronize();
+
+        // Busy-wait for FPGA response (typically 5-50µs)
+        volatile ra_query_ctrl_t *vctrl = (volatile ra_query_ctrl_t *)ctrl;
+        int timeout = 100000;  // ~100ms safety limit at ~1µs per iteration
+        while (vctrl->response_seq != s_rtquery_seq && --timeout > 0) {
+                // Spin
+        }
+
+        if (timeout <= 0) {
+                // Timeout — FPGA didn't respond
+                return 0;
+        }
+
+        // Read result
+        volatile ra_query_resp_t *vresp = (volatile ra_query_resp_t *)resp;
+        uint32_t value = vresp[0].value;
+
+        // Mask to requested byte count
+        if (num_bytes < 4) {
+                value &= (1u << (num_bytes * 8)) - 1;
+        }
+
+        return value;
+}
+
+int ra_rtquery_supported(const void *map)
+{
+        // Check FPGA version in debug word at DDRAM_BASE + 0x10
+        // Debug word 1: {ver(8), dispatch_cnt(8), first_dout(16), timeout_cnt(16), ok_cnt(16)}
+        // ver is at byte offset 0x17 (top byte of the 64-bit word at offset 0x10)
+        if (!map) return 0;
+        const uint8_t *base = (const uint8_t *)map;
+        // The debug word is at DDRAM offset 0x10 (word index 2)
+        // In the 64-bit word: FPGA_VERSION is in bits [63:56] = byte[7] of the word
+        // At byte offset 0x10 + 7 = 0x17
+        uint8_t ver = base[0x17];
+        return ver >= 0x02;
+}
+

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -74,6 +74,55 @@ typedef struct __attribute__((packed)) {
 #define RA_SNES_VALCACHE_OFFSET  0x48000   // FPGA → ARM: value response table
 #define RA_SNES_MAX_ADDRS        4096      // Max tracked addresses
 
+// ======================================================================
+// Realtime Query Mailbox (Option C "on steroids")
+// ARM writes query addresses, FPGA reads SDRAM, writes values back.
+// Used for AddAddress pointer resolution during rc_client_do_frame().
+// ======================================================================
+#define RA_QUERY_CTRL_OFFSET     0x50000   // Control word (8 bytes)
+#define RA_QUERY_REQ_OFFSET      0x50008   // Request slots (16 × 8 bytes)
+#define RA_QUERY_RESP_OFFSET     0x50088   // Response slots (16 × 8 bytes)
+#define RA_QUERY_MAX_SLOTS       16
+
+// Control word layout (8 bytes at QUERY_CTRL_OFFSET):
+//   [0] request_seq    (uint8_t)  ARM increments to signal new batch
+//   [1] num_queries    (uint8_t)  Number of queries (1-16)
+//   [2-3] reserved
+//   [4] response_seq   (uint8_t)  FPGA writes = request_seq when done
+//   [5-7] reserved
+//
+// Request slot layout (8 bytes each at QUERY_REQ_OFFSET + i*8):
+//   [0-3] address      (uint32_t) Byte address in game RAM
+//   [4]   num_bytes    (uint8_t)  Bytes to read (1-4)
+//   [5-7] reserved
+//
+// Response slot layout (8 bytes each at QUERY_RESP_OFFSET + i*8):
+//   [0-3] value        (uint32_t) Value read from game RAM (little-endian)
+//   [4-7] reserved
+
+typedef struct __attribute__((packed)) {
+        uint8_t  request_seq;
+        uint8_t  num_queries;
+        uint16_t reserved1;
+        uint8_t  response_seq;
+        uint8_t  reserved2[3];
+} ra_query_ctrl_t;
+
+typedef struct __attribute__((packed)) {
+        uint32_t address;
+        uint8_t  num_bytes;
+        uint8_t  reserved[3];
+} ra_query_req_t;
+
+typedef struct __attribute__((packed)) {
+        uint32_t value;
+        uint32_t reserved;
+} ra_query_resp_t;
+
+// Realtime query API — generic, works with any Option C core
+void     ra_rtquery_init(void *map);
+uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes);
+
 // Address request header at ADDRLIST_OFFSET (ARM writes)
 typedef struct __attribute__((packed)) {
 	uint32_t addr_count;    // Number of addresses
@@ -142,5 +191,8 @@ void ra_ramread_debug_dump(const void *map);
 
 // Print a one-line status summary (for periodic logging)
 void ra_ramread_debug_status(const void *map);
+
+// Realtime query: check if FPGA supports it (version >= 2)
+int ra_rtquery_supported(const void *map);
 
 #endif // RA_RAMREAD_H

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -64,6 +64,9 @@ typedef struct __attribute__((packed)) {
 #define RA_NES_CPURAM_REGION  0  // $0000-$07FF (2KB)
 #define RA_NES_CARTRAM_REGION 1  // $6000-$7FFF (up to 8KB+)
 
+// Atari 2600-specific region indices
+#define RA_ATARI2600_RIOT_REGION 0  // $0080-$00FF RIOT internal RAM (128 bytes)
+
 // SNES-specific layout (fixed offsets in DDRAM mirror)
 #define RA_SNES_WRAM_OFFSET   0x00100   // WRAM data starts at byte offset 0x100
 #define RA_SNES_WRAM_SIZE     0x20000   // 128KB
@@ -169,6 +172,11 @@ uint32_t ra_ramread_nes_read(const void *map, uint32_t address, uint8_t *buffer,
 //   0x000000-0x01FFFF = WRAM (128KB)
 //   0x020000+         = Save RAM (BSRAM)
 uint32_t ra_ramread_snes_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
+
+// Read Atari 2600 memory from mirrored RAM. rcheevos address map:
+//   0x0080-0x00FF: RIOT internal RAM (128 bytes)
+uint8_t  ra_ramread_atari2600_byte(const void *map, uint16_t addr);
+uint32_t ra_ramread_atari2600_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
 
 // Option C: Selective address reading (SNES)
 // ARM collects needed addresses from rcheevos, writes list to DDRAM.


### PR DESCRIPTION
This pull request adds full support for the Atari 2600 console to the RetroAchievements framework, refactors and improves the console handler interface, and enhances diagnostics and logging for Game Boy and GBA cores. The main themes are new platform support, interface modernization, and logging/diagnostics improvements.

**Atari 2600 support:**

* Added `achievements_atari2600.cpp` implementing Atari 2600-specific achievement handling, including memory mapping, polling, ROM hashing, and logging. Registered the handler in the main lookup tables. [[1]](diffhunk://#diff-7dd259e1ebd9468ada142702b2609e45cd734c9717860b34905e62af66dd130aR1-R175) [[2]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7L14-R18) [[3]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7L26-R32) [[4]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L58-R69)

**Console handler interface refactor:**

* Updated the `console_handler_t` struct to clarify method purposes, add a `detect_protocol` method, and improve documentation. The `poll` method now returns an int to indicate frame handling. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L26-R26) [[2]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L35-R52)
* Removed now-unnecessary global protocol detection function declarations and updated handler registration to match new interface. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L71-L80) [[2]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L58-R69)

**Game Boy core improvements:**

* Refactored Game Boy polling to use the new handler interface, improved watcher initialization and logging, and added periodic re-collection of addresses. Improved logging output for cache activation and watcher value changes. [[1]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeL49-R57) [[2]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeL87-R120) [[3]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR129-R146) [[4]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeL169-R192) [[5]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR206)
* The Game Boy protocol detection is now a static method, always sets Option C, and logs protocol selection.

**GBA core improvements:**

* Improved GBA diagnostics with a new `gba_optionc_dump_valcache` function for detailed cache and address logging. Refactored initialization and reset logic to use `memset` for state. [[1]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1L1-R1) [[2]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R14) [[3]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R23-R80)

**Minor updates:**

* Updated comments and documentation for clarity across several files. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L16-R16) [[2]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L26-R26) [[3]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L35-R52) [[4]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L58-R69)

These changes modernize the achievements framework, add new platform support, and improve diagnostics and maintainability.