### PR TITLE
Add Game Boy Advance support

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -697,6 +697,15 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 	case RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE:
 		{
 			RA_LOG("PROGRESS: %s — %s", event->achievement->title, event->achievement->measured_progress);
+                        // Dump all cached values on progress events for debugging
+                        if (g_ra_map) {
+                                int cnt = ra_snes_addrlist_count();
+                                const uint32_t *addrs = ra_snes_addrlist_addrs();
+                                for (int i = 0; i < cnt; i++) {
+                                        uint8_t v = ra_snes_addrlist_read_cached(g_ra_map, addrs[i]);
+                                        RA_LOG("  COND[%d] addr=0x%05X val=0x%02X", i, addrs[i], v);
+                                }
+                        }
 			if (g_show_progress_popups &&
 			    !ra_progress_popup_suppressed(event->achievement->id, event->achievement->measured_progress)) {
 				char buf[NOTIF_TEXT_MAX];

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -65,6 +65,7 @@ extern const console_handler_t g_console_neogeo;
 extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
+extern const console_handler_t g_console_tgfx16;
 
 // Get console handler by core name (returns NULL if not found)
 const console_handler_t *get_console_handler_by_name(const char *core_name);

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -16,6 +16,7 @@ extern const console_handler_t g_console_neogeo;
 extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
+extern const console_handler_t g_console_tgfx16;
 
 // Master lookup table
 static const console_handler_t *g_console_handlers[] = {
@@ -30,6 +31,7 @@ static const console_handler_t *g_console_handlers[] = {
 	&g_console_gba,
 	&g_console_megacd,
 	&g_console_atari2600,
+	&g_console_tgfx16,
 	NULL
 };
 
@@ -70,6 +72,10 @@ const console_handler_t *get_console_handler_by_id(int console_id)
 	// Game Gear (ID 15) uses SMS handler (ID 11)
 	if (console_id == 15) {
 		return &g_console_sms;
+	}
+	// PC Engine CD (ID 76) uses TG16 handler (ID 8)
+	if (console_id == 76) {
+		return &g_console_tgfx16;
 	}
 
 	return NULL;

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -3,6 +3,7 @@
 #include "achievements_console.h"
 #include "achievements.h"
 #include "ra_ramread.h"
+#include "shmem.h"
 #include "user_io.h"
 #include <string.h>
 #include <time.h>
@@ -48,20 +49,24 @@ static void gba_optionc_dump_valcache(const char *label, void *map)
         ra_log_write("GBA DUMP[%s] VALCACHE[0..%d]: %s\n", label, dump_len - 1, hex);
 
         // FPGA debug words at 0x10 / 0x18
+        // Word 1: {ver(8), dispatch(8), 0(16), timeout(16), ok(16)}
         const uint8_t *dbg8 = base + 0x10;
-        uint16_t iwram_cnt   = dbg8[0] | (dbg8[1] << 8);
+        uint16_t ok_cnt       = dbg8[0] | (dbg8[1] << 8);
+        uint16_t timeout_cnt  = dbg8[2] | (dbg8[3] << 8);
         uint8_t  dispatch_cnt = dbg8[6];
         uint8_t  fpga_ver     = dbg8[7];
+        // Word 2: {first_addr(16), iwram(16), ewram(16), cart(16)}
         const uint8_t *dbg8b = base + 0x18;
-        uint16_t ewram_cnt  = dbg8b[4] | (dbg8b[5] << 8);
-        uint16_t cart_cnt   = dbg8b[2] | (dbg8b[3] << 8);
+        uint16_t cart_cnt   = dbg8b[0] | (dbg8b[1] << 8);
+        uint16_t ewram_cnt  = dbg8b[2] | (dbg8b[3] << 8);
+        uint16_t iwram_cnt  = dbg8b[4] | (dbg8b[5] << 8);
         uint16_t first_addr = dbg8b[6] | (dbg8b[7] << 8);
 
-        ra_log_write("GBA DUMP[%s] FPGA ver=0x%02X dispatch=%u iwram=%u ewram=%u cart=%u faddr=0x%04X\n",
-                label, fpga_ver, dispatch_cnt, iwram_cnt, ewram_cnt, cart_cnt, first_addr);
+        ra_log_write("GBA DUMP[%s] FPGA ver=0x%02X dispatch=%u ok=%u timeout=%u iwram=%u ewram=%u cart=%u faddr=0x%04X\n",
+                label, fpga_ver, dispatch_cnt, ok_cnt, timeout_cnt, iwram_cnt, ewram_cnt, cart_cnt, first_addr);
 
-        // Address+value pairs (first 10)
-        int show = addr_count < 10 ? addr_count : 10;
+        // Address+value pairs (all addresses)
+        int show = addr_count;
         for (int i = 0; i < show; i++)
                 ra_log_write("GBA DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
 }
@@ -214,11 +219,54 @@ static void gba_set_hardcore(int enabled)
         ra_log_write("GBA: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
+// ---------------------------------------------------------------------------
+// GBA Flash DDRAM initialization
+// ---------------------------------------------------------------------------
+// On real GBA, erased/unwritten Flash reads 0xFF.  The FPGA core does not
+// pre-fill the DDRAM Flash region, so when no save file is loaded the area
+// stays at 0x00 (DDR3 default).  RetroAchievements conditions that check for
+// "no save present" compare against 0xFF, so we must initialise it here.
+//
+// ARM physical address for Flash = 0x30000000 (FLASH_BASE_DWORD=0, qword*8)
+// Size = 128 KB (same as Softmap_GBA_FLASH_ADDR range in GBA.sv)
+
+#define GBA_FLASH_PHYS_ADDR  0x30000000
+#define GBA_FLASH_SIZE       0x20000   // 128 KB
+
+static void gba_init_flash_ddram(void)
+{
+        void *flash = shmem_map(GBA_FLASH_PHYS_ADDR, GBA_FLASH_SIZE);
+        if (!flash) {
+                ra_log_write("GBA Flash init: shmem_map(0x%08X) failed\n", GBA_FLASH_PHYS_ADDR);
+                return;
+        }
+
+        // Check if the region is all-zero (no save file was loaded).
+        // A loaded save file will have non-zero bytes (including 0xFF for
+        // erased sectors), so we only fill when the DDR3 default is intact.
+        const uint8_t *p = (const uint8_t *)flash;
+        int all_zero = 1;
+        for (uint32_t i = 0; i < GBA_FLASH_SIZE; i += 256) {
+                if (p[i] != 0x00) { all_zero = 0; break; }
+        }
+
+        if (all_zero) {
+                memset(flash, 0xFF, GBA_FLASH_SIZE);
+                ra_log_write("GBA Flash init: filled 128KB at 0x%08X with 0xFF (no save loaded)\n",
+                        GBA_FLASH_PHYS_ADDR);
+        } else {
+                ra_log_write("GBA Flash init: region not zero, save file present — skipped\n");
+        }
+
+        shmem_unmap(flash, GBA_FLASH_SIZE);
+}
+
 static void gba_detect_protocol(void *map)
 {
         if (!map) return;
         // GBA always uses Option C
         g_gba_state.optionc = 1;
+        gba_init_flash_ddram();
         ra_log_write("GBA FPGA protocol: Option C (selective address reading)\n");
 }
 

--- a/achievements_tgfx16.cpp
+++ b/achievements_tgfx16.cpp
@@ -1,0 +1,273 @@
+// achievements_tgfx16.cpp — RetroAchievements TurboGrafx-16 / PC Engine implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "lib/md5/md5.h"
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// TG16 State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_tgfx16_state = {0};
+
+// ---------------------------------------------------------------------------
+// TG16 Option C Diagnostics
+// ---------------------------------------------------------------------------
+
+static void tgfx16_optionc_dump_valcache(const char *label, void *map)
+{
+if (!map) return;
+const uint8_t *base = (const uint8_t *)map;
+int addr_count = ra_snes_addrlist_count();
+const uint32_t *addrs = ra_snes_addrlist_addrs();
+
+const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
+const uint8_t *vals = base + RA_SNES_VALCACHE_OFFSET + 8;
+
+int dump_len = addr_count < 32 ? addr_count : 32;
+if (dump_len <= 0) dump_len = 32;
+char hex[200];
+int pos = 0, non_zero = 0;
+for (int i = 0; i < dump_len && pos < (int)sizeof(hex) - 4; i++) {
+pos += snprintf(hex + pos, sizeof(hex) - pos, "%02X ", vals[i]);
+if (vals[i]) non_zero++;
+}
+
+ra_log_write("TGFX16 DUMP[%s] resp_id=%u resp_frame=%u addrs=%d non_zero=%d\n",
+label, resp->response_id, resp->response_frame, addr_count, non_zero);
+ra_log_write("TGFX16 DUMP[%s] VALCACHE[0..%d]: %s\n", label, dump_len - 1, hex);
+
+// FPGA debug words
+const uint8_t *dbg8 = base + 0x10;
+uint16_t ok_cnt      = dbg8[0] | (dbg8[1] << 8);
+uint16_t timeout_cnt = dbg8[2] | (dbg8[3] << 8);
+uint8_t  dispatch_cnt = dbg8[6];
+uint8_t  fpga_ver     = dbg8[7];
+const uint8_t *dbg8b = base + 0x18;
+uint16_t wram_cnt = dbg8b[0] | (dbg8b[1] << 8);
+uint16_t cdram_cnt = dbg8b[2] | (dbg8b[3] << 8);
+uint16_t first_addr = dbg8b[6] | (dbg8b[7] << 8);
+
+ra_log_write("TGFX16 DUMP[%s] FPGA ver=0x%02X ok=%u timeout=%u dispatch=%u wram=%u cdram=%u faddr=0x%04X\n",
+label, fpga_ver, ok_cnt, timeout_cnt, dispatch_cnt, wram_cnt, cdram_cnt, first_addr);
+
+int show = addr_count < 10 ? addr_count : 10;
+for (int i = 0; i < show; i++)
+ra_log_write("TGFX16 DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[i], vals[i]);
+}
+
+// ---------------------------------------------------------------------------
+// TG16 Implementation
+// ---------------------------------------------------------------------------
+
+static void tgfx16_init(void)
+{
+memset(&g_tgfx16_state, 0, sizeof(g_tgfx16_state));
+}
+
+static void tgfx16_reset(void)
+{
+memset(&g_tgfx16_state, 0, sizeof(g_tgfx16_state));
+}
+
+static uint32_t tgfx16_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+if (g_tgfx16_state.optionc) {
+if (g_tgfx16_state.collecting) {
+for (uint32_t i = 0; i < num_bytes; i++)
+ra_snes_addrlist_add(address + i);
+}
+if (g_tgfx16_state.cache_ready) {
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+memset(buffer, 0, num_bytes);
+return num_bytes;
+}
+memset(buffer, 0, num_bytes);
+return num_bytes;
+}
+
+static int tgfx16_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+if (!client || !game_loaded || !map || !g_tgfx16_state.optionc)
+return 0;
+
+rc_client_t *rc_client = (rc_client_t *)client;
+
+if (ra_snes_addrlist_count() == 0 && !g_tgfx16_state.cache_ready) {
+// Bootstrap: collect addresses
+g_tgfx16_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+rc_client_do_frame(rc_client);
+g_tgfx16_state.collecting = 0;
+int changed = ra_snes_addrlist_end_collect(map);
+if (changed) {
+ra_log_write("TGFX16 OptionC: Bootstrap done, %d addrs\n",
+ra_snes_addrlist_count());
+tgfx16_optionc_dump_valcache("bootstrap", map);
+} else {
+ra_log_write("TGFX16 OptionC: No addresses collected\n");
+}
+} else if (!g_tgfx16_state.cache_ready) {
+// Wait for FPGA response
+if (ra_snes_addrlist_is_ready(map)) {
+g_tgfx16_state.cache_ready = 1;
+g_tgfx16_state.last_resp_frame = 0;
+g_tgfx16_state.game_frames = 0;
+g_tgfx16_state.poll_logged = 0;
+clock_gettime(CLOCK_MONOTONIC, &g_tgfx16_state.cache_time);
+ra_log_write("TGFX16 OptionC: Cache active!\n");
+tgfx16_optionc_dump_valcache("cache-active", map);
+}
+} else {
+// Normal frame processing
+uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+if (resp_frame > g_tgfx16_state.last_resp_frame) {
+g_tgfx16_state.last_resp_frame = resp_frame;
+g_tgfx16_state.game_frames++;
+ra_frame_processed(resp_frame);
+
+if (g_tgfx16_state.game_frames <= 5) {
+ra_log_write("TGFX16 OptionC: GameFrame %u (resp_frame=%u)\n",
+g_tgfx16_state.game_frames, resp_frame);
+tgfx16_optionc_dump_valcache("early-frame", map);
+}
+
+// Re-collect every ~5 min
+int re_collect = (g_tgfx16_state.game_frames % 18000 == 0) && (g_tgfx16_state.game_frames > 0);
+if (re_collect) {
+g_tgfx16_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+}
+
+rc_client_do_frame(rc_client);
+
+if (re_collect) {
+g_tgfx16_state.collecting = 0;
+if (ra_snes_addrlist_end_collect(map)) {
+ra_log_write("TGFX16 OptionC: Address list refreshed, %d addrs\n",
+ra_snes_addrlist_count());
+}
+}
+}
+}
+
+// Periodic debug logging
+uint32_t milestone = g_tgfx16_state.game_frames / 300;
+if (milestone > 0 && milestone != g_tgfx16_state.poll_logged) {
+g_tgfx16_state.poll_logged = milestone;
+struct timespec now;
+clock_gettime(CLOCK_MONOTONIC, &now);
+double elapsed = (now.tv_sec - g_tgfx16_state.cache_time.tv_sec)
++ (now.tv_nsec - g_tgfx16_state.cache_time.tv_nsec) / 1e9;
+double ms_per_cycle = (g_tgfx16_state.game_frames > 0) ?
+(elapsed * 1000.0 / g_tgfx16_state.game_frames) : 0.0;
+ra_log_write("POLL(TGFX16): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+g_tgfx16_state.last_resp_frame, g_tgfx16_state.game_frames, elapsed, ms_per_cycle,
+ra_snes_addrlist_count());
+if ((g_tgfx16_state.game_frames % 1800) < 300)
+tgfx16_optionc_dump_valcache("periodic", map);
+}
+
+return 1;
+#else
+return 0;
+#endif
+}
+
+static int tgfx16_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+// PC Engine ROMs: .pce files may have a 512-byte header if size % 1024 == 512
+FILE *f = fopen(rom_path, "rb");
+if (!f) {
+ra_log_write("TGFX16: Failed to open ROM for hashing: %s\n", rom_path);
+return 0;
+}
+
+fseek(f, 0, SEEK_END);
+long file_size = ftell(f);
+fseek(f, 0, SEEK_SET);
+
+if (file_size <= 0) { fclose(f); return 0; }
+
+uint8_t *rom_data = (uint8_t *)malloc(file_size);
+if (!rom_data) { fclose(f); return 0; }
+
+size_t nread = fread(rom_data, 1, file_size, f);
+fclose(f);
+
+if ((long)nread != file_size) { free(rom_data); return 0; }
+
+const uint8_t *hash_data = rom_data;
+long hash_size = file_size;
+
+// Skip 512-byte copier header if present
+if ((file_size % 1024) == 512 && file_size > 512) {
+ra_log_write("TGFX16: Copier header detected, skipping 512 bytes\n");
+hash_data = rom_data + 512;
+hash_size = file_size - 512;
+}
+
+MD5_CTX ctx;
+MD5Init(&ctx);
+MD5Update(&ctx, hash_data, hash_size);
+unsigned char md5_bin[16];
+MD5Final(md5_bin, &ctx);
+for (int i = 0; i < 16; i++)
+sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
+md5_hex_out[32] = '\0';
+
+free(rom_data);
+return 1;
+}
+
+static void tgfx16_set_hardcore(int enabled)
+{
+// TG16 core: disable cheats (status bit 5)
+user_io_status_set("[5]", enabled ? 1 : 0);
+ra_log_write("TGFX16: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
+}
+
+static void tgfx16_detect_protocol(void *map)
+{
+if (!map) return;
+const ra_header_t *hdr = (const ra_header_t *)map;
+if (hdr->region_count == 0) {
+g_tgfx16_state.optionc = 1;
+ra_log_write("TGFX16 FPGA protocol: Option C (selective address reading)\n");
+} else {
+g_tgfx16_state.optionc = 0;
+ra_log_write("TGFX16 FPGA protocol: VBlank-gated mirror (region_count=%d)\n",
+hdr->region_count);
+}
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_tgfx16 = {
+.init = tgfx16_init,
+.reset = tgfx16_reset,
+.read_memory = tgfx16_read_memory,
+.poll = tgfx16_poll,
+.calculate_hash = tgfx16_calculate_hash,
+.set_hardcore = tgfx16_set_hardcore,
+.detect_protocol = tgfx16_detect_protocol,
+.console_id = 8,  // RC_CONSOLE_PC_ENGINE
+.name = "TGFX16"
+};

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -148,21 +148,20 @@ uint32_t ra_ramread_snes_read(const void *map, uint32_t address, uint8_t *buffer
 
 uint8_t ra_ramread_atari2600_byte(const void *map, uint16_t addr)
 {
-	// Atari 2600 RIOT RAM: 128 bytes at CPU $0080-$00FF.
-	// rcheevos addresses this range as $0080-$00FF (and mirrors).
-	// We map any address with bit 7 set (and bit 9 clear) to region 0.
-	if ((addr & 0x0080) && !(addr & 0x0200)) {
-		uint8_t offset = addr & 0x007F;  // 0-127
+	// rcheevos maps Atari 2600 RIOT RAM as a 128-byte block starting at address 0.
+	// This matches Stella2014's retro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM) which
+	// returns a direct pointer to the 128-byte RIOT RAM — so rcheevos address 0x00
+	// = RIOT byte 0 = CPU $0080, and rcheevos address 0x4E = RIOT byte 0x4E = CPU $00CE.
+	// The old check (addr & 0x0080) was wrong: it rejected all addresses below 0x80.
+	if (addr < 128) {
 		if (!map) return 0;
 		const ra_header_t *hdr = (const ra_header_t *)map;
 		if (hdr->magic != RA_MAGIC) return 0;
 
 		// Bypass the region descriptor: ra_riot_mirror always writes RIOT data
-		// at a fixed DDRAM offset of 0x100 with size 128. The descriptor at
-		// offset 0x10 is sometimes stale (garbage from a previous core session),
-		// so we hardcode the layout here rather than trusting the descriptor.
+		// at a fixed DDRAM offset of 0x100 with size 128.
 		const uint8_t *data = (const uint8_t *)map + 0x100;
-		return data[offset];
+		return data[addr];
 	}
 	return 0;
 }


### PR DESCRIPTION
This pull request adds support for TurboGrafx-16 / PC Engine (TGFX16) achievements, improves GBA and Atari 2600 support, and enhances debugging and protocol handling for achievements. The main changes include a new TGFX16 implementation, fixes for GBA Flash initialization, improved address handling for Atari 2600, and additional debugging output.

**TurboGrafx-16 / PC Engine support:**
* Added a new file `achievements_tgfx16.cpp` implementing RetroAchievements support for TGFX16, including Option C protocol handling, ROM hashing, and integration with the core handler system.
* Registered the TGFX16 console handler in `achievements_console.h` and `achievements_console_lookup.cpp`, and mapped PC Engine CD (console ID 76) to use the TGFX16 handler. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R68) [[2]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R19) [[3]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R34) [[4]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R76-R79)

**GBA improvements:**
* Added DDRAM Flash initialization to fill the GBA Flash region with 0xFF if no save file is loaded, fixing compatibility with RetroAchievements logic for "no save present".
* Improved GBA Option C diagnostics: fixed the order and meaning of debug fields, and now dumps all address/value pairs instead of just the first 10.

**Atari 2600 fixes:**
* Corrected the mapping of RIOT RAM addresses to match the RetroAchievements and Stella2014 layout, ensuring proper achievement memory access.

**Debugging enhancements:**
* On achievement progress events, all cached address values are now dumped for easier debugging.

**Other:**
* Minor include fixes (added `shmem.h` to `achievements_gba.cpp`).