### PR TITLE
Add TurboGrafx/PC Engine support

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -174,6 +174,7 @@ static int g_show_challenge_hide_popup = 1; // 1 = show popup on challenge HIDE 
 static int g_show_progress_popups      = 1; // 1 = show progress indicator popups
 static int g_show_progress_name        = 1; // 1 = include achievement name in progress popup
 static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheats & save states)
+static int g_stall_recovery            = 0; // 1 = enable OptionC stall recovery (disabled by default)
 static char g_ua_clause[64]            = ""; // rcheevos user-agent clause (e.g. "rcheevos/11.6")
 
 // ---------------------------------------------------------------------------
@@ -493,6 +494,8 @@ static int ra_load_credentials(void)
 			g_show_progress_name = atoi(val);
 		} else if (!strcasecmp(key, "hardcore")) {
 			g_hardcore = atoi(val);
+		} else if (!strcasecmp(key, "stall_recovery")) {
+			g_stall_recovery = atoi(val);
 		}
 	}
 	fclose(f);
@@ -503,9 +506,9 @@ static int ra_load_credentials(void)
 	}
 
 	RA_LOG("Credentials loaded: user=%s password=***(%zu chars)", g_ra_user, strlen(g_ra_password));
-	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d hardcore=%d",
+	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d hardcore=%d stall_recovery=%d",
 		g_show_challenge_show_popup, g_show_challenge_hide_popup,
-		g_show_progress_popups, g_show_progress_name, g_hardcore);
+		g_show_progress_popups, g_show_progress_name, g_hardcore, g_stall_recovery);
 	return 1;
 }
 
@@ -1258,6 +1261,11 @@ int achievements_active(void)
 int achievements_hardcore_active(void)
 {
 	return g_hardcore;
+}
+
+int achievements_stall_recovery_enabled(void)
+{
+	return g_stall_recovery;
 }
 
 void achievements_info(void)

--- a/achievements.h
+++ b/achievements.h
@@ -45,5 +45,6 @@ int achievements_hardcore_active(void);
 
 // Update global frame counters (called by per-console poll handlers)
 void ra_frame_processed(uint32_t frame);
+int achievements_stall_recovery_enabled(void);
 
 #endif // ACHIEVEMENTS_H

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -19,6 +19,8 @@ typedef struct {
 	uint32_t poll_logged;     // Last game_frames milestone logged
 	int resolve_pass;         // Current pointer-resolution pass number
 	struct timespec cache_time; // Timestamp when cache became active
+	struct timespec stall_time; // Timestamp when resp_frame last advanced
+	uint32_t stall_frame;       // resp_frame value when stall tracking started
 } console_state_t;
 
 // Console-specific interface
@@ -75,5 +77,12 @@ const console_handler_t *get_console_handler_by_id(int console_id);
 
 // Initialize all console handlers (called once at startup)
 void init_all_console_handlers(void);
+
+// Shared OptionC stall recovery check.
+// Call from the else branch of 'if (resp_frame > state->last_resp_frame)'.
+// Returns 1 if recovery was triggered (caller should reset cache_ready etc).
+// Requires: achievements_stall_recovery_enabled() from achievements.h
+int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
+                                  const char *console_name);
 
 #endif // ACHIEVEMENTS_CONSOLE_H

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -90,3 +90,34 @@ void init_all_console_handlers(void)
 		}
 	}
 }
+
+
+// ---------------------------------------------------------------------------
+// Shared OptionC stall recovery
+// ---------------------------------------------------------------------------
+
+#include "achievements.h"
+#include "ra_ramread.h"
+
+int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
+                                  const char *console_name)
+{
+        if (!achievements_stall_recovery_enabled()) return 0;
+
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        double stall_secs = (now.tv_sec - state->stall_time.tv_sec)
+                + (now.tv_nsec - state->stall_time.tv_nsec) / 1e9;
+
+        if (stall_secs >= 5.0 && state->stall_frame == resp_frame) {
+                ra_log_write("%s OptionC: STALL RECOVERY -- resp_frame=%u stuck for %.1fs, re-collecting\n",
+                        console_name, resp_frame, stall_secs);
+                state->cache_ready = 0;
+                state->needs_recollect = 0;
+                ra_snes_addrlist_init();
+                clock_gettime(CLOCK_MONOTONIC, &state->stall_time);
+                state->stall_frame = 0;
+                return 1;
+        }
+        return 0;
+}

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -116,6 +116,8 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 			g_gb_state.last_resp_frame = resp_frame;
 			g_gb_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_gb_state.stall_time);
+			g_gb_state.stall_frame = resp_frame;
 
 			// Periodically re-collect to catch address changes (every ~5 min)
 			int re_collect = (g_gb_state.game_frames % 18000 == 0) && (g_gb_state.game_frames > 0);
@@ -147,6 +149,8 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_gb_state, resp_frame, "GameBoy");
 		}
 	}
 

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -143,6 +143,8 @@ static int gba_poll(void *map, void *client, int game_loaded)
                         g_gba_state.last_resp_frame = resp_frame;
                         g_gba_state.game_frames++;
                         ra_frame_processed(resp_frame);
+                        clock_gettime(CLOCK_MONOTONIC, &g_gba_state.stall_time);
+                        g_gba_state.stall_frame = resp_frame;
 
                         if (g_gba_state.game_frames <= 5) {
                                 ra_log_write("GBA OptionC: GameFrame %u (resp_frame=%u)\n",
@@ -166,6 +168,8 @@ static int gba_poll(void *map, void *client, int game_loaded)
                                                 ra_snes_addrlist_count());
                                 }
                         }
+                } else {
+                	optionc_check_stall_recovery(&g_gba_state, resp_frame, "GBA");
                 }
         }
 

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -96,6 +96,8 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 			g_md_state.last_resp_frame = resp_frame;
 			g_md_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_md_state.stall_time);
+			g_md_state.stall_frame = resp_frame;
 
 			// Early-frame valcache dump (first 5 frames)
 			if (g_md_state.game_frames <= 5) {
@@ -128,6 +130,8 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_md_state, resp_frame, "Genesis");
 		}
 	}
 

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -97,6 +97,8 @@ static int megacd_poll(void *map, void *client, int game_loaded)
 			g_mcd_state.last_resp_frame = resp_frame;
 			g_mcd_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_mcd_state.stall_time);
+			g_mcd_state.stall_frame = resp_frame;
 
 			// Early-frame valcache dump (first 5 frames)
 			if (g_mcd_state.game_frames <= 5) {
@@ -153,6 +155,8 @@ static int megacd_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_mcd_state, resp_frame, "MegaCD");
 		}
 	}
 

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -193,6 +193,8 @@ static int n64_poll(void *map, void *client, int game_loaded)
 			g_n64_state.last_resp_frame = resp_frame;
 			g_n64_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_n64_state.stall_time);
+			g_n64_state.stall_frame = resp_frame;
 
 			if (g_n64_state.game_frames <= 5)
 				ra_log_write("N64 OptionC: GameFrame %u (resp_frame=%u)\n",
@@ -229,6 +231,8 @@ static int n64_poll(void *map, void *client, int game_loaded)
 					g_n64_state.resolve_pass = 0;
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_n64_state, resp_frame, "N64");
 		}
 	}
 

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -139,6 +139,8 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			g_neogeo_state.last_resp_frame = resp_frame;
 			g_neogeo_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.stall_time);
+			g_neogeo_state.stall_frame = resp_frame;
 
 			// Re-collect every 18000 frames (~5min).
 			// Do NOT invalidate cache: avoids zeros during active gameplay.
@@ -157,6 +159,8 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_neogeo_state, resp_frame, "NeoGeo");
 		}
 	}
 

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -21,6 +21,7 @@
 static console_state_t g_psx_state = {};
 static int g_psx_rtquery = 0; // 1 if FPGA supports realtime queries
 
+
 // ---------------------------------------------------------------------------
 // PSX Option C Diagnostics
 // ---------------------------------------------------------------------------
@@ -154,6 +155,8 @@ static int psx_poll(void *map, void *client, int game_loaded)
 			g_psx_state.last_resp_frame = resp_frame;
 			g_psx_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_psx_state.stall_time);
+			g_psx_state.stall_frame = resp_frame;
 
 			if (g_psx_state.game_frames <= 5) {
 				ra_log_write("PSX OptionC: GameFrame %u (resp_frame=%u)\n",
@@ -178,6 +181,8 @@ static int psx_poll(void *map, void *client, int game_loaded)
 					g_psx_state.cache_ready = 0; // wait for new FPGA data
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_psx_state, resp_frame, "PSX");
 		}
 	}
 

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -96,6 +96,8 @@ static int sms_poll(void *map, void *client, int game_loaded)
 			g_sms_state.last_resp_frame = resp_frame;
 			g_sms_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_sms_state.stall_time);
+			g_sms_state.stall_frame = resp_frame;
 
 			// Re-collect every ~5 min to catch address changes
 			int re_collect = (g_sms_state.game_frames % 18000 == 0) && (g_sms_state.game_frames > 0);
@@ -113,6 +115,8 @@ static int sms_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_sms_state, resp_frame, "SMS");
 		}
 	}
 

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -142,6 +142,8 @@ static int snes_poll(void *map, void *client, int game_loaded)
 			g_snes_state.last_resp_frame = resp_frame;
 			g_snes_state.game_frames++;
 			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_snes_state.stall_time);
+			g_snes_state.stall_frame = resp_frame;
 
 			// Dump first 5 frames after cache became active
 			if (g_snes_state.game_frames <= 5) {
@@ -166,6 +168,8 @@ static int snes_poll(void *map, void *client, int game_loaded)
 						ra_snes_addrlist_count());
 				}
 			}
+		} else {
+			optionc_check_stall_recovery(&g_snes_state, resp_frame, "SNES");
 		}
 	}
 

--- a/achievements_tgfx16.cpp
+++ b/achievements_tgfx16.cpp
@@ -6,6 +6,7 @@
 #include "user_io.h"
 #include "lib/md5/md5.h"
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -13,6 +14,7 @@
 #ifdef HAS_RCHEEVOS
 #include "rc_client.h"
 #include "rc_consoles.h"
+#include "rc_hash.h"
 #endif
 
 // ---------------------------------------------------------------------------
@@ -140,6 +142,8 @@ if (resp_frame > g_tgfx16_state.last_resp_frame) {
 g_tgfx16_state.last_resp_frame = resp_frame;
 g_tgfx16_state.game_frames++;
 ra_frame_processed(resp_frame);
+clock_gettime(CLOCK_MONOTONIC, &g_tgfx16_state.stall_time);
+g_tgfx16_state.stall_frame = resp_frame;
 
 if (g_tgfx16_state.game_frames <= 5) {
 ra_log_write("TGFX16 OptionC: GameFrame %u (resp_frame=%u)\n",
@@ -163,6 +167,9 @@ ra_log_write("TGFX16 OptionC: Address list refreshed, %d addrs\n",
 ra_snes_addrlist_count());
 }
 }
+
+} else {
+	optionc_check_stall_recovery(&g_tgfx16_state, resp_frame, "TGFX16");
 }
 }
 
@@ -189,12 +196,44 @@ return 0;
 #endif
 }
 
+static int tgfx16_is_cd_image(const char *path)
+{
+const char *ext = strrchr(path, '.');
+if (!ext) return 0;
+return (strcasecmp(ext, ".cue") == 0 ||
+        strcasecmp(ext, ".chd") == 0 ||
+        strcasecmp(ext, ".ccd") == 0 ||
+        strcasecmp(ext, ".iso") == 0 ||
+        strcasecmp(ext, ".img") == 0);
+}
+
 static int tgfx16_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
-// PC Engine ROMs: .pce files may have a 512-byte header if size % 1024 == 512
-FILE *f = fopen(rom_path, "rb");
+char abs_path[1024];
+if (rom_path[0] == '/') {
+snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
+} else {
+extern const char *getRootDir(void);
+snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
+}
+
+#ifdef HAS_RCHEEVOS
+if (tgfx16_is_cd_image(rom_path)) {
+// PC Engine CD: use rcheevos CD hashing with console_id 76
+ra_log_write("TGFX16: CD image detected, using rc_hash (console_id=76): %s\n", abs_path);
+if (rc_hash_generate_from_file(md5_hex_out, 76, abs_path)) {
+ra_log_write("TGFX16 CD hash: %s\n", md5_hex_out);
+return 1;
+}
+ra_log_write("TGFX16: rc_hash_generate_from_file failed for %s\n", abs_path);
+return 0;
+}
+#endif
+
+// HuCard ROM: .pce files may have a 512-byte header if size % 1024 == 512
+FILE *f = fopen(abs_path, "rb");
 if (!f) {
-ra_log_write("TGFX16: Failed to open ROM for hashing: %s\n", rom_path);
+ra_log_write("TGFX16: Failed to open ROM for hashing: %s\n", abs_path);
 return 0;
 }
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -2705,6 +2705,7 @@ void HandleUI(void)
 			{
 				pcecd_set_image(ioctl_index, selPath);
 				cheats_init(selPath, 0);
+				achievements_load_game(selPath, 0);
 			}
 			else if (is_psx() && ioctl_index == 1)
 			{


### PR DESCRIPTION
This pull request introduces a new OptionC stall recovery feature for the achievements system and improves hash calculation for PC Engine CD images. The main changes include adding a configurable stall recovery mechanism across multiple console achievement handlers, implementing shared recovery logic, and enhancing the hashing logic for TGFX16 CD images to use the rcheevos library. Below are the most important changes grouped by theme:

**OptionC Stall Recovery Feature:**

* Added a new global configuration variable `g_stall_recovery` (with config file support and logging) and a corresponding accessor function `achievements_stall_recovery_enabled()` in `achievements.cpp` and `achievements.h`. This allows enabling/disabling the stall recovery feature via configuration. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR177) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR497-R498) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL506-R511) [[4]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1266-R1270) [[5]](diffhunk://#diff-ee4fed7675082f718263a601afeb6b87d598d18d444c81eb28238b646df05eeeR48)
* Extended the `console_state_t` struct to track stall timing and frame information, and declared the shared recovery interface in `achievements_console.h`. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R22-R23) [[2]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R81-R87)
* Implemented the shared `optionc_check_stall_recovery` logic in `achievements_console_lookup.cpp`, which resets the achievement address cache if a stall is detected (no progress in `resp_frame` for 5 seconds).
* Updated all console achievement polling functions (GameBoy, GBA, Genesis, MegaCD, N64, NeoGeo, PSX, SMS, SNES, TGFX16) to track stall timing and invoke the new stall recovery logic when appropriate. [[1]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR119-R120) [[2]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR152-R153) [[3]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R146-R147) [[4]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R171-R172) [[5]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dR99-R100) [[6]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dR133-R134) [[7]](diffhunk://#diff-4c1febe6aefb613053fa5a951b212c1924273a913ff7e4a6dd33c0f15dff0f64R100-R101) [[8]](diffhunk://#diff-4c1febe6aefb613053fa5a951b212c1924273a913ff7e4a6dd33c0f15dff0f64R158-R159) [[9]](diffhunk://#diff-2e2e43bd0804815caa8ed2df42f77d559cf085ee37ba2fd5cb0de0f57e89a774R196-R197) [[10]](diffhunk://#diff-2e2e43bd0804815caa8ed2df42f77d559cf085ee37ba2fd5cb0de0f57e89a774R234-R235) [[11]](diffhunk://#diff-b3c75c13bfbe45ba41424899a197d30bd169396c7fc507826202b7f91f87a7faR142-R143) [[12]](diffhunk://#diff-b3c75c13bfbe45ba41424899a197d30bd169396c7fc507826202b7f91f87a7faR162-R163) [[13]](diffhunk://#diff-eab83b801263e7e8c9ecc8f83920bc0b96b554a2ac8d19b497018926f86c2146R158-R159) [[14]](diffhunk://#diff-eab83b801263e7e8c9ecc8f83920bc0b96b554a2ac8d19b497018926f86c2146R184-R185) [[15]](diffhunk://#diff-11bd452c7a74aa29a7a8e15cfb49b0bc3a302db479495f6f7ae36ae125360f99R99-R100) [[16]](diffhunk://#diff-11bd452c7a74aa29a7a8e15cfb49b0bc3a302db479495f6f7ae36ae125360f99R118-R119) [[17]](diffhunk://#diff-3cfe337a1a9a90d7323dbdd9b282331697e189e7f16f400648274e0921acf6d7R145-R146) [[18]](diffhunk://#diff-3cfe337a1a9a90d7323dbdd9b282331697e189e7f16f400648274e0921acf6d7R171-R172) [[19]](diffhunk://#diff-c618855ee62a3b9604aec0bb1e89b222648147d176f59010146c66773ffd8e52R145-R146) [[20]](diffhunk://#diff-c618855ee62a3b9604aec0bb1e89b222648147d176f59010146c66773ffd8e52R170-R172)

**TGFX16 CD Hashing Improvements:**

* Enhanced PC Engine/TGFX16 achievement support to detect CD images and use the rcheevos library's `rc_hash_generate_from_file` for hash calculation, improving compatibility and accuracy for CD-based games.
* Added necessary includes and utility functions for CD image detection and path normalization in `achievements_tgfx16.cpp`. [[1]](diffhunk://#diff-c618855ee62a3b9604aec0bb1e89b222648147d176f59010146c66773ffd8e52R9-R17) [[2]](diffhunk://#diff-c618855ee62a3b9604aec0bb1e89b222648147d176f59010146c66773ffd8e52R199-R236)

**Game Loading Integration:**

* Ensured that achievements are loaded when mounting a PCECD image by calling `achievements_load_game` in the PCECD image handler in `menu.cpp`.