### PR TITLE
Add support for Sega 32X

### DIFF
--- a/achievements_atari2600.cpp
+++ b/achievements_atari2600.cpp
@@ -39,6 +39,10 @@ static void atari2600_reset(void)
 
 static uint32_t atari2600_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
+	// region_count=1 -> 2600 (128-byte RIOT), region_count=2 -> 7800 (4KB RAM)
+	uint8_t region_count = map ? ((const uint8_t *)map)[4] : 1;
+	if (region_count == 2)
+		return ra_ramread_atari7800_read(map, address, buffer, num_bytes);
 	return ra_ramread_atari2600_read(map, address, buffer, num_bytes);
 }
 

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -68,6 +68,7 @@ extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
 extern const console_handler_t g_console_tgfx16;
+extern const console_handler_t g_console_s32x;
 
 // Get console handler by core name (returns NULL if not found)
 const console_handler_t *get_console_handler_by_name(const char *core_name);

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -17,6 +17,7 @@ extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
 extern const console_handler_t g_console_tgfx16;
+extern const console_handler_t g_console_s32x;
 
 // Master lookup table
 static const console_handler_t *g_console_handlers[] = {
@@ -32,6 +33,7 @@ static const console_handler_t *g_console_handlers[] = {
 	&g_console_megacd,
 	&g_console_atari2600,
 	&g_console_tgfx16,
+	&g_console_s32x,
 	NULL
 };
 
@@ -52,6 +54,9 @@ const console_handler_t *get_console_handler_by_name(const char *core_name)
 	}
 	if (!strcasecmp(core_name, "GBC")) {
 		return &g_console_gameboy;  // GameBoy handler handles both GB and GBC
+	}
+	if (!strcasecmp(core_name, "MegaDrive32X")) {
+		return &g_console_s32x;
 	}
 
 	return NULL;

--- a/achievements_s32x.cpp
+++ b/achievements_s32x.cpp
@@ -1,0 +1,195 @@
+// achievements_s32x.cpp — RetroAchievements Sega 32X implementation
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// Sega 32X State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_s32x_state = {};
+
+// ---------------------------------------------------------------------------
+// Sega 32X Implementation
+// ---------------------------------------------------------------------------
+
+static void s32x_init(void)
+{
+memset(&g_s32x_state, 0, sizeof(g_s32x_state));
+}
+
+static void s32x_reset(void)
+{
+memset(&g_s32x_state, 0, sizeof(g_s32x_state));
+}
+
+static uint32_t s32x_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+if (g_s32x_state.optionc) {
+if (g_s32x_state.collecting) {
+for (uint32_t i = 0; i < num_bytes; i++)
+ra_snes_addrlist_add(address + i);
+}
+if (g_s32x_state.cache_ready) {
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+memset(buffer, 0, num_bytes);
+return num_bytes;
+}
+return 0;
+}
+
+static int s32x_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+if (!client || !game_loaded || !map || !g_s32x_state.optionc) return 0;
+
+rc_client_t *rc_client = (rc_client_t *)client;
+
+if (ra_snes_addrlist_count() == 0 && !g_s32x_state.cache_ready) {
+// Bootstrap: run one do_frame to discover needed addresses
+g_s32x_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+rc_client_do_frame(rc_client);
+g_s32x_state.collecting = 0;
+int changed = ra_snes_addrlist_end_collect(map);
+if (changed) {
+ra_log_write("S32X OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+ra_snes_addrlist_count());
+} else {
+ra_log_write("S32X OptionC: No addresses collected\n");
+}
+} else if (!g_s32x_state.cache_ready) {
+// Wait for FPGA to respond with cached values
+if (ra_snes_addrlist_is_ready(map)) {
+g_s32x_state.cache_ready = 1;
+g_s32x_state.last_resp_frame = 0;
+g_s32x_state.game_frames = 0;
+g_s32x_state.poll_logged = 0;
+clock_gettime(CLOCK_MONOTONIC, &g_s32x_state.cache_time);
+ra_log_write("S32X OptionC: Cache active! FPGA response matched request.\n");
+// Dump first few addresses on activation
+const uint32_t *a0 = ra_snes_addrlist_addrs();
+int ac = ra_snes_addrlist_count();
+int ad = ac < 20 ? ac : 20;
+char ah[256]; int ap = 0;
+for (int i = 0; i < ad && ap < (int)sizeof(ah) - 8; i++)
+ap += snprintf(ah + ap, sizeof(ah) - ap, "%04X ", a0[i]);
+ra_log_write("S32X ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
+}
+} else {
+// Normal frame processing from cache
+uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+if (resp_frame > g_s32x_state.last_resp_frame) {
+g_s32x_state.last_resp_frame = resp_frame;
+g_s32x_state.game_frames++;
+ra_frame_processed(resp_frame);
+clock_gettime(CLOCK_MONOTONIC, &g_s32x_state.stall_time);
+g_s32x_state.stall_frame = resp_frame;
+
+// Early-frame valcache dump (first 5 frames)
+if (g_s32x_state.game_frames <= 5) {
+const uint8_t *ev = (const uint8_t *)map + 0x48000 + 8;
+int ec = ra_snes_addrlist_count();
+int ed = ec < 45 ? ec : 45;
+int enz = 0;
+char eh[256]; int ep = 0;
+for (int i = 0; i < ed && ep < (int)sizeof(eh) - 4; i++) {
+ep += snprintf(eh + ep, sizeof(eh) - ep, "%02X ", ev[i]);
+if (ev[i]) enz++;
+}
+ra_log_write("S32X early[%u]: VALCACHE %s (%d nz)\n",
+g_s32x_state.game_frames, eh, enz);
+}
+
+// Re-collect every ~5 min to catch address changes
+int re_collect = (g_s32x_state.game_frames % 18000 == 0) && (g_s32x_state.game_frames > 0);
+if (re_collect) {
+g_s32x_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+}
+
+rc_client_do_frame(rc_client);
+
+if (re_collect) {
+g_s32x_state.collecting = 0;
+if (ra_snes_addrlist_end_collect(map)) {
+ra_log_write("S32X OptionC: Address list refreshed, %d addrs\n",
+ra_snes_addrlist_count());
+}
+}
+} else {
+optionc_check_stall_recovery(&g_s32x_state, resp_frame, "S32X");
+}
+}
+
+// Periodic log every 300 frames (~5 sec)
+uint32_t milestone = g_s32x_state.game_frames / 300;
+if (milestone > 0 && milestone != g_s32x_state.poll_logged) {
+g_s32x_state.poll_logged = milestone;
+struct timespec now;
+clock_gettime(CLOCK_MONOTONIC, &now);
+double elapsed = (now.tv_sec - g_s32x_state.cache_time.tv_sec)
++ (now.tv_nsec - g_s32x_state.cache_time.tv_nsec) / 1e9;
+double ms_per_cycle = (g_s32x_state.game_frames > 0) ?
+(elapsed * 1000.0 / g_s32x_state.game_frames) : 0.0;
+ra_log_write("POLL(S32X): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+g_s32x_state.last_resp_frame, g_s32x_state.game_frames, elapsed, ms_per_cycle,
+ra_snes_addrlist_count());
+}
+
+return 1; // S32X handled
+#else
+return 0;
+#endif
+}
+
+static int s32x_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+(void)rom_path;
+(void)md5_hex_out;
+return 0; // use default MD5
+}
+
+static void s32x_set_hardcore(int enabled)
+{
+user_io_status_set("[64]", enabled ? 1 : 0); // disable cheats
+user_io_status_set("[24]", enabled ? 1 : 0); // disable save states
+ra_log_write("S32X: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
+}
+
+static void s32x_detect_protocol(void *map)
+{
+(void)map;
+// S32X always uses Option C
+g_s32x_state.optionc = 1;
+ra_log_write("S32X FPGA protocol: Option C (selective address reading)\n");
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_s32x = {
+.init = s32x_init,
+.reset = s32x_reset,
+.read_memory = s32x_read_memory,
+.poll = s32x_poll,
+.calculate_hash = s32x_calculate_hash,
+.set_hardcore = s32x_set_hardcore,
+.detect_protocol = s32x_detect_protocol,
+.console_id = 10,  // RC_CONSOLE_SEGA_32X
+.name = "S32X"
+};

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -174,6 +174,32 @@ uint32_t ra_ramread_atari2600_read(const void *map, uint32_t address, uint8_t *b
 	return num_bytes;
 }
 
+// ---------------------------------------------------------------------------
+// Atari 7800 — 4 KB internal RAM (ram0 + ram1)
+//   addr 0x0000-0x07FF -> ram0, DDRAM offset 0x100
+//   addr 0x0800-0x0FFF -> ram1, DDRAM offset 0x900
+// ---------------------------------------------------------------------------
+uint8_t ra_ramread_atari7800_byte(const void *map, uint16_t addr)
+{
+	if (!map) return 0;
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	if (hdr->magic != RA_MAGIC) return 0;
+	if (addr < 0x0800) {
+		return ((const uint8_t *)map + 0x100)[addr];
+	} else if (addr < 0x1000) {
+		return ((const uint8_t *)map + 0x900)[addr - 0x0800];
+	}
+	return 0;
+}
+
+uint32_t ra_ramread_atari7800_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
+{
+	for (uint32_t i = 0; i < num_bytes; i++) {
+		buffer[i] = ra_ramread_atari7800_byte(map, (uint16_t)(address + i));
+	}
+	return num_bytes;
+}
+
 void ra_ramread_debug_dump(const void *map)
 {
 	RA_DBG("=== DDRAM Mirror Diagnostic Dump ===");

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -178,6 +178,9 @@ uint32_t ra_ramread_snes_read(const void *map, uint32_t address, uint8_t *buffer
 uint8_t  ra_ramread_atari2600_byte(const void *map, uint16_t addr);
 uint32_t ra_ramread_atari2600_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
 
+uint8_t  ra_ramread_atari7800_byte(const void *map, uint16_t addr);
+uint32_t ra_ramread_atari7800_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
+
 // Option C: Selective address reading (SNES)
 // ARM collects needed addresses from rcheevos, writes list to DDRAM.
 // FPGA reads only those addresses each VBlank. ARM reads cached values.


### PR DESCRIPTION
This pull request adds support for the Sega 32X (S32X) console to the RetroAchievements codebase and introduces improved memory handling for the Atari 7800. The main changes include implementing the S32X handler, updating lookup tables and interfaces to recognize S32X, and adding dedicated RAM reading routines for Atari 7800.

**Sega 32X (S32X) Support:**

* Added a new file, `achievements_s32x.cpp`, which implements the S32X console handler, including initialization, memory reading, polling, and protocol detection using Option C (selective address reading).
* Registered the S32X handler in the lookup tables and header files, and updated the `get_console_handler_by_name` function to recognize "MegaDrive32X" as S32X. [[1]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R20) [[2]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R36) [[3]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R58-R60) [[4]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R71)

**Atari 7800 Memory Handling:**

* Added new functions `ra_ramread_atari7800_byte` and `ra_ramread_atari7800_read` to support reading the Atari 7800's 4 KB RAM, with proper memory mapping. [[1]](diffhunk://#diff-168bd3df9d7d5edadd996021a96d9f5c1a33dc62be067723e1407076439ef609R177-R202) [[2]](diffhunk://#diff-2c00936cd444b2baf06870c1911501bfda3e3142593d075df12017ff5ec370cdR181-R183)
* Updated `atari2600_read_memory` to detect Atari 7800 via region count and delegate to the new 7800 memory read function.

These changes ensure the codebase can now handle Sega 32X achievements and accurately access Atari 7800 RAM for RetroAchievements.