### PR TITLE
Add achievement list feature

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -20,6 +20,7 @@
 #include "user_io.h"
 #include "file_io.h"
 #include "menu.h"
+#include "osd.h"
 #include "hardware.h"
 #include "lib/md5/md5.h"
 
@@ -1342,4 +1343,177 @@ void achievements_info(void)
 	#undef NOTIF_APPEND
 
 	Info(buf, 4000, 0, 0, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Achievement list view (F6 shortcut)
+// ---------------------------------------------------------------------------
+
+#ifdef HAS_RCHEEVOS
+static rc_client_achievement_list_t *g_ach_view_list = nullptr;
+#endif
+static int g_ach_view_first    = 0;
+static int g_ach_view_selected = 0;
+static int g_ach_view_total    = 0;
+
+// Convert flat index to the achievement pointer, iterating buckets in order.
+#ifdef HAS_RCHEEVOS
+static const rc_client_achievement_t *ach_at_flat_index(int flat_idx)
+{
+	if (!g_ach_view_list) return nullptr;
+	// LOCK_STATE grouping orders buckets as LOCKED…UNLOCKED, so iterate in reverse
+	// to present unlocked achievements first.
+	for (int b = (int)g_ach_view_list->num_buckets - 1; b >= 0; b--) {
+		if (flat_idx < (int)g_ach_view_list->buckets[b].num_achievements)
+			return g_ach_view_list->buckets[b].achievements[flat_idx];
+		flat_idx -= (int)g_ach_view_list->buckets[b].num_achievements;
+	}
+	return nullptr;
+}
+#endif
+
+int achievements_has_active_game(void)
+{
+#ifdef HAS_RCHEEVOS
+	return g_logged_in && g_game_loaded;
+#else
+	return 0;
+#endif
+}
+
+int achievements_list_open(void)
+{
+	achievements_list_close();
+#ifdef HAS_RCHEEVOS
+	if (!g_client || !g_logged_in || !g_game_loaded)
+		return 0;
+
+	// LOCK_STATE grouping: bucket 0 = unlocked, bucket 1 = locked — gives us unlocked-first order.
+	g_ach_view_list = rc_client_create_achievement_list(g_client,
+		RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE,
+		RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
+	if (!g_ach_view_list)
+		return 0;
+
+	uint32_t total = 0;
+	for (uint32_t b = 0; b < g_ach_view_list->num_buckets; b++)
+		total += g_ach_view_list->buckets[b].num_achievements;
+	g_ach_view_total = (int)total;
+#else
+	g_ach_view_total = 0;
+#endif
+	g_ach_view_first    = 0;
+	g_ach_view_selected = 0;
+	return g_ach_view_total;
+}
+
+void achievements_list_close(void)
+{
+#ifdef HAS_RCHEEVOS
+	if (g_ach_view_list) {
+		rc_client_destroy_achievement_list(g_ach_view_list);
+		g_ach_view_list = nullptr;
+	}
+#endif
+	g_ach_view_first    = 0;
+	g_ach_view_selected = 0;
+	g_ach_view_total    = 0;
+}
+
+int achievements_list_count(void)
+{
+	return g_ach_view_total;
+}
+
+void achievements_list_scan(int mode)
+{
+	int total    = g_ach_view_total;
+	int osd_size = OsdGetSize();
+	if (total == 0) return;
+
+	switch (mode) {
+		case SCANF_INIT:
+			g_ach_view_selected = 0;
+			g_ach_view_first    = 0;
+			break;
+		case SCANF_END:
+			g_ach_view_selected = total - 1;
+			g_ach_view_first    = total - osd_size;
+			if (g_ach_view_first < 0) g_ach_view_first = 0;
+			break;
+		case SCANF_NEXT:
+			if (g_ach_view_selected < total - 1) {
+				g_ach_view_selected++;
+				if (g_ach_view_selected >= g_ach_view_first + osd_size)
+					g_ach_view_first++;
+			}
+			break;
+		case SCANF_PREV:
+			if (g_ach_view_selected > 0) {
+				g_ach_view_selected--;
+				if (g_ach_view_selected < g_ach_view_first)
+					g_ach_view_first--;
+			}
+			break;
+		case SCANF_NEXT_PAGE:
+			g_ach_view_selected += osd_size;
+			if (g_ach_view_selected >= total) g_ach_view_selected = total - 1;
+			g_ach_view_first += osd_size;
+			if (g_ach_view_first > total - osd_size) g_ach_view_first = total - osd_size;
+			if (g_ach_view_first < 0) g_ach_view_first = 0;
+			break;
+		case SCANF_PREV_PAGE:
+			g_ach_view_selected -= osd_size;
+			if (g_ach_view_selected < 0) g_ach_view_selected = 0;
+			g_ach_view_first -= osd_size;
+			if (g_ach_view_first < 0) g_ach_view_first = 0;
+			break;
+	}
+}
+
+void achievements_list_print(void)
+{
+	static char s[32];
+	int total    = g_ach_view_total;
+	int osd_size = OsdGetSize();
+
+	for (int i = 0; i < osd_size; i++) {
+		int idx      = g_ach_view_first + i;
+		char leftchar = 0;
+
+		if (i == 0 && g_ach_view_first > 0)
+			leftchar = 17;
+		if (i == osd_size - 1 && (g_ach_view_first + osd_size) < total)
+			leftchar = 16;
+
+		if (idx < total) {
+#ifdef HAS_RCHEEVOS
+			const rc_client_achievement_t *ach = ach_at_flat_index(idx);
+			if (ach) {
+				bool unlocked = (ach->state == RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
+				s[0] = ' ';
+				s[1] = unlocked ? 0x1a : 0x1b;
+				s[2] = ' ';
+				strncpy(s + 3, ach->title, 26);
+				s[29] = 0;
+				int len = (int)strlen(s);
+				if (len > 28) {
+					s[28] = 22; // continuation marker (more text follows)
+					s[29] = 0;
+				}
+			} else {
+				memset(s, ' ', 29);
+				s[29] = 0;
+			}
+#else
+			memset(s, ' ', 29);
+			s[29] = 0;
+#endif
+		} else {
+			memset(s, ' ', 29);
+			s[29] = 0;
+		}
+
+		OsdWriteOffset(i, s, (idx == g_ach_view_selected), 0, 0, leftchar);
+	}
 }

--- a/achievements.h
+++ b/achievements.h
@@ -43,6 +43,25 @@ void achievements_info(void);
 // Returns 1 if hardcore mode is enabled in retroachievements.cfg
 int achievements_hardcore_active(void);
 
+// Returns 1 if the user is logged in and a game is currently loaded.
+int achievements_has_active_game(void);
+
+// Open the achievement list view (builds sorted list: unlocked first, then locked).
+// Returns the total number of achievements, or 0 if not available.
+int achievements_list_open(void);
+
+// Close and free the achievement list view.
+void achievements_list_close(void);
+
+// Navigate the list. Use SCANF_NEXT, SCANF_PREV, SCANF_NEXT_PAGE, etc. from file_io.h.
+void achievements_list_scan(int mode);
+
+// Render the current page of the achievement list to the OSD.
+void achievements_list_print(void);
+
+// Returns the total count in the currently open list (0 if not open).
+int achievements_list_count(void);
+
 // Update global frame counters (called by per-console poll handlers)
 void ra_frame_processed(uint32_t frame);
 int achievements_stall_recovery_enabled(void);

--- a/menu.cpp
+++ b/menu.cpp
@@ -138,6 +138,9 @@ enum MENU
 	MENU_CHEATS1,
 	MENU_CHEATS2,
 
+	MENU_RA_ACHIEVEMENTS1,
+	MENU_RA_ACHIEVEMENTS2,
+
 	MENU_UART1,
 	MENU_UART2,
 	MENU_UART3,
@@ -1293,6 +1296,21 @@ void HandleUI(void)
 				user_io_status_set("[3:1]", user_io_status_get("[3:1]") + 1);
 				user_io_status_save(user_io_create_config_name());
 				video_menu_bg(user_io_status_get("[3:1]"));
+			}
+			break;
+
+		case KEY_F6:
+			if (achievements_has_active_game())
+			{
+				int ach_count = achievements_list_open();
+				if (ach_count > 0)
+				{
+					OsdSetSize(16);
+					menusub = 0;
+					OsdClear();
+					OsdEnable(DISABLE_KEYBOARD);
+					menustate = MENU_RA_ACHIEVEMENTS1;
+				}
 			}
 			break;
 
@@ -5536,6 +5554,68 @@ void HandleUI(void)
 				cheats_toggle();
 			}
 			menustate = MENU_CHEATS1;
+		}
+		break;
+
+		/******************************************************************/
+		/* RetroAchievements list (F6 shortcut)                           */
+		/******************************************************************/
+	case MENU_RA_ACHIEVEMENTS1:
+	{
+		helptext_idx = 0;
+		char ra_title[32];
+		snprintf(ra_title, sizeof(ra_title), "Achievements (%d)", achievements_list_count());
+		OsdSetTitle(ra_title);
+		achievements_list_print();
+		menustate = MENU_RA_ACHIEVEMENTS2;
+		parentstate = menustate;
+		break;
+	}
+
+	case MENU_RA_ACHIEVEMENTS2:
+		menumask = 0;
+
+		if (menu)
+		{
+			achievements_list_close();
+			menustate = MENU_NONE1;
+			break;
+		}
+
+		if (c == KEY_HOME)
+		{
+			achievements_list_scan(SCANF_INIT);
+			menustate = MENU_RA_ACHIEVEMENTS1;
+		}
+
+		if (c == KEY_END)
+		{
+			achievements_list_scan(SCANF_END);
+			menustate = MENU_RA_ACHIEVEMENTS1;
+		}
+
+		if ((c == KEY_PAGEUP) || (c == KEY_LEFT))
+		{
+			achievements_list_scan(SCANF_PREV_PAGE);
+			menustate = MENU_RA_ACHIEVEMENTS1;
+		}
+
+		if ((c == KEY_PAGEDOWN) || (c == KEY_RIGHT))
+		{
+			achievements_list_scan(SCANF_NEXT_PAGE);
+			menustate = MENU_RA_ACHIEVEMENTS1;
+		}
+
+		if (down)
+		{
+			achievements_list_scan(SCANF_NEXT);
+			menustate = MENU_RA_ACHIEVEMENTS1;
+		}
+
+		if (up)
+		{
+			achievements_list_scan(SCANF_PREV);
+			menustate = MENU_RA_ACHIEVEMENTS1;
 		}
 		break;
 


### PR DESCRIPTION
This pull request adds a new on-screen view for RetroAchievements, allowing users to browse achievements for the currently loaded game using the F6 shortcut. The implementation includes a paginated, scrollable list that displays unlocked achievements first, and integrates this view into the menu system. The most important changes are grouped below:

**RetroAchievements List View Implementation:**

* Added a new achievement list view with navigation and rendering functions in `achievements.cpp` and declared these in `achievements.h`. The view supports opening, closing, scanning (for navigation), and printing the current page to the OSD, with achievements sorted unlocked-first. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1347-R1519) [[2]](diffhunk://#diff-ee4fed7675082f718263a601afeb6b87d598d18d444c81eb28238b646df05eeeR46-R64)
* Introduced new menu states (`MENU_RA_ACHIEVEMENTS1`, `MENU_RA_ACHIEVEMENTS2`) in the `MENU` enum to support the new achievements view.

**Menu and UI Integration:**

* Integrated the achievements list view into the UI: pressing F6 opens the list if a user is logged in and a game is loaded, initializes the OSD, and transitions to the new menu state.
* Implemented navigation and display logic for the achievements list within the menu handler, supporting scrolling, paging, and closing the list with menu controls.

**Codebase Maintenance:**

* Added a missing include for `osd.h` in `achievements.cpp` to support OSD operations.