### PR TITLE
Enhance login process with scores and core support

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -153,6 +153,10 @@ static char g_ra_password[128] = {};
 static int g_logged_in = 0;
 static int g_login_pending = 0;
 static int g_game_load_pending = 0;
+static int g_login_deferred = 0;      // login deferred until FPGA mirror validated
+static int g_game_load_deferred = 0;  // game load deferred until
+static int      g_mirror_confirming = 0;       // magic seen, waiting for frame counter to advance
+static uint32_t g_mirror_initial_frame = 0;    // frame when magic was first seen (stale detection) FPGA mirror validated
 
 // Debug counters
 static uint32_t g_frames_processed = 0;
@@ -960,12 +964,13 @@ void achievements_init(void)
 
 	RA_LOG("rc_client created successfully");
 
-	// Begin login if credentials available
+	// Begin login if credentials available.
+	// Always defer: all cores require an adapted FPGA bitstream (magic 0x52414348).
+	// If the mirror never activates, login is silently suppressed.
 	if (has_creds) {
-		RA_LOG("Starting login for user '%s'...", g_ra_user);
-		g_login_pending = 1;
-		rc_client_begin_login_with_password(g_client, g_ra_user, g_ra_password,
-			ra_login_callback, NULL);
+		g_login_deferred = 1;
+		RA_LOG("Login deferred until FPGA mirror validated (core: '%s').",
+			g_active_handler ? g_active_handler->name : "none");
 	} else {
 		RA_LOG("No credentials — running in monitor-only mode.");
 		RA_LOG("Create %s to enable RetroAchievements.", RA_CFG_PATH);
@@ -1012,6 +1017,9 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 	g_last_frame = 0;
 	g_first_frame = 0;
 	g_mirror_validated = 0;
+	g_mirror_confirming = 0;
+	g_mirror_initial_frame = 0;
+	g_game_load_deferred = 0;
 	g_frames_processed = 0;
 	g_frames_skipped = 0;
 	g_game_loaded = 0;
@@ -1029,14 +1037,20 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 #ifdef HAS_RCHEEVOS
 	if (g_client && g_rom_md5[0]) {
 		if (g_logged_in && !g_game_load_pending) {
-			// Already logged in — load game immediately
-			RA_LOG("Logged in, loading game by MD5: %s", g_rom_md5);
-			g_game_load_pending = 1;
-			rc_client_begin_load_game(g_client, g_rom_md5,
-				ra_load_game_callback, NULL);
-		} else if (g_login_pending) {
-			// Login still in progress — game will be loaded in login callback
-			RA_LOG("Login in progress, game will load when login completes.");
+			if (g_ra_map && ra_ramread_active(g_ra_map)) {
+				// Already logged in and FPGA mirror active — load immediately
+				RA_LOG("Logged in and FPGA mirror active, loading game by MD5: %s", g_rom_md5);
+				g_game_load_pending = 1;
+				rc_client_begin_load_game(g_client, g_rom_md5,
+					ra_load_game_callback, NULL);
+			} else {
+				// Mirror not yet active — defer until FPGA validated
+				RA_LOG("Logged in but FPGA mirror not active — game load deferred.");
+				g_game_load_deferred = 1;
+			}
+		} else if (g_login_pending || g_login_deferred) {
+			// Login still in progress or deferred — game loads after login
+			RA_LOG("Login pending/deferred, game will load when login completes.");
 		} else {
 			RA_LOG("Not logged in — game identified but achievements unavailable.");
 			RA_LOG("MD5: %s (can verify at retroachievements.org)", g_rom_md5);
@@ -1085,14 +1099,58 @@ void achievements_poll(void)
 	// Check if mirror has become active
 	if (!g_mirror_validated) {
 		if (ra_ramread_active(g_ra_map)) {
-			g_mirror_validated = 1;
-			RA_LOG("=== DDRAM Mirror Activated! ===");
-			ra_ramread_debug_dump(g_ra_map);
+			uint32_t cur_frame = ra_ramread_frame(g_ra_map);
+			if (!g_mirror_confirming) {
+				// First time we see the magic — record frame, wait for it to advance
+				g_mirror_confirming = 1;
+				g_mirror_initial_frame = cur_frame;
+				RA_LOG("DDRAM magic detected (frame=%u), waiting for frame to advance...", cur_frame);
+			} else if (cur_frame != g_mirror_initial_frame) {
+				// Frame advanced — FPGA is alive and adapted
+				g_mirror_confirming = 0;
+				g_mirror_validated = 1;
+				RA_LOG("=== DDRAM Mirror Activated! (frame %u -> %u) ===", g_mirror_initial_frame, cur_frame);
+				ra_ramread_debug_dump(g_ra_map);
 
-			// Detect FPGA protocol — delegate to the active console handler
-			if (g_active_handler && g_active_handler->detect_protocol)
-				g_active_handler->detect_protocol(g_ra_map);
+				// Detect FPGA protocol — returns 1 if adapted, 0 if not supported
+				int fpga_ok = 1;
+				if (g_active_handler && g_active_handler->detect_protocol)
+					fpga_ok = g_active_handler->detect_protocol(g_ra_map);
+
+				if (!fpga_ok) {
+					RA_LOG("FPGA core not adapted for RA — suppressing login/load.");
+					g_login_deferred = 0;
+					g_game_load_deferred = 0;
+					g_active_handler = NULL;
+					return;
+				}
+
+#ifdef HAS_RCHEEVOS
+				// Trigger deferred login now that FPGA is confirmed adapted
+				if (g_login_deferred && g_ra_user[0] && g_ra_password[0]
+						&& !g_login_pending && !g_logged_in) {
+					g_login_deferred = 0;
+					RA_LOG("FPGA validated — starting deferred login for '%s'", g_ra_user);
+					g_login_pending = 1;
+					rc_client_begin_login_with_password(g_client, g_ra_user, g_ra_password,
+						ra_login_callback, NULL);
+				}
+
+				// Trigger deferred game load (mirror reactivated, already logged in)
+				if (g_game_load_deferred && g_logged_in && g_rom_md5[0]
+						&& !g_game_load_pending) {
+					g_game_load_deferred = 0;
+					RA_LOG("FPGA validated — loading deferred game by MD5: %s", g_rom_md5);
+					g_game_load_pending = 1;
+					rc_client_begin_load_game(g_client, g_rom_md5,
+						ra_load_game_callback, NULL);
+				}
+#endif
+			}
+			// else: frame still frozen — stale DDRAM from previous session, keep waiting
 		} else {
+			// Magic disappeared — reset confirming state
+			g_mirror_confirming = 0;
 			// Periodic debug while waiting for FPGA mirror
 			static uint32_t wait_count = 0;
 			if ((++wait_count % 18000) == 1) {
@@ -1223,8 +1281,12 @@ void achievements_unload_game(void)
 
 	g_game_loaded = 0;
 	g_game_load_pending = 0;
+	g_game_load_deferred = 0;
 	g_last_frame = 0;
 	g_mirror_validated = 0;
+	g_mirror_confirming = 0;
+	g_mirror_initial_frame = 0;
+	g_login_deferred = 0;
 	g_rom_md5[0] = '\0';
 	g_rom_path[0] = '\0';
 
@@ -1247,11 +1309,19 @@ void achievements_deinit(void)
 		g_client = NULL;
 		RA_LOG("rc_client destroyed");
 	}
+	// Reset auth state — client destroyed, so login is no longer valid
+	g_logged_in = 0;
+	g_login_pending = 0;
+	g_login_deferred = 0;
 #endif
 
 	ra_http_deinit();
 
 	if (g_ra_map) {
+		// Clear DDRAM magic before unmapping so the next core starts clean
+		uint32_t *magic_ptr = (uint32_t *)g_ra_map;
+		*magic_ptr = 0;
+		RA_LOG("DDRAM magic cleared");
 		ra_ramread_unmap(g_ra_map);
 		g_ra_map = NULL;
 		RA_LOG("DDRAM mirror unmapped");

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -779,16 +779,9 @@ static void ra_login_callback(int result, const char *error_message,
 		const rc_client_user_t *user = rc_client_get_user_info(client);
 		RA_LOG("LOGIN OK: %s (hardcore: %u, softcore: %u)", user->display_name, user->score, user->score_softcore);
 		g_logged_in = 1;
+		// Login popup is shown at game load time, not here
 
-		{
-			char buf[NOTIF_TEXT_MAX];
-			snprintf(buf, sizeof(buf),
-				"RetroAchievements\n\n%s\nHardcore: %u  Softcore: %u",
-				user->display_name, user->score, user->score_softcore);
-			ra_notify(buf, 2500);
-		}
-
-		// If a game MD5 is already available, load it now
+		// FPGA was validated before login completed (login fired from poll), load game now
 		if (g_rom_md5[0] && !g_game_loaded && !g_game_load_pending) {
 			RA_LOG("Game MD5 available, loading game: %s", g_rom_md5);
 			g_game_load_pending = 1;
@@ -819,6 +812,7 @@ static void ra_load_game_callback(int result, const char *error_message,
 		g_game_loaded = 1;
 
 		{
+			// Single combined popup: game title + achievement count + logged-in user
 			char buf[NOTIF_TEXT_MAX];
 			// Count achievements via the list API
 			rc_client_achievement_list_t *list =
@@ -831,14 +825,25 @@ static void ra_load_game_callback(int result, const char *error_message,
 					total += list->buckets[b].num_achievements;
 				rc_client_destroy_achievement_list(list);
 			}
-			if (total > 0) {
+			const rc_client_user_t *user = rc_client_get_user_info(client);
+			if (user && total > 0) {
 				snprintf(buf, sizeof(buf),
-					"%s\n\n%u achievements",
+					"%s\n%u achievements\n\nUser: %s\nScore: (HC:%u SC:%u)",
+					game->title, total,
+					user->display_name, user->score, user->score_softcore);
+			} else if (user) {
+				snprintf(buf, sizeof(buf),
+					"%s\n\nUser: %s\nScore: (HC:%u SC:%u)",
+					game->title,
+					user->display_name, user->score, user->score_softcore);
+			} else if (total > 0) {
+				snprintf(buf, sizeof(buf),
+					"%s\n%u achievements",
 					game->title, total);
 			} else {
 				snprintf(buf, sizeof(buf), "%s", game->title);
 			}
-			ra_notify(buf, 3000);
+			ra_notify(buf, 4000);
 		}
 	} else {
 		RA_LOG("GAME LOAD FAILED: result=%d error=%s", result,
@@ -964,9 +969,9 @@ void achievements_init(void)
 
 	RA_LOG("rc_client created successfully");
 
-	// Begin login if credentials available.
-	// Always defer: all cores require an adapted FPGA bitstream (magic 0x52414348).
-	// If the mirror never activates, login is silently suppressed.
+	// Defer login until FPGA mirror is validated (magic present + frame counter advancing).
+	// This ensures login only fires when an adapted bitstream is actually running.
+	// A non-adapted core never writes the magic, so login is silently suppressed.
 	if (has_creds) {
 		g_login_deferred = 1;
 		RA_LOG("Login deferred until FPGA mirror validated (core: '%s').",
@@ -1136,7 +1141,7 @@ void achievements_poll(void)
 						ra_login_callback, NULL);
 				}
 
-				// Trigger deferred game load (mirror reactivated, already logged in)
+				// Trigger deferred game load (mirror activated, already logged in)
 				if (g_game_load_deferred && g_logged_in && g_rom_md5[0]
 						&& !g_game_load_pending) {
 					g_game_load_deferred = 0;

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -777,14 +777,14 @@ static void ra_login_callback(int result, const char *error_message,
 
 	if (result == RC_OK) {
 		const rc_client_user_t *user = rc_client_get_user_info(client);
-		RA_LOG("LOGIN OK: %s (score: %u)", user->display_name, user->score);
+		RA_LOG("LOGIN OK: %s (hardcore: %u, softcore: %u)", user->display_name, user->score, user->score_softcore);
 		g_logged_in = 1;
 
 		{
 			char buf[NOTIF_TEXT_MAX];
 			snprintf(buf, sizeof(buf),
-				"RetroAchievements\n\n%s\nScore: %u",
-				user->display_name, user->score);
+				"RetroAchievements\n\n%s\nHardcore: %u  Softcore: %u",
+				user->display_name, user->score, user->score_softcore);
 			ra_notify(buf, 2500);
 		}
 

--- a/achievements_atari2600.cpp
+++ b/achievements_atari2600.cpp
@@ -106,9 +106,11 @@ static int atari2600_poll(void *map, void *client, int game_loaded)
 		for (int j = 0; j < 512; j++) {
 			uint8_t v = b[256 + j];
 			if (v != s_ram0_prev[j]) {
-				// Log changes to values 1,8,10,15 OR at specific key addrs
-				if (v == 1 || v == 8 || v == 10 || v == 15 ||
-				    j == 0x53 || j == 0x5B || j == 0xBC || j == 0xC4) {
+				// Key addrs: 0x5B=game-state, 0xBC=hammer-timer, 0x84/0x85=round/sub
+				if (v == 0x0F || v == 1 || v == 8 || v == 10 ||
+				    j == 0x53 || j == 0x5B ||
+				    j == 0xBC || j == 0xC4 ||
+				    j == 0x84 || j == 0x85) {
 					ra_log_write("A7800 RAM0[%03X]:%02X->%02X f=%u\n",
 						j, (unsigned)s_ram0_prev[j], v, frame_ctr);
 				}
@@ -120,10 +122,14 @@ static int atari2600_poll(void *map, void *client, int game_loaded)
 	return 0;
 }
 
-static void atari2600_detect_protocol(void *map)
+static int atari2600_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("ATARI2600: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// Region-based layout; no protocol detection needed
+	return 1;
 }
 
 static int atari2600_calculate_hash(const char *rom_path, char *md5_hex_out)

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -45,8 +45,9 @@ typedef struct {
 	// Set hardcore mode bits (NULL = no FPGA mapping for this console)
 	void (*set_hardcore)(int enabled);
 
-	// Detect FPGA protocol type (called when DDRAM mirror first activates)
-	void (*detect_protocol)(void *map);
+	// Detect FPGA protocol type (called when DDRAM mirror first activates).
+	// Returns 1 if FPGA is adapted for RA, 0 if not (login/load will be suppressed).
+	int (*detect_protocol)(void *map);
 
 	// Get console ID (RC_CONSOLE_*)
 	int console_id;

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -189,12 +189,16 @@ static void gameboy_set_hardcore(int enabled)
 	ra_log_write("GameBoy: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void gameboy_detect_protocol(void *map)
+static int gameboy_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("Gameboy: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// GameBoy always uses Option C
 	g_gb_state.optionc = 1;
 	ra_log_write("Gameboy FPGA protocol: Option C (selective address reading)\n");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -265,13 +265,17 @@ static void gba_init_flash_ddram(void)
         shmem_unmap(flash, GBA_FLASH_SIZE);
 }
 
-static void gba_detect_protocol(void *map)
+static int gba_detect_protocol(void *map)
 {
-        if (!map) return;
+        if (!ra_ramread_active(map)) {
+                ra_log_write("GBA: FPGA mirror not detected -- RA support unavailable\n");
+                return 0;
+        }
         // GBA always uses Option C
         g_gba_state.optionc = 1;
         gba_init_flash_ddram();
         ra_log_write("GBA FPGA protocol: Option C (selective address reading)\n");
+        return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -170,12 +170,16 @@ static void genesis_set_hardcore(int enabled)
 	ra_log_write("Genesis: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void genesis_detect_protocol(void *map)
+static int genesis_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("Genesis: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// Genesis always uses Option C (no VBlank-gated mode)
 	g_md_state.optionc = 1;
 	ra_log_write("MegaDrive FPGA protocol: Option C (selective address reading)\n");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -208,12 +208,16 @@ static void megacd_set_hardcore(int enabled)
 	ra_log_write("MegaCD: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void megacd_detect_protocol(void *map)
+static int megacd_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("MEGACD: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// MegaCD always uses Option C (no VBlank-gated mode)
 	g_mcd_state.optionc = 1;
 	ra_log_write("MegaCD FPGA protocol: Option C (selective address reading)\n");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -282,12 +282,16 @@ static void n64_set_hardcore(int enabled)
 		enabled ? "enabled" : "disabled");
 }
 
-static void n64_detect_protocol(void *map)
+static int n64_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("N64: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// N64 always uses Option C
 	g_n64_state.optionc = 1;
 	ra_log_write("N64 FPGA protocol: Option C (selective address reading)\n");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -254,14 +254,18 @@ static void neogeo_set_hardcore(int enabled)
 		enabled ? "enabled" : "disabled");
 }
 
-static void neogeo_detect_protocol(void *map)
+static int neogeo_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("NeoGeo: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// NeoGeo always uses Option C; detect CD vs MVS for byte-ordering
 	g_neogeo_state.optionc = 1;
 	g_neogeo_is_cd = is_neogeo_cd();
 	ra_log_write("%s FPGA protocol: Option C (selective address reading)\n",
 		g_neogeo_is_cd ? "NeoGeoCD" : "NeoGeo");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -42,10 +42,16 @@ static int nes_poll(void *map, void *client, int game_loaded)
 	return 0; // fall through to achievements_poll default path
 }
 
-static void nes_detect_protocol(void *map)
+static int nes_detect_protocol(void *map)
 {
-	(void)map;
-	// NES uses region-based layout; no protocol detection needed
+	if (!ra_ramread_active(map)) {
+		ra_log_write("NES: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
+	const ra_header_t *hdr = (const ra_header_t *)map;
+	ra_log_write("NES: FPGA mirror OK, regions=%u frame=%u\n",
+		hdr->region_count, hdr->frame_counter);
+	return 1;
 }
 
 static int nes_calculate_hash(const char *rom_path, char *md5_hex_out)

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -235,13 +235,17 @@ static void psx_set_hardcore(int enabled)
 	ra_log_write("PSX: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void psx_detect_protocol(void *map)
+static int psx_detect_protocol(void *map)
 {
+	if (!ra_ramread_active(map)) {
+		ra_log_write("PSX: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// PSX always uses Option C (no VBlank-gated mode)
 	g_psx_state.optionc = 1;
 	ra_log_write("PSX FPGA protocol: Option C (selective address reading)\n");
 
-	if (map && ra_rtquery_supported(map)) {
+	if (ra_rtquery_supported(map)) {
 		g_psx_rtquery = 1;
 		ra_rtquery_init(map);
 		ra_log_write("PSX: Realtime queries supported (FPGA v2+)\n");
@@ -249,6 +253,7 @@ static void psx_detect_protocol(void *map)
 		g_psx_rtquery = 0;
 		ra_log_write("PSX: Realtime queries NOT supported (FPGA v1)\n");
 	}
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_s32x.cpp
+++ b/achievements_s32x.cpp
@@ -170,12 +170,16 @@ user_io_status_set("[24]", enabled ? 1 : 0); // disable save states
 ra_log_write("S32X: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void s32x_detect_protocol(void *map)
+static int s32x_detect_protocol(void *map)
 {
-(void)map;
+        if (!ra_ramread_active(map)) {
+                ra_log_write("S32X: FPGA mirror not detected -- RA support unavailable\n");
+                return 0;
+        }
 // S32X always uses Option C
 g_s32x_state.optionc = 1;
 ra_log_write("S32X FPGA protocol: Option C (selective address reading)\n");
+        return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -153,12 +153,16 @@ static void sms_set_hardcore(int enabled)
 	ra_log_write("SMS: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void sms_detect_protocol(void *map)
+static int sms_detect_protocol(void *map)
 {
-	(void)map;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("SMS: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	// SMS always uses Option C
 	g_sms_state.optionc = 1;
 	ra_log_write("SMS FPGA protocol: Option C (selective address reading)\n");
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -248,9 +248,12 @@ static void snes_set_hardcore(int enabled)
 	ra_log_write("SNES: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-void snes_detect_protocol(void *map)
+int snes_detect_protocol(void *map)
 {
-	if (!map) return;
+	if (!ra_ramread_active(map)) {
+		ra_log_write("SNES: FPGA mirror not detected -- RA support unavailable\n");
+		return 0;
+	}
 	const ra_header_t *hdr = (const ra_header_t *)map;
 	if (hdr->region_count == 0) {
 		g_snes_state.optionc = 1;
@@ -260,6 +263,7 @@ void snes_detect_protocol(void *map)
 		ra_log_write("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n",
 			hdr->region_count);
 	}
+	return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/achievements_tgfx16.cpp
+++ b/achievements_tgfx16.cpp
@@ -281,9 +281,12 @@ user_io_status_set("[5]", enabled ? 1 : 0);
 ra_log_write("TGFX16: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
 
-static void tgfx16_detect_protocol(void *map)
+static int tgfx16_detect_protocol(void *map)
 {
-if (!map) return;
+if (!ra_ramread_active(map)) {
+	ra_log_write("TGFX16: FPGA mirror not detected -- RA support unavailable\n");
+	return 0;
+}
 const ra_header_t *hdr = (const ra_header_t *)map;
 if (hdr->region_count == 0) {
 g_tgfx16_state.optionc = 1;
@@ -293,6 +296,7 @@ g_tgfx16_state.optionc = 0;
 ra_log_write("TGFX16 FPGA protocol: VBlank-gated mirror (region_count=%d)\n",
 hdr->region_count);
 }
+return 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -195,13 +195,18 @@ uint8_t ra_ramread_atari7800_byte(const void *map, uint16_t addr)
 	if (addr >= 0x1800 && addr <= 0x1FFF)
 		return ((const uint8_t *)map + 0x900)[addr & 0x7FF];
 	// ram0: physical 0x2000-0x27FF (main) and zero-page/stack mirrors
-	// Note: requires real BIOS (boot0.rom). Without BIOS, bypass_bios shifts
-	// all game variables -8 in BRAM and inverts game-state semantics,
-	// breaking achievement reset conditions. With real BIOS, direct mapping works.
+	// ProSystem (reference emulator for Atari 7800 achievements) stores game
+	// variables 8 bytes higher in BRAM than our FPGA. The -8 offset compensates.
+	// However, system/BIOS variables in BRAM[0x00-0x7F] map directly (no offset).
+	// Game variables in BRAM[0x80+] need the -8 shift.
+	// Example: RA addr 0x20C4 (bram=0xC4 >=0x80) -> BRAM[0xBC] = hammer timer.
+	//          RA addr 0x205B (bram=0x5B < 0x80) -> BRAM[0x5B] = 0 (no reset).
 	if ((addr >= 0x2000 && addr <= 0x27FF) ||
 	    (addr >= 0x0040 && addr <= 0x00FF) ||
 	    (addr >= 0x0140 && addr <= 0x01FF)) {
-		return ((const uint8_t *)map + 0x100)[addr & 0x7FF];
+		uint16_t bram_idx = addr & 0x7FF;
+		if (bram_idx >= 0x80) bram_idx -= 8;
+		return ((const uint8_t *)map + 0x100)[bram_idx];
 	}
 	return 0;
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the way FPGA adaptation is detected and handled for RetroAchievements integration. The main focus is to ensure that login and game load operations are only triggered when a compatible, adapted FPGA core is detected, preventing unnecessary or failed attempts on unsupported cores. Additionally, protocol detection functions across all supported consoles are unified to return a status, and user notifications are enhanced to provide clearer information.

**FPGA Adaptation and Deferred Operations**

* Added state variables (`g_login_deferred`, `g_game_load_deferred`, `g_mirror_confirming`, `g_mirror_initial_frame`) to manage deferred login and game load until FPGA adaptation is validated.
* Modified the main poll loop to confirm the FPGA mirror is active and adapted before allowing login or game load, suppressing these actions if the core is not supported.
* Updated initialization, game load, and unload functions to properly reset and manage deferred states, ensuring clean transitions between games/cores. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL963-R978) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1025-R1027) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1032-R1058) [[4]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1289-R1294) [[5]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1317-R1329)

**Protocol Detection Refactor**

* Changed all `detect_protocol` functions in console-specific files to return an `int` (1 for adapted, 0 for not adapted), and to check for FPGA mirror activity before reporting support, improving reliability and consistency. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21L48-R50) [[2]](diffhunk://#diff-7dd259e1ebd9468ada142702b2609e45cd734c9717860b34905e62af66dd130aL123-R132) [[3]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeL192-R201) [[4]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1L268-R278) [[5]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dL173-R182) [[6]](diffhunk://#diff-4c1febe6aefb613053fa5a951b212c1924273a913ff7e4a6dd33c0f15dff0f64L211-R220) [[7]](diffhunk://#diff-2e2e43bd0804815caa8ed2df42f77d559cf085ee37ba2fd5cb0de0f57e89a774L285-R294) [[8]](diffhunk://#diff-b3c75c13bfbe45ba41424899a197d30bd169396c7fc507826202b7f91f87a7faL257-R268) [[9]](diffhunk://#diff-4b10f21214c8cf7cdcb672c48035df2307625f7779c1a2973bd837b6e542fe24L45-R54) [[10]](diffhunk://#diff-eab83b801263e7e8c9ecc8f83920bc0b96b554a2ac8d19b497018926f86c2146L238-R256) [[11]](diffhunk://#diff-664ab78c0efde18e58ddc6c8ad05abe7795f7b1ff85e5b62dd1116846cf777b4L173-R182) [[12]](diffhunk://#diff-11bd452c7a74aa29a7a8e15cfb49b0bc3a302db479495f6f7ae36ae125360f99L156-R165) [[13]](diffhunk://#diff-3cfe337a1a9a90d7323dbdd9b282331697e189e7f16f400648274e0921acf6d7L251-R256)

**User Feedback and Notification Improvements**

* Enhanced login and game load notifications to include both hardcore and softcore user scores, and to display more comprehensive information in a single popup. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL776-R784) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR815) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL830-R846)

**Console-Specific Logging and Debugging**

* Improved RAM change logging for Atari 2600 by adding more key addresses and value triggers for debugging.

These changes collectively ensure that RetroAchievements only attempts to log in and load games when the environment is correctly adapted and ready, improving user experience and reliability across all supported consoles.