### PR TITLE
fix: smart-cache implementation for NES

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -1683,7 +1683,7 @@ int achievements_smart_cache_enabled(void)
 
 #ifdef HAS_RCHEEVOS
 	int cid = ra_get_console_id();
-	if (cid == RC_CONSOLE_PLAYSTATION || cid == RC_CONSOLE_SUPER_NINTENDO) {
+	if (cid == RC_CONSOLE_PLAYSTATION || cid == RC_CONSOLE_NINTENDO) {
 		return 1;
 	}
 #endif

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -1,4 +1,5 @@
 // achievements_nes.cpp — RetroAchievements NES-specific implementation
+// Option C + Smart Cache (Tier 1) — selective address reading with RTQuery
 
 #include "achievements_console.h"
 #include "achievements.h"
@@ -8,10 +9,19 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 
 #ifdef HAS_RCHEEVOS
+#include "rc_client.h"
 #include "rc_consoles.h"
 #endif
+
+// ---------------------------------------------------------------------------
+// NES State
+// ---------------------------------------------------------------------------
+
+static console_state_t g_nes_state = {0};
+static int g_nes_rtquery = 0;
 
 // ---------------------------------------------------------------------------
 // NES Implementation
@@ -19,27 +29,273 @@
 
 static void nes_init(void)
 {
-	// NES has no console-specific state
+	memset(&g_nes_state, 0, sizeof(g_nes_state));
+	g_nes_rtquery = 0;
 }
 
 static void nes_reset(void)
 {
-	// NES has no console-specific state to reset
+	memset(&g_nes_state, 0, sizeof(g_nes_state));
+	g_nes_rtquery = 0;
 }
 
 static uint32_t nes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	// NES uses region-based layout (no Option C)
-	return ra_ramread_nes_read(map, address, buffer, num_bytes);
+	if (g_nes_state.optionc) {
+		if (g_nes_state.collecting) {
+			for (uint32_t i = 0; i < num_bytes; i++)
+				ra_snes_addrlist_add(address + i);
+		}
+		if (g_nes_state.cache_ready) {
+			if (achievements_smart_cache_enabled() && g_nes_rtquery) {
+				// During reindexing, use rtquery for all reads
+				if (g_nes_state.cache_reindexing) {
+					if (num_bytes <= 4) {
+						uint32_t val = ra_rtquery_read(map, address, num_bytes);
+						for (uint32_t i = 0; i < num_bytes; i++)
+							buffer[i] = (uint8_t)(val >> (i * 8));
+						return num_bytes;
+					}
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+					}
+					return num_bytes;
+				}
+				// Smart Cache: check each byte, rtquery on miss
+				int any_miss = 0;
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) < 0) {
+						any_miss = 1;
+						break;
+					}
+				}
+				if (!any_miss) {
+					for (uint32_t i = 0; i < num_bytes; i++)
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					return num_bytes;
+				}
+				// Cache miss: use rtquery
+				if (num_bytes <= 4) {
+					uint32_t val = ra_rtquery_read(map, address, num_bytes);
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						buffer[i] = (uint8_t)(val >> (i * 8));
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+					return num_bytes;
+				}
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) >= 0) {
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					} else {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+				}
+				return num_bytes;
+			}
+			// Legacy path: read from cache
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		// RTQuery fallback for pre-cache reads
+		if (g_nes_rtquery && achievements_rtquery_enabled() && !g_nes_state.collecting && num_bytes <= 4) {
+			uint32_t val = ra_rtquery_read(map, address, num_bytes);
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = (uint8_t)(val >> (i * 8));
+			return num_bytes;
+		}
+		memset(buffer, 0, num_bytes);
+		return num_bytes;
+	} else {
+		// VBlank-gated: read from full mirror (fallback)
+		return ra_ramread_nes_read(map, address, buffer, num_bytes);
+	}
 }
 
 static int nes_poll(void *map, void *client, int game_loaded)
 {
-	(void)map;
-	(void)client;
-	(void)game_loaded;
-	// NES uses default frame tracking (no Option C)
-	return 0; // fall through to achievements_poll default path
+#ifdef HAS_RCHEEVOS
+	if (!client || !game_loaded || !map || !g_nes_state.optionc)
+		return 0;
+
+	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// ===================================================================
+	// Smart Cache path (Tier 1)
+	// ===================================================================
+	if (achievements_smart_cache_enabled() && g_nes_rtquery) {
+
+		if (ra_snes_addrlist_count() == 0 && !g_nes_state.cache_ready) {
+			// Phase 1: Bootstrap
+			g_nes_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_nes_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed) {
+				ra_log_write("NES SmartCache: Bootstrap done, %d addrs written to DDRAM\n",
+					ra_snes_addrlist_count());
+			} else {
+				ra_log_write("NES SmartCache: No addresses collected\n");
+			}
+		} else if (!g_nes_state.cache_ready) {
+			// Phase 2: Wait for FPGA to fill cache
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_nes_state.cache_ready = 1;
+				g_nes_state.last_resp_frame = 0;
+				g_nes_state.game_frames = 0;
+				g_nes_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_nes_state.cache_time);
+				ra_log_write("NES SmartCache: Cache active! %d addrs monitored\n",
+					ra_snes_addrlist_count());
+			}
+		} else {
+			// Phase 3: Normal — cache miss handled in read_memory
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+
+			if (g_nes_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
+				g_nes_state.cache_reindexing = 0;
+				ra_log_write("NES SmartCache: Reindex complete (%d addrs)\n",
+					ra_snes_addrlist_count());
+			}
+
+			if (resp_frame > g_nes_state.last_resp_frame) {
+				g_nes_state.last_resp_frame = resp_frame;
+				g_nes_state.game_frames++;
+				ra_frame_processed(resp_frame);
+
+				if (g_nes_state.game_frames <= 5) {
+					ra_log_write("NES SmartCache: GameFrame %u (resp_frame=%u, addrs=%d)\n",
+						g_nes_state.game_frames, resp_frame, ra_snes_addrlist_count());
+				}
+
+				// Periodic cleanup: prune stale entries every ~10s
+				int cleanup_frame = (g_nes_state.game_frames % 600 == 0)
+					&& (g_nes_state.game_frames > 0)
+					&& !g_nes_state.cache_reindexing;
+				if (cleanup_frame) {
+					g_nes_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
+
+				rc_client_do_frame(rc_client);
+
+				if (cleanup_frame) {
+					g_nes_state.collecting = 0;
+					int old_count = ra_snes_addrlist_count();
+					if (ra_snes_addrlist_end_collect(map)) {
+						int new_count = ra_snes_addrlist_count();
+						ra_log_write("NES SmartCache: Cleanup — pruned %d stale (%d -> %d)\n",
+							old_count - new_count, old_count, new_count);
+						g_nes_state.cache_reindexing = 1;
+					}
+				} else {
+					if (ra_snes_addrlist_has_pending()) {
+						ra_snes_addrlist_flush_dynamic(map);
+					}
+				}
+			}
+		}
+
+		// Periodic logging
+		uint32_t milestone = g_nes_state.game_frames / 300;
+		if (milestone > 0 && milestone != g_nes_state.poll_logged) {
+			g_nes_state.poll_logged = milestone;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			double elapsed = (now.tv_sec - g_nes_state.cache_time.tv_sec)
+				+ (now.tv_nsec - g_nes_state.cache_time.tv_nsec) / 1e9;
+			double ms_per_cycle = (g_nes_state.game_frames > 0) ?
+				(elapsed * 1000.0 / g_nes_state.game_frames) : 0.0;
+			ra_log_write("POLL(NES-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d reindexing=%d\n",
+				g_nes_state.last_resp_frame, g_nes_state.game_frames, elapsed, ms_per_cycle,
+				ra_snes_addrlist_count(), g_nes_state.cache_reindexing);
+		}
+
+		return 1;
+	}
+
+	// ===================================================================
+	// Legacy path: periodic recollect (no RTQuery)
+	// ===================================================================
+
+	if (ra_snes_addrlist_count() == 0 && !g_nes_state.cache_ready) {
+		g_nes_state.collecting = 1;
+		ra_snes_addrlist_begin_collect();
+		rc_client_do_frame(rc_client);
+		g_nes_state.collecting = 0;
+		int changed = ra_snes_addrlist_end_collect(map);
+		if (changed) {
+			ra_log_write("NES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+				ra_snes_addrlist_count());
+		}
+	} else if (!g_nes_state.cache_ready) {
+		if (ra_snes_addrlist_is_ready(map)) {
+			g_nes_state.cache_ready = 1;
+			g_nes_state.last_resp_frame = 0;
+			g_nes_state.game_frames = 0;
+			g_nes_state.poll_logged = 0;
+			clock_gettime(CLOCK_MONOTONIC, &g_nes_state.cache_time);
+			ra_log_write("NES OptionC: Cache active!\n");
+		}
+	} else {
+		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		if (resp_frame > g_nes_state.last_resp_frame) {
+			g_nes_state.last_resp_frame = resp_frame;
+			g_nes_state.game_frames++;
+			ra_frame_processed(resp_frame);
+			clock_gettime(CLOCK_MONOTONIC, &g_nes_state.stall_time);
+			g_nes_state.stall_frame = resp_frame;
+
+			if (g_nes_state.game_frames <= 5) {
+				ra_log_write("NES OptionC: GameFrame %u (resp_frame=%u)\n",
+					g_nes_state.game_frames, resp_frame);
+			}
+
+			// Periodically re-collect (~5 min)
+			int re_collect = !achievements_smart_cache_enabled()
+				&& (g_nes_state.game_frames % 18000 == 0) && (g_nes_state.game_frames > 0);
+			if (re_collect) {
+				g_nes_state.collecting = 1;
+				ra_snes_addrlist_begin_collect();
+			}
+
+			rc_client_do_frame(rc_client);
+
+			if (re_collect) {
+				g_nes_state.collecting = 0;
+				if (ra_snes_addrlist_end_collect(map)) {
+					ra_log_write("NES OptionC: Address list refreshed, %d addrs\n",
+						ra_snes_addrlist_count());
+				}
+			}
+		} else {
+			optionc_check_stall_recovery(&g_nes_state, resp_frame, "NES");
+		}
+	}
+
+	// Periodic logging
+	uint32_t milestone = g_nes_state.game_frames / 300;
+	if (milestone > 0 && milestone != g_nes_state.poll_logged) {
+		g_nes_state.poll_logged = milestone;
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		double elapsed = (now.tv_sec - g_nes_state.cache_time.tv_sec)
+			+ (now.tv_nsec - g_nes_state.cache_time.tv_nsec) / 1e9;
+		double ms_per_cycle = (g_nes_state.game_frames > 0) ?
+			(elapsed * 1000.0 / g_nes_state.game_frames) : 0.0;
+		ra_log_write("POLL(NES): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+			g_nes_state.last_resp_frame, g_nes_state.game_frames, elapsed, ms_per_cycle,
+			ra_snes_addrlist_count());
+	}
+
+	return 1;
+#else
+	return 0;
+#endif
 }
 
 static int nes_detect_protocol(void *map)
@@ -49,8 +305,28 @@ static int nes_detect_protocol(void *map)
 		return 0;
 	}
 	const ra_header_t *hdr = (const ra_header_t *)map;
-	ra_log_write("NES: FPGA mirror OK, regions=%u frame=%u\n",
-		hdr->region_count, hdr->frame_counter);
+	if (hdr->region_count == 0) {
+		g_nes_state.optionc = 1;
+		ra_log_write("NES FPGA protocol: Option C (selective address reading)\n");
+	} else {
+		g_nes_state.optionc = 0;
+		ra_log_write("NES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n",
+			hdr->region_count);
+	}
+
+	if (g_nes_state.optionc) {
+		if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+			g_nes_rtquery = 1;
+			ra_rtquery_init(map);
+			ra_log_write("NES: Realtime queries supported and ENABLED\n");
+		} else if (ra_rtquery_supported(map)) {
+			g_nes_rtquery = 0;
+			ra_log_write("NES: Realtime queries supported but DISABLED by config\n");
+		} else {
+			g_nes_rtquery = 0;
+			ra_log_write("NES: Realtime queries NOT supported (FPGA v1)\n");
+		}
+	}
 	return 1;
 }
 


### PR DESCRIPTION
**NES Smart Cache and Protocol Enhancements:**

* Added a Smart Cache system for NES achievements, enabling selective address reading and dynamic cache management using RTQuery where available. This includes cache bootstrapping, cache-miss handling, periodic cleanup, and fallback to legacy behavior if Smart Cache is not enabled. (`achievements_nes.cpp`)
* Improved NES protocol detection to distinguish between Option C (selective address reading) and VBlank-gated full mirror modes, and to initialize RTQuery support accordingly. (`achievements_nes.cpp`)
* Introduced new NES state variables (`g_nes_state`, `g_nes_rtquery`) to track cache state, RTQuery support, and collection phases. (`achievements_nes.cpp`)
* Updated the Smart Cache enablement check to use the correct console constant for NES (from `RC_CONSOLE_SUPER_NINTENDO` to `RC_CONSOLE_NINTENDO`). (`achievements.cpp`)

**Codebase maintenance:**

* Added relevant includes and documentation comments for the new Smart Cache logic. (`achievements_nes.cpp`)