### PR TITLE
feature: genesis support to smart-cache

### DIFF
--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_md_state = {};
+static int g_md_rtquery = 0;
 
 // ---------------------------------------------------------------------------
 // Genesis/MegaDrive Implementation
@@ -26,11 +27,13 @@ static console_state_t g_md_state = {};
 static void genesis_init(void)
 {
 	memset(&g_md_state, 0, sizeof(g_md_state));
+	g_md_rtquery = 0;
 }
 
 static void genesis_reset(void)
 {
 	memset(&g_md_state, 0, sizeof(g_md_state));
+	g_md_rtquery = 0;
 }
 
 static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
@@ -41,8 +44,58 @@ static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_md_state.cache_ready) {
+			if (achievements_smart_cache_enabled() && g_md_rtquery) {
+				if (g_md_state.cache_reindexing) {
+					if (num_bytes <= 4) {
+						uint32_t val = ra_rtquery_read(map, address, num_bytes);
+						for (uint32_t i = 0; i < num_bytes; i++)
+							buffer[i] = (uint8_t)(val >> (i * 8));
+						return num_bytes;
+					}
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+					}
+					return num_bytes;
+				}
+				int any_miss = 0;
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) < 0) {
+						any_miss = 1; break;
+					}
+				}
+				if (!any_miss) {
+					for (uint32_t i = 0; i < num_bytes; i++)
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					return num_bytes;
+				}
+				if (num_bytes <= 4) {
+					uint32_t val = ra_rtquery_read(map, address, num_bytes);
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						buffer[i] = (uint8_t)(val >> (i * 8));
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+					return num_bytes;
+				}
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) >= 0) {
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					} else {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+				}
+				return num_bytes;
+			}
 			for (uint32_t i = 0; i < num_bytes; i++)
 				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		if (g_md_rtquery && achievements_rtquery_enabled() && !g_md_state.collecting && num_bytes <= 4) {
+			uint32_t val = ra_rtquery_read(map, address, num_bytes);
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = (uint8_t)(val >> (i * 8));
 			return num_bytes;
 		}
 		memset(buffer, 0, num_bytes);
@@ -57,6 +110,93 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 	if (!client || !game_loaded || !map || !g_md_state.optionc) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// ===================================================================
+	// Smart Cache path (Tier 1)
+	// ===================================================================
+	if (achievements_smart_cache_enabled() && g_md_rtquery) {
+
+		if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
+			g_md_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_md_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed)
+				ra_log_write("MD SmartCache: Bootstrap done, %d addrs\n", ra_snes_addrlist_count());
+			else
+				ra_log_write("MD SmartCache: No addresses collected\n");
+		} else if (!g_md_state.cache_ready) {
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_md_state.cache_ready = 1;
+				g_md_state.last_resp_frame = 0;
+				g_md_state.game_frames = 0;
+				g_md_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_md_state.cache_time);
+				ra_log_write("MD SmartCache: Cache active! %d addrs\n", ra_snes_addrlist_count());
+			}
+		} else {
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+
+			if (g_md_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
+				g_md_state.cache_reindexing = 0;
+				ra_log_write("MD SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
+			}
+
+			if (resp_frame > g_md_state.last_resp_frame) {
+				g_md_state.last_resp_frame = resp_frame;
+				g_md_state.game_frames++;
+				ra_frame_processed(resp_frame);
+
+				if (g_md_state.game_frames <= 5)
+					ra_log_write("MD SmartCache: GameFrame %u (resp_frame=%u, addrs=%d)\n",
+						g_md_state.game_frames, resp_frame, ra_snes_addrlist_count());
+
+				int cleanup_frame = (g_md_state.game_frames % 600 == 0)
+					&& (g_md_state.game_frames > 0)
+					&& !g_md_state.cache_reindexing;
+				if (cleanup_frame) {
+					g_md_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
+
+				rc_client_do_frame(rc_client);
+
+				if (cleanup_frame) {
+					g_md_state.collecting = 0;
+					int old_count = ra_snes_addrlist_count();
+					if (ra_snes_addrlist_end_collect(map)) {
+						int new_count = ra_snes_addrlist_count();
+						ra_log_write("MD SmartCache: Cleanup — pruned %d stale (%d -> %d)\n",
+							old_count - new_count, old_count, new_count);
+						g_md_state.cache_reindexing = 1;
+					}
+				} else {
+					if (ra_snes_addrlist_has_pending())
+						ra_snes_addrlist_flush_dynamic(map);
+				}
+			}
+		}
+
+		uint32_t milestone = g_md_state.game_frames / 300;
+		if (milestone > 0 && milestone != g_md_state.poll_logged) {
+			g_md_state.poll_logged = milestone;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			double elapsed = (now.tv_sec - g_md_state.cache_time.tv_sec)
+				+ (now.tv_nsec - g_md_state.cache_time.tv_nsec) / 1e9;
+			double ms_per_cycle = (g_md_state.game_frames > 0) ?
+				(elapsed * 1000.0 / g_md_state.game_frames) : 0.0;
+			ra_log_write("POLL(MD-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+				g_md_state.last_resp_frame, g_md_state.game_frames, elapsed, ms_per_cycle,
+				ra_snes_addrlist_count());
+		}
+		return 1;
+	}
+
+	// ===================================================================
+	// Legacy path
+	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
 		// Bootstrap: run one do_frame with zeros to discover needed addresses
@@ -178,9 +318,20 @@ static int genesis_detect_protocol(void *map)
 		ra_log_write("Genesis: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// Genesis always uses Option C (no VBlank-gated mode)
 	g_md_state.optionc = 1;
 	ra_log_write("MegaDrive FPGA protocol: Option C (selective address reading)\n");
+
+	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+		g_md_rtquery = 1;
+		ra_rtquery_init(map);
+		ra_log_write("Genesis: Realtime queries supported and ENABLED\n");
+	} else if (ra_rtquery_supported(map)) {
+		g_md_rtquery = 0;
+		ra_log_write("Genesis: Realtime queries supported but DISABLED by config\n");
+	} else {
+		g_md_rtquery = 0;
+		ra_log_write("Genesis: Realtime queries NOT supported (FPGA v1)\n");
+	}
 	return 1;
 }
 


### PR DESCRIPTION
This pull request adds support for a "Smart Cache" and real-time query (RTQuery) system to the Genesis/MegaDrive achievements implementation, improving memory read efficiency and cache management. It introduces a new runtime query mode that can be enabled if supported, and refactors the polling and memory read logic to leverage these new features for better performance and configurability.

Key changes:

**Smart Cache and RTQuery Integration:**
* Introduced the `g_md_rtquery` variable to track RTQuery support and enablement, initializing it during system setup and reset (`achievements_genesis.cpp`). [[1]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dR21) [[2]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dR30-R36)
* Enhanced the protocol detection function to check for RTQuery support and enablement, initializing the RTQuery system and logging the current state accordingly.

**Memory Read Optimization:**
* Updated `genesis_read_memory` to use RTQuery and Smart Cache logic when enabled, including dynamic address collection, cache reindexing, and optimized memory reads for small byte ranges. Falls back to legacy behavior if unsupported.

**Polling and Cache Management:**
* Refactored the polling function to add a new Smart Cache path, handling cache bootstrapping, activation, reindexing, cleanup, and periodic logging of cache statistics. The legacy path is retained for compatibility.