### PR TITLE
Implement granular leaderboard pop-ups and force reset feature

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -192,6 +192,7 @@ static int g_show_progress_popups      = 1; // 1 = show progress indicator popup
 static int g_show_progress_name        = 1; // 1 = include achievement name in progress popup
 static int g_leaderboards_enabled      = 1; // 1 = handle leaderboard events and tracker popups
 static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheats & save states)
+static int g_force_hardcore            = 0; // 1 = force hardcore mode even if core doesn't support it
 static int g_stall_recovery            = 0; // 1 = enable OptionC stall recovery (disabled by default)
 static int g_rtquery_enabled           = 1; // 1 = enable realtime queries for AddAddress resolution
 static int g_recollect_interval        = 600; // frames between address re-collections (PSX default 600, SNES 18000)
@@ -529,6 +530,8 @@ static int ra_load_credentials(void)
 				g_leaderboards_enabled = atoi(val);
 		} else if (!strcasecmp(key, "hardcore")) {
 			g_hardcore = atoi(val);
+		} else if (!strcasecmp(key, "force_hardcore")) {
+			g_force_hardcore = atoi(val);
 		} else if (!strcasecmp(key, "stall_recovery")) {
 			g_stall_recovery = atoi(val);
 		} else if (!strcasecmp(key, "rtquery_enabled") ||
@@ -553,10 +556,10 @@ static int ra_load_credentials(void)
 	}
 
 	RA_LOG("Credentials loaded: user=%s password=***(%zu chars)", g_ra_user, strlen(g_ra_password));
-	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d leaderboards_enabled=%d hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d debug=%d",
+	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d leaderboards_enabled=%d hardcore=%d force_hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d debug=%d",
                 g_show_challenge_show_popup, g_show_challenge_hide_popup,
                 g_show_progress_popups, g_show_progress_name, g_leaderboards_enabled,
-                g_hardcore, g_stall_recovery, g_rtquery_enabled, g_recollect_interval, g_smart_cache, g_n64_snapshot, g_ra_debug);
+                g_hardcore, g_force_hardcore, g_stall_recovery, g_rtquery_enabled, g_recollect_interval, g_smart_cache, g_n64_snapshot, g_ra_debug);
 	return 1;
 }
 
@@ -1147,7 +1150,7 @@ void achievements_init(void)
 	g_active_handler->init();
 
 	// Apply hardcore FPGA bits immediately so restrictions are active before any game loads
-	if (g_hardcore && g_active_handler->set_hardcore) {
+	if (achievements_hardcore_active() && g_active_handler->set_hardcore) {
 		g_active_handler->set_hardcore(1);
 		RA_LOG("Hardcore: FPGA bits applied at core init for %s", g_active_handler->name);
 	}
@@ -1192,9 +1195,9 @@ void achievements_init(void)
 
 	rc_client_enable_logging(g_client, RC_CLIENT_LOG_LEVEL_VERBOSE, ra_log_callback);
 	rc_client_set_event_handler(g_client, ra_event_handler);
-	int core_protected = g_active_handler && g_active_handler->hardcore_protected;
-	rc_client_set_hardcore_enabled(g_client, g_hardcore && core_protected ? 1 : 0);
-	RA_LOG("Hardcore mode: %s", (g_hardcore && core_protected) ? "ENABLED" : "disabled");
+	int hardcore_active = achievements_hardcore_active();
+	rc_client_set_hardcore_enabled(g_client, hardcore_active ? 1 : 0);
+	RA_LOG("Hardcore mode: %s", hardcore_active ? "ENABLED" : "disabled");
 
 	// Configure User-Agent: "MiSTer/1.0 rcheevos/x.y.z" (updated per-core in achievements_load_game)
 	{
@@ -1342,7 +1345,7 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
         RA_LOG("--- Game Load Complete, monitoring frames ---");
 
         // Hardcore mode: let handler set console-specific FPGA bits
-        if (g_hardcore && g_active_handler->set_hardcore) {
+        if (achievements_hardcore_active() && g_active_handler->set_hardcore) {
                 g_active_handler->set_hardcore(1);
                 RA_LOG("Hardcore: FPGA bits applied for %s", g_active_handler->name);
         }
@@ -1561,6 +1564,10 @@ void achievements_unload_game(void)
         g_active_handler->reset();
         ra_snes_addrlist_init();
 
+        // Disable FPGA query mailbox polling — no game loaded, no need to poll.
+        // FPGA will stop after next VBlank (reads RA_ARM_CONFIG_OFFSET once per cycle).
+        if (g_ra_map) ra_rtquery_disable(g_ra_map);
+
         // RetroAchievements safety: clear the DDRAM mirror data area so the next
         // game does not see stale bytes from the unloaded game. The header is
         // preserved; only the payload (offset 0x100+) is wiped.
@@ -1670,7 +1677,8 @@ int achievements_active(void)
 
 int achievements_hardcore_active(void)
 {
-	return g_hardcore;
+	if (g_force_hardcore) return 1;
+	return g_hardcore && g_active_handler && g_active_handler->hardcore_protected;
 }
 
 int achievements_stall_recovery_enabled(void)

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -190,7 +190,9 @@ static int g_show_challenge_show_popup = 1; // 1 = show popup on challenge SHOW 
 static int g_show_challenge_hide_popup = 1; // 1 = show popup on challenge HIDE event
 static int g_show_progress_popups      = 1; // 1 = show progress indicator popups
 static int g_show_progress_name        = 1; // 1 = include achievement name in progress popup
-static int g_leaderboards_enabled      = 1; // 1 = handle leaderboard events and tracker popups
+static int g_leaderboards_enabled      = 1; // [deprecated] fallback only when both new leaderboard popup flags are absent
+static int g_show_leaderboards_updates = 1; // 1 = show STARTED/FAILED/TRACKER SHOW/TRACKER UPDATE popups
+static int g_show_leaderboards_submission = 1; // 1 = show SUBMITTED/SCOREBOARD popups
 static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheats & save states)
 static int g_force_hardcore            = 0; // 1 = force hardcore mode even if core doesn't support it
 static int g_stall_recovery            = 0; // 1 = enable OptionC stall recovery (disabled by default)
@@ -482,6 +484,9 @@ static int ra_load_credentials(void)
 {
 	g_ra_user[0] = '\0';
 	g_ra_password[0] = '\0';
+	int legacy_leaderboards_defined = 0;
+	int show_leaderboards_updates_defined = 0;
+	int show_leaderboards_submission_defined = 0;
 
 	FILE *f = fopen(RA_CFG_PATH, "r");
 	if (!f) {
@@ -524,10 +529,19 @@ static int ra_load_credentials(void)
 		} else if (!strcasecmp(key, "show_progress_popups")) {
 			g_show_progress_popups = atoi(val);
 		} else if (!strcasecmp(key, "show_progress_name")) {
-                        g_show_progress_name = atoi(val);
+			g_show_progress_name = atoi(val);
+		} else if (!strcasecmp(key, "show_leaderboards_updates") ||
+					   !strcasecmp(key, "show-leaderboards-updates")) {
+			g_show_leaderboards_updates = atoi(val);
+			show_leaderboards_updates_defined = 1;
+		} else if (!strcasecmp(key, "show_leaderboards_submission") ||
+					   !strcasecmp(key, "show-leaderboards-submission")) {
+			g_show_leaderboards_submission = atoi(val);
+			show_leaderboards_submission_defined = 1;
 		} else if (!strcasecmp(key, "leaderboards-enabled") ||
 					!strcasecmp(key, "leaderboards_enabled")) {
 				g_leaderboards_enabled = atoi(val);
+				legacy_leaderboards_defined = 1;
 		} else if (!strcasecmp(key, "hardcore")) {
 			g_hardcore = atoi(val);
 		} else if (!strcasecmp(key, "force_hardcore")) {
@@ -550,15 +564,22 @@ static int ra_load_credentials(void)
 	}
 	fclose(f);
 
+	/* Backward compatibility: transfer deprecated value only when both new keys are absent. */
+	if (!show_leaderboards_updates_defined && !show_leaderboards_submission_defined && legacy_leaderboards_defined) {
+		g_show_leaderboards_updates = g_leaderboards_enabled;
+		g_show_leaderboards_submission = g_leaderboards_enabled;
+	}
+
 	if (!g_ra_user[0] || !g_ra_password[0]) {
 		RA_LOG("Credentials incomplete (need both username and password)");
 		return 0;
 	}
 
 	RA_LOG("Credentials loaded: user=%s password=***(%zu chars)", g_ra_user, strlen(g_ra_password));
-	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d leaderboards_enabled=%d hardcore=%d force_hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d debug=%d",
+	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d show_leaderboards_updates=%d show_leaderboards_submission=%d leaderboards_enabled(deprecated)=%d hardcore=%d force_hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d debug=%d",
                 g_show_challenge_show_popup, g_show_challenge_hide_popup,
-                g_show_progress_popups, g_show_progress_name, g_leaderboards_enabled,
+                g_show_progress_popups, g_show_progress_name,
+		g_show_leaderboards_updates, g_show_leaderboards_submission, g_leaderboards_enabled,
                 g_hardcore, g_force_hardcore, g_stall_recovery, g_rtquery_enabled, g_recollect_interval, g_smart_cache, g_n64_snapshot, g_ra_debug);
 	return 1;
 }
@@ -786,7 +807,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 
         case RC_CLIENT_EVENT_LEADERBOARD_STARTED:
                 {
-                        if (!g_leaderboards_enabled || !event->leaderboard)
+                        if (!g_show_leaderboards_updates || !event->leaderboard)
                                 break;
 
                         RA_LOG("LEADERBOARD STARTED: [%u] %s",
@@ -806,7 +827,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 
         case RC_CLIENT_EVENT_LEADERBOARD_FAILED:
                 {
-                        if (!g_leaderboards_enabled || !event->leaderboard)
+                        if (!g_show_leaderboards_updates || !event->leaderboard)
                                 break;
 
                         RA_LOG("LEADERBOARD FAILED: [%u] %s",
@@ -825,8 +846,8 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
                 break;
 
         case RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED:
-                {
-                        if (!g_leaderboards_enabled || !event->leaderboard)
+		{
+			if (!g_show_leaderboards_submission || !event->leaderboard)
                                 break;
 
                         RA_LOG("LEADERBOARD SUBMITTED: [%u] %s",
@@ -852,7 +873,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
         case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW:
         case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE:
                 {
-                        if (!g_leaderboards_enabled || !event->leaderboard_tracker)
+                        if (!g_show_leaderboards_updates || !event->leaderboard_tracker)
                                 break;
 
                         RA_LOG("LEADERBOARD TRACKER: id=%u value=%s",
@@ -869,7 +890,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 
         case RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE:
                 {
-                        if (!g_leaderboards_enabled || !event->leaderboard_tracker)
+                        if (!g_show_leaderboards_updates || !event->leaderboard_tracker)
                                 break;
 
                         RA_LOG("LEADERBOARD TRACKER HIDE: id=%u",
@@ -879,7 +900,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 
         case RC_CLIENT_EVENT_LEADERBOARD_SCOREBOARD:
                 {
-                        if (!g_leaderboards_enabled || !event->leaderboard_scoreboard)
+                        if (!g_show_leaderboards_submission || !event->leaderboard_scoreboard)
                                 break;
 
                         RA_LOG("LEADERBOARD SCOREBOARD: id=%u submitted=%s best=%s rank=%u entries=%u",

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_gb_state = {};
+static int g_gb_rtquery = 0;
 
 // Value-change watchers for debugging
 typedef struct {
@@ -46,6 +47,7 @@ static gb_watcher_t g_gb_watchers[] = {
 static void gameboy_init(void)
 {
 	memset(&g_gb_state, 0, sizeof(g_gb_state));
+	g_gb_rtquery = 0;
 	for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
 		g_gb_watchers[i].initialized = 0;
 		g_gb_watchers[i].last_val = 0;
@@ -55,6 +57,7 @@ static void gameboy_init(void)
 static void gameboy_reset(void)
 {
 	memset(&g_gb_state, 0, sizeof(g_gb_state));
+	g_gb_rtquery = 0;
 	for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
 		g_gb_watchers[i].initialized = 0;
 		g_gb_watchers[i].last_val = 0;
@@ -69,8 +72,58 @@ static uint32_t gameboy_read_memory(void *map, uint32_t address, uint8_t *buffer
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_gb_state.cache_ready) {
+			if (achievements_smart_cache_enabled() && g_gb_rtquery) {
+				if (g_gb_state.cache_reindexing) {
+					if (num_bytes <= 4) {
+						uint32_t val = ra_rtquery_read(map, address, num_bytes);
+						for (uint32_t i = 0; i < num_bytes; i++)
+							buffer[i] = (uint8_t)(val >> (i * 8));
+						return num_bytes;
+					}
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+					}
+					return num_bytes;
+				}
+				int any_miss = 0;
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) < 0) {
+						any_miss = 1; break;
+					}
+				}
+				if (!any_miss) {
+					for (uint32_t i = 0; i < num_bytes; i++)
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					return num_bytes;
+				}
+				if (num_bytes <= 4) {
+					uint32_t val = ra_rtquery_read(map, address, num_bytes);
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						buffer[i] = (uint8_t)(val >> (i * 8));
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+					return num_bytes;
+				}
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) >= 0) {
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					} else {
+						uint32_t val = ra_rtquery_read(map, address + i, 1);
+						buffer[i] = (uint8_t)val;
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+				}
+				return num_bytes;
+			}
 			for (uint32_t i = 0; i < num_bytes; i++)
 				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		if (g_gb_rtquery && achievements_rtquery_enabled() && !g_gb_state.collecting && num_bytes <= 4) {
+			uint32_t val = ra_rtquery_read(map, address, num_bytes);
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = (uint8_t)(val >> (i * 8));
 			return num_bytes;
 		}
 		memset(buffer, 0, num_bytes);
@@ -85,6 +138,93 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 	if (!client || !game_loaded || !map || !g_gb_state.optionc) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// ===================================================================
+	// Smart Cache path (Tier 1)
+	// ===================================================================
+	if (achievements_smart_cache_enabled() && g_gb_rtquery) {
+
+		if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
+			g_gb_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_gb_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed)
+				ra_log_write("GB SmartCache: Bootstrap done, %d addrs\n", ra_snes_addrlist_count());
+			else
+				ra_log_write("GB SmartCache: No addresses collected\n");
+		} else if (!g_gb_state.cache_ready) {
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_gb_state.cache_ready = 1;
+				g_gb_state.last_resp_frame = 0;
+				g_gb_state.game_frames = 0;
+				g_gb_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_gb_state.cache_time);
+				ra_log_write("GB SmartCache: Cache active! %d addrs\n", ra_snes_addrlist_count());
+			}
+		} else {
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+
+			if (g_gb_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
+				g_gb_state.cache_reindexing = 0;
+				ra_log_write("GB SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
+			}
+
+			if (resp_frame > g_gb_state.last_resp_frame) {
+				g_gb_state.last_resp_frame = resp_frame;
+				g_gb_state.game_frames++;
+				ra_frame_processed(resp_frame);
+
+				if (g_gb_state.game_frames <= 5)
+					ra_log_write("GB SmartCache: GameFrame %u (resp_frame=%u, addrs=%d)\n",
+						g_gb_state.game_frames, resp_frame, ra_snes_addrlist_count());
+
+				int cleanup_frame = (g_gb_state.game_frames % 600 == 0)
+					&& (g_gb_state.game_frames > 0)
+					&& !g_gb_state.cache_reindexing;
+				if (cleanup_frame) {
+					g_gb_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
+
+				rc_client_do_frame(rc_client);
+
+				if (cleanup_frame) {
+					g_gb_state.collecting = 0;
+					int old_count = ra_snes_addrlist_count();
+					if (ra_snes_addrlist_end_collect(map)) {
+						int new_count = ra_snes_addrlist_count();
+						ra_log_write("GB SmartCache: Cleanup — pruned %d stale (%d -> %d)\n",
+							old_count - new_count, old_count, new_count);
+						g_gb_state.cache_reindexing = 1;
+					}
+				} else {
+					if (ra_snes_addrlist_has_pending())
+						ra_snes_addrlist_flush_dynamic(map);
+				}
+			}
+		}
+
+		uint32_t milestone = g_gb_state.game_frames / 300;
+		if (milestone > 0 && milestone != g_gb_state.poll_logged) {
+			g_gb_state.poll_logged = milestone;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			double elapsed = (now.tv_sec - g_gb_state.cache_time.tv_sec)
+				+ (now.tv_nsec - g_gb_state.cache_time.tv_nsec) / 1e9;
+			double ms_per_cycle = (g_gb_state.game_frames > 0) ?
+				(elapsed * 1000.0 / g_gb_state.game_frames) : 0.0;
+			ra_log_write("POLL(GB-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+				g_gb_state.last_resp_frame, g_gb_state.game_frames, elapsed, ms_per_cycle,
+				ra_snes_addrlist_count());
+		}
+		return 1;
+	}
+
+	// ===================================================================
+	// Legacy path
+	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
 		// Bootstrap: run one do_frame with zeros to discover needed addresses
@@ -197,9 +337,20 @@ static int gameboy_detect_protocol(void *map)
 		ra_log_write("Gameboy: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// GameBoy always uses Option C
 	g_gb_state.optionc = 1;
 	ra_log_write("Gameboy FPGA protocol: Option C (selective address reading)\n");
+
+	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+		g_gb_rtquery = 1;
+		ra_rtquery_init(map);
+		ra_log_write("Gameboy: Realtime queries supported and ENABLED\n");
+	} else if (ra_rtquery_supported(map)) {
+		g_gb_rtquery = 0;
+		ra_log_write("Gameboy: Realtime queries supported but DISABLED by config\n");
+	} else {
+		g_gb_rtquery = 0;
+		ra_log_write("Gameboy: Realtime queries NOT supported (FPGA v1)\n");
+	}
 	return 1;
 }
 

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -294,5 +294,5 @@ const console_handler_t g_console_gba = {
         .detect_protocol = gba_detect_protocol,
         .console_id = 5,  // RC_CONSOLE_GAME_BOY_ADVANCE
         .name = "GBA",
-        .hardcore_protected = 1
+        .hardcore_protected = 0
 };

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -349,5 +349,5 @@ const console_handler_t g_console_genesis = {
 	.detect_protocol = genesis_detect_protocol,
 	.console_id = 1,  // RC_CONSOLE_MEGA_DRIVE
 	.name = "Genesis",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -236,5 +236,5 @@ const console_handler_t g_console_megacd = {
 	.detect_protocol = megacd_detect_protocol,
 	.console_id = 9,  // RC_CONSOLE_SEGA_CD
 	.name = "MegaCD",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -247,5 +247,5 @@ const console_handler_t g_console_n64 = {
 	.detect_protocol = n64_detect_protocol,
 	.console_id = 2,  // RC_CONSOLE_NINTENDO_64
 	.name = "N64",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -19,7 +19,8 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_neogeo_state = {};
-static int g_neogeo_is_cd = 0; // 1 = NeoGeoCD (no byte-swap), 0 = MVS (XOR addr^1)
+static int g_neogeo_is_cd = 0;
+static int g_neogeo_rtquery = 0;
 
 // ---------------------------------------------------------------------------
 // NeoGeo Implementation
@@ -29,12 +30,14 @@ static void neogeo_init(void)
 {
 	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
 	g_neogeo_is_cd = 0;
+	g_neogeo_rtquery = 0;
 }
 
 static void neogeo_reset(void)
 {
 	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
 	g_neogeo_is_cd = 0;
+	g_neogeo_rtquery = 0;
 }
 
 
@@ -43,20 +46,62 @@ static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer,
 	if (g_neogeo_state.optionc) {
 		if (g_neogeo_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++) {
-				// MVS (FBNeo): XOR^1 to match FBNeo byte-swap convention.
-				// NeoGeoCD shadow RAM is sampled in native 68K byte order.
-				// Both MVS and CD use BIGENDIAN XOR (neocd_libretro sets RETRO_MEMDESC_BIGENDIAN;
-				// P1 shadow is in native 68K order, same convention as MVS WRAMU/WRAML).
 				uint32_t a = (address + i);
-                                if (!g_neogeo_is_cd) a ^= 1;
-                                ra_snes_addrlist_add(a);
+				if (!g_neogeo_is_cd) a ^= 1;
+				ra_snes_addrlist_add(a);
 			}
 		}
 		if (g_neogeo_state.cache_ready) {
+			if (achievements_smart_cache_enabled() && g_neogeo_rtquery) {
+				if (g_neogeo_state.cache_reindexing) {
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						uint32_t a = (address + i);
+						if (!g_neogeo_is_cd) a ^= 1;
+						uint32_t val = ra_rtquery_read(map, a, 1);
+						buffer[i] = (uint8_t)val;
+					}
+					return num_bytes;
+				}
+				int any_miss = 0;
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					uint32_t a = (address + i);
+					if (!g_neogeo_is_cd) a ^= 1;
+					if (ra_snes_addrlist_contains(a) < 0) { any_miss = 1; break; }
+				}
+				if (!any_miss) {
+					for (uint32_t i = 0; i < num_bytes; i++) {
+						uint32_t a = (address + i);
+						if (!g_neogeo_is_cd) a ^= 1;
+						buffer[i] = ra_snes_addrlist_read_cached(map, a);
+					}
+					return num_bytes;
+				}
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					uint32_t a = (address + i);
+					if (!g_neogeo_is_cd) a ^= 1;
+					if (ra_snes_addrlist_contains(a) >= 0) {
+						buffer[i] = ra_snes_addrlist_read_cached(map, a);
+					} else {
+						uint32_t val = ra_rtquery_read(map, a, 1);
+						buffer[i] = (uint8_t)val;
+						ra_snes_addrlist_add_dynamic(a);
+					}
+				}
+				return num_bytes;
+			}
 			for (uint32_t i = 0; i < num_bytes; i++) {
 				uint32_t a = (address + i);
-                                if (!g_neogeo_is_cd) a ^= 1;
-                                buffer[i] = ra_snes_addrlist_read_cached(map, a);
+				if (!g_neogeo_is_cd) a ^= 1;
+				buffer[i] = ra_snes_addrlist_read_cached(map, a);
+			}
+			return num_bytes;
+		}
+		if (g_neogeo_rtquery && achievements_rtquery_enabled() && !g_neogeo_state.collecting && num_bytes <= 4) {
+			for (uint32_t i = 0; i < num_bytes; i++) {
+				uint32_t a = (address + i);
+				if (!g_neogeo_is_cd) a ^= 1;
+				uint32_t val = ra_rtquery_read(map, a, 1);
+				buffer[i] = (uint8_t)val;
 			}
 			return num_bytes;
 		}
@@ -72,6 +117,115 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 	if (!client || !game_loaded || !map || !g_neogeo_state.optionc) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
+
+	// ===================================================================
+	// Smart Cache path (Tier 1)
+	// ===================================================================
+	if (achievements_smart_cache_enabled() && g_neogeo_rtquery) {
+
+		if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
+			g_neogeo_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_neogeo_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed) {
+				g_neogeo_state.needs_recollect = 1;
+				g_neogeo_state.resolve_pass = 0;
+				ra_log_write("NeoGeo SmartCache: Bootstrap done, %d addrs\n", ra_snes_addrlist_count());
+			} else {
+				ra_log_write("NeoGeo SmartCache: No addresses collected\n");
+			}
+		} else if (!g_neogeo_state.cache_ready) {
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_neogeo_state.cache_ready = 1;
+				g_neogeo_state.last_resp_frame = 0;
+				g_neogeo_state.game_frames = 0;
+				g_neogeo_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.cache_time);
+				if (g_neogeo_state.needs_recollect)
+					ra_log_write("NeoGeo SmartCache: Cache active (pre-resolve)\n");
+				else
+					ra_log_write("NeoGeo SmartCache: Cache active! %d addrs\n", ra_snes_addrlist_count());
+			}
+		} else if (g_neogeo_state.needs_recollect) {
+			g_neogeo_state.resolve_pass++;
+			g_neogeo_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_neogeo_state.collecting = 0;
+			int changed = ra_snes_addrlist_end_collect(map);
+			if (changed && g_neogeo_state.resolve_pass < 4) {
+				ra_log_write("NeoGeo SmartCache: Resolve pass %d, %d addrs\n",
+					g_neogeo_state.resolve_pass, ra_snes_addrlist_count());
+				g_neogeo_state.cache_ready = 0;
+			} else {
+				g_neogeo_state.needs_recollect = 0;
+				if (changed) g_neogeo_state.cache_ready = 0;
+				ra_log_write("NeoGeo SmartCache: Resolve done, %d addrs\n", ra_snes_addrlist_count());
+			}
+		} else {
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+
+			if (g_neogeo_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
+				g_neogeo_state.cache_reindexing = 0;
+				ra_log_write("NeoGeo SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
+			}
+
+			if (resp_frame > g_neogeo_state.last_resp_frame) {
+				g_neogeo_state.last_resp_frame = resp_frame;
+				g_neogeo_state.game_frames++;
+				ra_frame_processed(resp_frame);
+
+				if (g_neogeo_state.game_frames <= 5)
+					ra_log_write("NeoGeo SmartCache: GameFrame %u (addrs=%d)\n",
+						g_neogeo_state.game_frames, ra_snes_addrlist_count());
+
+				int cleanup_frame = (g_neogeo_state.game_frames % 600 == 0)
+					&& (g_neogeo_state.game_frames > 0)
+					&& !g_neogeo_state.cache_reindexing;
+				if (cleanup_frame) {
+					g_neogeo_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
+
+				rc_client_do_frame(rc_client);
+
+				if (cleanup_frame) {
+					g_neogeo_state.collecting = 0;
+					int old_count = ra_snes_addrlist_count();
+					if (ra_snes_addrlist_end_collect(map)) {
+						int new_count = ra_snes_addrlist_count();
+						ra_log_write("NeoGeo SmartCache: Cleanup %d -> %d\n", old_count, new_count);
+						g_neogeo_state.cache_reindexing = 1;
+					}
+				} else {
+					if (ra_snes_addrlist_has_pending())
+						ra_snes_addrlist_flush_dynamic(map);
+				}
+			}
+		}
+
+		uint32_t milestone = g_neogeo_state.game_frames / 300;
+		if (milestone > 0 && milestone != g_neogeo_state.poll_logged) {
+			g_neogeo_state.poll_logged = milestone;
+			struct timespec now;
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			double elapsed = (now.tv_sec - g_neogeo_state.cache_time.tv_sec)
+				+ (now.tv_nsec - g_neogeo_state.cache_time.tv_nsec) / 1e9;
+			double ms_per_cycle = (g_neogeo_state.game_frames > 0) ?
+				(elapsed * 1000.0 / g_neogeo_state.game_frames) : 0.0;
+			ra_log_write("POLL(NeoGeo%s-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d\n",
+				g_neogeo_is_cd ? "CD" : "",
+				g_neogeo_state.last_resp_frame, g_neogeo_state.game_frames, elapsed, ms_per_cycle,
+				ra_snes_addrlist_count());
+		}
+		return 1;
+	}
+
+	// ===================================================================
+	// Legacy path
+	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
 		// Phase 1: Bootstrap — collect addresses with zeros
@@ -261,11 +415,22 @@ static int neogeo_detect_protocol(void *map)
 		ra_log_write("NeoGeo: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// NeoGeo always uses Option C; detect CD vs MVS for byte-ordering
 	g_neogeo_state.optionc = 1;
 	g_neogeo_is_cd = is_neogeo_cd();
 	ra_log_write("%s FPGA protocol: Option C (selective address reading)\n",
 		g_neogeo_is_cd ? "NeoGeoCD" : "NeoGeo");
+
+	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+		g_neogeo_rtquery = 1;
+		ra_rtquery_init(map);
+		ra_log_write("NeoGeo: Realtime queries supported and ENABLED\n");
+	} else if (ra_rtquery_supported(map)) {
+		g_neogeo_rtquery = 0;
+		ra_log_write("NeoGeo: Realtime queries supported but DISABLED by config\n");
+	} else {
+		g_neogeo_rtquery = 0;
+		ra_log_write("NeoGeo: Realtime queries NOT supported (FPGA v1)\n");
+	}
 	return 1;
 }
 

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -432,5 +432,5 @@ const console_handler_t g_console_psx = {
 	.detect_protocol = psx_detect_protocol,
 	.console_id = 12,  // RC_CONSOLE_PLAYSTATION
 	.name = "PSX",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/achievements_s32x.cpp
+++ b/achievements_s32x.cpp
@@ -197,6 +197,6 @@ const console_handler_t g_console_s32x = {
 .set_hardcore = s32x_set_hardcore,
 .detect_protocol = s32x_detect_protocol,
 .console_id = 10,  // RC_CONSOLE_SEGA_32X
-.name = "S32X",
-.hardcore_protected = 1
+	.name = "S32X",
+	.hardcore_protected = 0
 };

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -182,5 +182,5 @@ const console_handler_t g_console_sms = {
 	.detect_protocol = sms_detect_protocol,
 	.console_id = 11,  // RC_CONSOLE_MASTER_SYSTEM (also handles Game Gear ID 15)
 	.name = "SMS",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -458,5 +458,5 @@ const console_handler_t g_console_snes = {
 	.detect_protocol = snes_detect_protocol,
 	.console_id = 3,  // RC_CONSOLE_SUPER_NINTENDO
 	.name = "SNES",
-	.hardcore_protected = 1
+	.hardcore_protected = 0
 };

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -217,7 +217,6 @@ uint8_t ra_ramread_atari7800_byte(const void *map, uint16_t addr)
 	    (addr >= 0x0040 && addr <= 0x00FF) ||
 	    (addr >= 0x0140 && addr <= 0x01FF)) {
 		uint16_t bram_idx = addr & 0x7FF;
-		if (bram_idx >= 0x80) bram_idx -= 8;
 		return ((const uint8_t *)map + 0x100)[bram_idx];
 	}
 	return 0;
@@ -590,7 +589,24 @@ void ra_rtquery_init(void *map)
         ra_query_ctrl_t *ctrl = (ra_query_ctrl_t *)(base + RA_QUERY_CTRL_OFFSET);
         memset(ctrl, 0, sizeof(*ctrl));
         __sync_synchronize();
+
+        // Signal FPGA that rtquery polling is now needed.
+        // The FPGA reads RA_ARM_CONFIG_OFFSET once per VBlank and starts polling
+        // the query mailbox only when this bit is set. This prevents ~107k unnecessary
+        // DDRAM reads per second on cores where rtquery is enabled but not actively used.
+        base[RA_ARM_CONFIG_OFFSET] |= RA_ARM_CFG_RTQUERY;
+        __sync_synchronize();
+
         RA_DBG("RTQuery: initialized (mailbox at offset 0x%X)", RA_QUERY_CTRL_OFFSET);
+}
+
+void ra_rtquery_disable(void *map)
+{
+        if (!map) return;
+        uint8_t *base = (uint8_t *)map;
+        base[RA_ARM_CONFIG_OFFSET] &= (uint8_t)(~RA_ARM_CFG_RTQUERY);
+        __sync_synchronize();
+        RA_DBG("RTQuery: disabled (FPGA will stop polling query mailbox after next VBlank)");
 }
 
 uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes)

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -57,6 +57,12 @@ typedef struct __attribute__((packed)) {
 // Flag bits
 #define RA_FLAG_BUSY 0x01
 
+// ARM-written config flags at byte offset 0x40 from RA_DDRAM_PHYS_BASE.
+// The ARM sets these bits; the FPGA reads them once per VBlank to gate features.
+// The FPGA never writes this location, so ARM bits persist across VBlanks.
+#define RA_ARM_CONFIG_OFFSET  0x40   // Byte offset from RA_DDRAM_PHYS_BASE
+#define RA_ARM_CFG_RTQUERY    0x01   // Bit 0: FPGA should poll realtime query mailbox
+
 // Maximum regions supported
 #define RA_MAX_REGIONS 4
 
@@ -124,6 +130,7 @@ typedef struct __attribute__((packed)) {
 
 // Realtime query API — generic, works with any Option C core
 void     ra_rtquery_init(void *map);
+void     ra_rtquery_disable(void *map);  // clears RA_ARM_CFG_RTQUERY so FPGA stops polling
 uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes);
 
 // Address request header at ADDRLIST_OFFSET (ARM writes)

--- a/retroachievements.cfg
+++ b/retroachievements.cfg
@@ -1,3 +1,6 @@
+# RetroAchievements configuration file
+
+# RetroAchievements credentials
 username=odelot
 password=
 
@@ -13,8 +16,11 @@ show_progress_popups=1
 # Include achievement name in progress popups (1=yes, 0=no)
 show_progress_name=1
 
-# Enable leaderboard events/tracker popups (1=yes, 0=no)
-leaderboards-enabled=1
+# Show leaderboard update popups (STARTED, FAILED, TRACKER SHOW/UPDATE) (1=yes, 0=no)
+show_leaderboards_updates=1
+
+# Show leaderboard submission popups (SUBMITTED and SCOREBOARD result) (1=yes, 0=no)
+show_leaderboards_submission=1
 
 # Turn on debug logging (1=yes, 0=no)
 debug=0

--- a/retroachievements.cfg
+++ b/retroachievements.cfg
@@ -21,3 +21,6 @@ debug=0
 
 # Enable hardcore mode for supported cores (1=yes, 0=no)
 hardcore=0
+
+# Force hardcore mode on unsupported cores (1=yes, 0=no)
+force_hardcore=0


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the achievements system, focusing on increased configurability for leaderboard popups, enhanced and more robust handling of "hardcore" mode, and optimizations for Game Boy achievements support. The changes also include improved backward compatibility and logging, as well as minor corrections to console handler protection flags.

**Leaderboard Popup Configuration and Backward Compatibility:**

* Introduced two new config options: `show_leaderboards_updates` and `show_leaderboards_submission` to control which leaderboard popups are shown, deprecating the older `leaderboards_enabled` flag. The code now prefers the new flags, but will fall back to the deprecated one if the new ones are absent for backward compatibility. Logging and event handling have been updated to reflect this change. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL193-R197) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR487-R489) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR533-R548) [[4]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR567-R583) [[5]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL786-R810) [[6]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL806-R830) [[7]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL826-R850) [[8]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL852-R876) [[9]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL869-R893) [[10]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL879-R903)

**Hardcore Mode Handling:**

* Added a new `force_hardcore` configuration flag and refactored the logic for determining if hardcore mode is active into a new function `achievements_hardcore_active()`. This ensures that hardcore mode is only enabled when supported by the core or when forced, improving safety and user control. All relevant code paths now use this function. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL193-R197) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR533-R548) [[3]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1150-R1174) [[4]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1195-R1221) [[5]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1345-R1369) [[6]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1673-R1702)

**Game Boy Achievements Optimizations:**

* Added support for "smart cache" and real-time query (RTQuery) optimizations in the Game Boy achievements implementation, including new logic for cache initialization, address collection, and polling. This should improve performance and accuracy of memory reads for achievements. [[1]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR21) [[2]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR50) [[3]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR60) [[4]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR75-R128) [[5]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR142-R228) [[6]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeL200-R353)

**General Stability and Logging:**

* Added logic to disable FPGA query mailbox polling when no game is loaded, preventing unnecessary resource usage. Improved logging throughout the achievements system for better diagnostics.

**Console Handler Corrections:**

* Updated the `hardcore_protected` flag for GBA, Genesis, and MegaCD console handlers to `0`, reflecting that these cores do not currently support hardcore protection. [[1]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1L297-R297) [[2]](diffhunk://#diff-5635bc528a6f5c36f3fe38c38ecffdc2a8517ee6a0142ee490dc79325387878dL352-R352) [[3]](diffhunk://#diff-4c1febe6aefb613053fa5a951b212c1924273a913ff7e4a6dd33c0f15dff0f64L239-R239)