### PR TITLE
Fix issue with fds id

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -1274,12 +1274,12 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
         snprintf(g_rom_path, sizeof(g_rom_path), "%s", rom_path);
 
         // Switch to FDS handler if we are NES and the ROM is an FDS file
-        if (g_active_handler && (g_active_handler->console_id == 7 || g_active_handler->console_id == 91)) {
+        if (g_active_handler && (g_active_handler->console_id == 7 || g_active_handler->console_id == 81)) {
                 size_t len = strlen(rom_path);
                 if (len >= 4 && strcasecmp(rom_path + len - 4, ".fds") == 0) {
                         extern const console_handler_t g_console_fds;
                         g_active_handler = &g_console_fds;
-                        RA_LOG("FDS ROM detected, switching handler to Famicom Disk System (ID 91)");
+                        RA_LOG("FDS ROM detected, switching handler to Famicom Disk System (ID 81)");
                 } else {
                         extern const console_handler_t g_console_nes;
                         g_active_handler = &g_console_nes;

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -82,6 +82,10 @@ const console_handler_t *get_console_handler_by_id(int console_id)
 	if (console_id == 76) {
 		return &g_console_tgfx16;
 	}
+	// Famicom Disk System (ID 81) uses NES handler
+	if (console_id == 81) {
+		return &g_console_nes;
+	}
 
 	return NULL;
 }

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -439,7 +439,7 @@ const console_handler_t g_console_fds = {
 	.calculate_hash = nes_calculate_hash,
 	.set_hardcore = nes_set_hardcore,
 	.detect_protocol = nes_detect_protocol,
-	.console_id = 91,  // RC_CONSOLE_FAMICOM_DISK_SYSTEM
+	.console_id = 81,  // RC_CONSOLE_FAMICOM_DISK_SYSTEM
 	.name = "Famicom Disk System",
 	.hardcore_protected = 1
 };


### PR DESCRIPTION
This pull request updates the way the Famicom Disk System (FDS) is identified and handled in the codebase. The main change is correcting the console ID for FDS from 91 to 81 throughout the relevant files, ensuring consistency and proper handler selection for FDS ROMs.

**Console ID correction and handler updates:**

* Changed the `console_id` for the Famicom Disk System from 91 to 81 in the `g_console_fds` definition in `achievements_nes.cpp`.
* Updated the logic in `achievements_load_game` to check for `console_id == 81` instead of 91 when switching to the FDS handler, and updated the corresponding log message.
* Added a case in `get_console_handler_by_id` in `achievements_console_lookup.cpp` to return the NES handler for `console_id == 81`, reflecting that the FDS uses the NES handler.