### PR TITLE
Play achievement sound with notifications

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -300,6 +300,7 @@ static void ra_play_achievement_sound(void)
 struct ra_notif {
 	char text[NOTIF_TEXT_MAX];
 	int duration_ms;
+	int play_sound;
 };
 
 // Tier 1 — urgent queue
@@ -317,7 +318,7 @@ static int  s_instant_showing = 0;
 static unsigned long s_instant_timer = 0;
 
 // Add to urgent queue (never dropped by instant notifications)
-static void ra_notify_urgent(const char *text, int duration_ms = 4000)
+static void ra_notify_urgent(const char *text, int duration_ms = 4000, int play_sound = 0)
 {
 	int count = s_urgent_head - s_urgent_tail;
 	if (count >= NOTIF_QUEUE_CAP) {
@@ -327,6 +328,7 @@ static void ra_notify_urgent(const char *text, int duration_ms = 4000)
 	ra_notif *n = &s_urgent_queue[s_urgent_head % NOTIF_QUEUE_CAP];
 	snprintf(n->text, NOTIF_TEXT_MAX, "%s", text);
 	n->duration_ms = duration_ms;
+	n->play_sound  = play_sound;
 	s_urgent_head++;
 }
 
@@ -365,6 +367,7 @@ static void ra_osd_poll(void)
 		ra_notif *n = &s_urgent_queue[s_urgent_tail % NOTIF_QUEUE_CAP];
 		s_urgent_tail++;
 		Info(n->text, n->duration_ms + 500, 0, 0, 1);
+		if (n->play_sound) ra_play_achievement_sound();
 		s_urgent_timer    = GetTimer(n->duration_ms);
 		s_urgent_showing  = 1;
 		// Urgent takes over the display — discard any pending instant
@@ -717,6 +720,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 				RA_LOG("*** ACHIEVEMENT TRIGGERED: [%u] %s — %s ***",
 					event->achievement->id, event->achievement->title,
 					event->achievement->description);
+					gba_dump_trigger(event->achievement->id);
 				const int title_max = 28;
 				const int desc_max  = 60;
 				char title_buf[32];
@@ -731,8 +735,7 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 				snprintf(buf, sizeof(buf),
 					">> ACHIEVEMENT <<\n\n%s\n%s",
 					title_buf, desc_buf);
-				ra_notify_urgent(buf, 4000);
-				ra_play_achievement_sound();
+								ra_notify_urgent(buf, 4000, 1);
 			}
 		}
 		break;


### PR DESCRIPTION
This pull request updates the achievement notification system to allow urgent notifications to optionally play a sound, improving the flexibility and clarity of notification handling. The main change is that the decision to play a sound is now controlled by a parameter passed to the notification function, rather than always playing a sound for certain events.

**Notification system improvements:**

* Added a `play_sound` field to the `ra_notif` struct, allowing each urgent notification to specify whether a sound should be played.
* Updated the `ra_notify_urgent` function to accept a `play_sound` parameter (defaulting to 0) and set the new struct field accordingly. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL320-R321) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR331)
* Modified the urgent notification display logic in `ra_osd_poll` to play the achievement sound only if the notification requests it.
* Changed the achievement event handler to pass `play_sound = 1` when an achievement is triggered, instead of calling the sound function separately.

**Debugging/Logging improvements:**

* Added a call to `gba_dump_trigger` when an achievement is triggered, likely for debugging or analytics purposes.