### PR TITLE
feature: clear gba memory before load a new game

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -197,6 +197,7 @@ static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheat
 static int g_force_hardcore            = 0; // 1 = force hardcore mode even if core doesn't support it
 static int g_stall_recovery            = 0; // 1 = enable OptionC stall recovery (disabled by default)
 static int g_rtquery_enabled           = 1; // 1 = enable realtime queries for AddAddress resolution
+static int g_gba_reset_ram             = 1; // 1 = clear IWRAM+EWRAM on game load (retroachievements.cfg: gba_reset_ram)
 static int g_recollect_interval        = 600; // frames between address re-collections (PSX default 600, SNES 18000)
 static int g_smart_cache               = -1; // -1 = default per console, 1 = smart cache: rtquery on cache miss, no periodic recollect
 static int g_n64_snapshot              = 0;  // 1 = snapshot RDRAM at VBlank for consistent reads
@@ -563,6 +564,8 @@ static int ra_load_credentials(void)
 			g_ra_debug = atoi(val);
 		} else if (!strcasecmp(key, "n64_snapshot")) {
 			g_n64_snapshot = atoi(val);
+		} else if (!strcasecmp(key, "gba_reset_ram")) {
+			g_gba_reset_ram = atoi(val);
 		}
 	}
 	fclose(f);
@@ -579,11 +582,11 @@ static int ra_load_credentials(void)
 	}
 
 	RA_LOG("Credentials loaded: user=%s password=***(%zu chars)", g_ra_user, strlen(g_ra_password));
-	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d show_leaderboards_updates=%d show_leaderboards_submission=%d leaderboards_enabled(deprecated)=%d hardcore=%d force_hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d debug=%d",
+	RA_LOG("Config: show_challenge_show=%d show_challenge_hide=%d show_progress=%d show_progress_name=%d show_leaderboards_updates=%d show_leaderboards_submission=%d leaderboards_enabled(deprecated)=%d hardcore=%d force_hardcore=%d stall_recovery=%d rtquery=%d recollect=%d smart_cache=%d n64_snapshot=%d gba_reset_ram=%d debug=%d",
                 g_show_challenge_show_popup, g_show_challenge_hide_popup,
                 g_show_progress_popups, g_show_progress_name,
 		g_show_leaderboards_updates, g_show_leaderboards_submission, g_leaderboards_enabled,
-                g_hardcore, g_force_hardcore, g_stall_recovery, g_rtquery_enabled, g_recollect_interval, g_smart_cache, g_n64_snapshot, g_ra_debug);
+                g_hardcore, g_force_hardcore, g_stall_recovery, g_rtquery_enabled, g_recollect_interval, g_smart_cache, g_n64_snapshot, g_gba_reset_ram, g_ra_debug);
 	return 1;
 }
 
@@ -1713,6 +1716,11 @@ int achievements_stall_recovery_enabled(void)
 int achievements_rtquery_enabled(void)
 {
 	return g_rtquery_enabled;
+}
+
+int achievements_gba_reset_ram(void)
+{
+	return g_gba_reset_ram;
 }
 
 int achievements_recollect_interval(void)

--- a/achievements.h
+++ b/achievements.h
@@ -69,6 +69,7 @@ int achievements_list_count(void);
 void ra_frame_processed(uint32_t frame);
 int achievements_stall_recovery_enabled(void);
 int achievements_rtquery_enabled(void);
+int achievements_gba_reset_ram(void);   // 1 = clear IWRAM+EWRAM on game load (retroachievements.cfg: gba_reset_ram)
 int achievements_recollect_interval(void);
 int achievements_smart_cache_enabled(void);
 int achievements_n64_snapshot_enabled(void);

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -94,4 +94,7 @@ void init_all_console_handlers(void);
 int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                                   const char *console_name);
 
+// GBA: dump valcache when an achievement triggers (call from event handler)
+void gba_dump_trigger(uint32_t ach_id);
+
 #endif // ACHIEVEMENTS_CONSOLE_H

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -20,6 +20,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_gba_state = {};
+static void *g_gba_last_map = NULL;
 
 // ---------------------------------------------------------------------------
 // GBA Option C Diagnostics
@@ -109,6 +110,7 @@ static int gba_poll(void *map, void *client, int game_loaded)
         if (!client || !game_loaded || !map || !g_gba_state.optionc)
                 return 0;
 
+        g_gba_last_map = map;
         rc_client_t *rc_client = (rc_client_t *)client;
 
         if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
@@ -198,6 +200,16 @@ static int gba_poll(void *map, void *client, int game_loaded)
 #endif
 }
 
+void gba_dump_trigger(uint32_t ach_id)
+{
+#ifdef HAS_RCHEEVOS
+        if (!g_gba_last_map) return;
+        char label[32];
+        snprintf(label, sizeof(label), "trigger-%u", ach_id);
+        gba_optionc_dump_valcache(label, g_gba_last_map);
+#endif
+}
+
 static int gba_calculate_hash(const char *rom_path, char *md5_hex_out)
 {
 #ifdef HAS_RCHEEVOS
@@ -276,6 +288,10 @@ static int gba_detect_protocol(void *map)
         // GBA always uses Option C
         g_gba_state.optionc = 1;
         gba_init_flash_ddram();
+        if (achievements_gba_reset_ram())
+                ra_clear_en_set(map);    // FPGA clears IWRAM+EWRAM on each game load
+        else
+                ra_clear_en_clear(map);  // gba_reset_ram=0 in retroachievements.cfg
         ra_log_write("GBA FPGA protocol: Option C (selective address reading)\n");
         return 1;
 }

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -634,6 +634,22 @@ void ra_rtquery_disable(void *map)
         RA_DBG("RTQuery: disabled (FPGA will stop polling query mailbox after next VBlank)");
 }
 
+void ra_clear_en_set(void *map)
+{
+        if (!map) return;
+        uint8_t *base = (uint8_t *)map;
+        base[RA_ARM_CONFIG_OFFSET] |= RA_ARM_CFG_CLEAR_EN;
+        __sync_synchronize();
+}
+
+void ra_clear_en_clear(void *map)
+{
+        if (!map) return;
+        uint8_t *base = (uint8_t *)map;
+        base[RA_ARM_CONFIG_OFFSET] &= (uint8_t)(~RA_ARM_CFG_CLEAR_EN);
+        __sync_synchronize();
+}
+
 uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes)
 {
         if (!map || num_bytes == 0 || num_bytes > 4) return 0;

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -62,6 +62,7 @@ typedef struct __attribute__((packed)) {
 // The FPGA never writes this location, so ARM bits persist across VBlanks.
 #define RA_ARM_CONFIG_OFFSET  0x40   // Byte offset from RA_DDRAM_PHYS_BASE
 #define RA_ARM_CFG_RTQUERY    0x01   // Bit 0: FPGA should poll realtime query mailbox
+#define RA_ARM_CFG_CLEAR_EN   0x02   // Bit 1: FPGA clears IWRAM on ROM load (set by RA)
 
 // Maximum regions supported
 #define RA_MAX_REGIONS 4
@@ -131,6 +132,8 @@ typedef struct __attribute__((packed)) {
 // Realtime query API — generic, works with any Option C core
 void     ra_rtquery_init(void *map);
 void     ra_rtquery_disable(void *map);  // clears RA_ARM_CFG_RTQUERY so FPGA stops polling
+void     ra_clear_en_set(void *map);     // sets   RA_ARM_CFG_CLEAR_EN (FPGA clears IWRAM on game load)
+void     ra_clear_en_clear(void *map);   // clears RA_ARM_CFG_CLEAR_EN
 uint32_t ra_rtquery_read(void *map, uint32_t address, uint32_t num_bytes);
 
 // Address request header at ADDRLIST_OFFSET (ARM writes)

--- a/retroachievements.cfg
+++ b/retroachievements.cfg
@@ -30,3 +30,7 @@ hardcore=0
 
 # Force hardcore mode on unsupported cores (1=yes, 0=no)
 force_hardcore=0
+
+# Clear GBA IWRAM and EWRAM before each game load to prevent stale-RAM false
+# positives in RetroAchievements (1=yes [default], 0=no)
+gba_reset_ram=1


### PR DESCRIPTION
This pull request adds support for a new configuration option, `gba_reset_ram`, which allows users to control whether the GBA IWRAM and EWRAM are cleared on each game load to prevent stale RAM from causing false positives in RetroAchievements. The implementation includes changes to configuration parsing, logging, and the GBA protocol logic, as well as new utility functions for managing the clear enable flag in the FPGA protocol. Additionally, a debug function for dumping the GBA value cache on achievement triggers has been introduced.

**GBA RAM clearing configuration:**

* Added a new global variable `g_gba_reset_ram` and corresponding configuration option `gba_reset_ram` (default enabled) to control whether GBA RAM is cleared on game load (`retroachievements.cfg`). [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR200) [[2]](diffhunk://#diff-4832f30d195dca4d091d2c66d7382b4bf0076532dbad0630cebcb6ffd91d8399R33-R36)
* Updated the configuration loader to parse and log the new `gba_reset_ram` setting. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR567-R568) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL582-R589)
* Added the function `achievements_gba_reset_ram()` to provide access to the configuration value. [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdR1721-R1725) [[2]](diffhunk://#diff-ee4fed7675082f718263a601afeb6b87d598d18d444c81eb28238b646df05eeeR72)

**GBA protocol logic:**

* Modified the GBA protocol initialization to set or clear the FPGA's RAM clear enable flag based on the `gba_reset_ram` configuration, ensuring RAM is cleared or preserved as configured.
* Implemented `ra_clear_en_set()` and `ra_clear_en_clear()` functions for manipulating the FPGA clear enable flag, and defined the new `RA_ARM_CFG_CLEAR_EN` bit. [[1]](diffhunk://#diff-168bd3df9d7d5edadd996021a96d9f5c1a33dc62be067723e1407076439ef609R637-R652) [[2]](diffhunk://#diff-2c00936cd444b2baf06870c1911501bfda3e3142593d075df12017ff5ec370cdR65) [[3]](diffhunk://#diff-2c00936cd444b2baf06870c1911501bfda3e3142593d075df12017ff5ec370cdR135-R136)

**Debugging and diagnostics:**

* Added a new function `gba_dump_trigger()` to dump the GBA value cache when an achievement triggers, which can be called from event handlers for debugging purposes. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R97-R99) [[2]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R203-R212)
* Tracked the last used GBA memory map to support value cache dumping. [[1]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R23) [[2]](diffhunk://#diff-bdfd4e4993426610ccfb4fd2d21d38061c17325ad8324f61d83dc039a56885f1R113)