### PR TITLE
Enable hardcore mode for SNES and Mega Drive

### DIFF
--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -349,5 +349,5 @@ const console_handler_t g_console_genesis = {
 	.detect_protocol = genesis_detect_protocol,
 	.console_id = 1,  // RC_CONSOLE_MEGA_DRIVE
 	.name = "Genesis",
-	.hardcore_protected = 0
+	.hardcore_protected = 1
 };

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -458,5 +458,5 @@ const console_handler_t g_console_snes = {
 	.detect_protocol = snes_detect_protocol,
 	.console_id = 3,  // RC_CONSOLE_SUPER_NINTENDO
 	.name = "SNES",
-	.hardcore_protected = 0
+	.hardcore_protected = 1
 };


### PR DESCRIPTION
This pull request updates the configuration for both the Genesis and SNES console handlers to enable hardcore protection. This change ensures that achievements are now protected in hardcore mode for these consoles.

Configuration updates:

* Set the `hardcore_protected` field to `1` in the `g_console_genesis` handler in `achievements_genesis.cpp`, enabling hardcore protection for Genesis.
* Set the `hardcore_protected` field to `1` in the `g_console_snes` handler in `achievements_snes.cpp`, enabling hardcore protection for SNES.