### PR TITLE
feature: hardcore support for n64 and psx

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -1208,10 +1208,13 @@ void achievements_init(void)
 	// Call handler init — N64 sets DDRAM base here, must happen before ra_ramread_map()
 	g_active_handler->init();
 
-	// Apply hardcore FPGA bits immediately so restrictions are active before any game loads
-	if (achievements_hardcore_active() && g_active_handler->set_hardcore) {
-		g_active_handler->set_hardcore(1);
-		RA_LOG("Hardcore: FPGA bits applied at core init for %s", g_active_handler->name);
+	// Apply the correct hardcore FPGA bits at core init. Must be symmetric: when
+	// hardcore is inactive we clear the bits, otherwise stale restrictions (e.g. a
+	// status bit restored from the core config) keep restore-state blocked.
+	if (g_active_handler->set_hardcore) {
+		int hc = achievements_hardcore_active();
+		g_active_handler->set_hardcore(hc);
+		RA_LOG("Hardcore: FPGA bits %s at core init for %s", hc ? "applied" : "cleared", g_active_handler->name);
 	}
 
 #ifdef HAS_RCHEEVOS
@@ -1403,10 +1406,12 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
 
         RA_LOG("--- Game Load Complete, monitoring frames ---");
 
-        // Hardcore mode: let handler set console-specific FPGA bits
-        if (achievements_hardcore_active() && g_active_handler->set_hardcore) {
-                g_active_handler->set_hardcore(1);
-                RA_LOG("Hardcore: FPGA bits applied for %s", g_active_handler->name);
+        // Hardcore mode: let handler set console-specific FPGA bits (symmetric:
+        // clear them when hardcore is inactive so restore-state is re-enabled).
+        if (g_active_handler->set_hardcore) {
+                int hc = achievements_hardcore_active();
+                g_active_handler->set_hardcore(hc);
+                RA_LOG("Hardcore: FPGA bits %s for %s", hc ? "applied" : "cleared", g_active_handler->name);
         }
 }
 

--- a/achievements_n64.cpp
+++ b/achievements_n64.cpp
@@ -247,5 +247,5 @@ const console_handler_t g_console_n64 = {
 	.detect_protocol = n64_detect_protocol,
 	.console_id = 2,  // RC_CONSOLE_NINTENDO_64
 	.name = "N64",
-	.hardcore_protected = 0
+	.hardcore_protected = 1
 };

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -404,9 +404,9 @@ static int nes_calculate_hash(const char *rom_path, char *md5_hex_out)
 static void nes_set_hardcore(int enabled)
 {
 	if (enabled) {
-		user_io_status_set("[70]", 1);  // Disable cheats
-		user_io_status_set("[20]", 1);  // Disable save states
-		ra_log_write("NES: Hardcore mode enabled (cheats/states disabled)\n");
+		user_io_status_set("[70]", 1);  // hardcore master: blocks restore-state (save-state stays enabled), disables cheats
+		user_io_status_set("[20]", 1);  // Cheats Enabled OSD toggle -> Off
+		ra_log_write("NES: Hardcore mode enabled (restore-state/cheats disabled, save-state still allowed)\n");
 	} else {
 		user_io_status_set("[70]", 0);
 		user_io_status_set("[20]", 0);

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -718,5 +718,5 @@ const console_handler_t g_console_psx = {
 	.detect_protocol = psx_detect_protocol,
 	.console_id = 12,  // RC_CONSOLE_PLAYSTATION
 	.name = "PSX",
-	.hardcore_protected = 0
+	.hardcore_protected = 1
 };


### PR DESCRIPTION
This pull request improves the handling of "hardcore" mode restrictions for achievements across multiple emulator cores, ensuring that restrictions are applied and cleared symmetrically when hardcore mode is toggled. It also updates the protection status for N64 and PSX consoles and clarifies the behavior of hardcore mode for NES.

**Hardcore mode restriction handling:**

* Updated both `achievements_init` and `achievements_load_game` to symmetrically apply or clear hardcore FPGA bits based on the current mode, preventing stale restrictions and ensuring restore-state is properly enabled or disabled. Log messages now indicate whether bits are "applied" or "cleared". [[1]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1211-R1217) [[2]](diffhunk://#diff-552792ddef7f6cf8e62d29c453541e394f68812d44ee24564240ff478bf7e3bdL1406-R1414)

**Console handler protection status:**

* Set `hardcore_protected` to `1` for both the N64 and PSX console handlers, indicating these systems now enforce hardcore restrictions. (`achievements_n64.cpp`, `achievements_psx.cpp`) [[1]](diffhunk://#diff-2e2e43bd0804815caa8ed2df42f77d559cf085ee37ba2fd5cb0de0f57e89a774L250-R250) [[2]](diffhunk://#diff-eab83b801263e7e8c9ecc8f83920bc0b96b554a2ac8d19b497018926f86c2146L721-R721)

**NES hardcore mode behavior clarification:**

* Clarified that in NES hardcore mode, restore-state is blocked and cheats are disabled, but save-state remains allowed. Updated log messages and comments to reflect this behavior. (`achievements_nes.cpp`)