### PR TITLE
Feature/fix reset

### DIFF
--- a/achievements.cpp
+++ b/achievements.cpp
@@ -203,6 +203,12 @@ static int g_recollect_interval        = 600; // frames between address re-colle
 static int g_smart_cache               = -1; // -1 = default per console, 1 = smart cache: rtquery on cache miss, no periodic recollect
 static int g_n64_snapshot              = 0;  // 1 = snapshot RDRAM at VBlank for consistent reads
 static int g_multiline_desc            = 0;  // 1 = wrap long text to extra lines instead of truncating with "..."
+
+// Debug watch list (retroachievements.cfg: watch=19807d,19795a — RA addresses
+// in hex). Handlers log every value change of these addresses per frame.
+#define RA_WATCH_MAX 16
+static uint32_t g_watch_addrs[RA_WATCH_MAX];
+static int g_watch_count = 0;
 static char g_ua_clause[64]            = ""; // rcheevos user-agent clause (e.g. "rcheevos/11.6")
 static char g_fpga_core_version[8]     = "0.1"; // version reported by FPGA in DDRAM header
 
@@ -590,6 +596,17 @@ static int ra_load_credentials(void)
 			g_gba_reset_ram = atoi(val);
 		} else if (!strcasecmp(key, "multiline_desc")) {
 			g_multiline_desc = atoi(val);
+		} else if (!strcasecmp(key, "watch")) {
+			g_watch_count = 0;
+			const char *p = val;
+			while (*p && g_watch_count < RA_WATCH_MAX) {
+				char *end;
+				unsigned long a = strtoul(p, &end, 16);
+				if (end == p) break;
+				g_watch_addrs[g_watch_count++] = (uint32_t)a;
+				p = end;
+				while (*p == ',' || *p == ' ') p++;
+			}
 		}
 	}
 	fclose(f);
@@ -1865,6 +1882,12 @@ int achievements_smart_cache_enabled(void)
 int achievements_n64_snapshot_enabled(void)
 {
 	return g_n64_snapshot;
+}
+
+int achievements_watch_list(const uint32_t **addrs)
+{
+	if (addrs) *addrs = g_watch_addrs;
+	return g_watch_count;
 }
 
 void achievements_info(void)

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -769,15 +769,20 @@ static void ra_event_handler(const rc_client_event_t *event, rc_client_t *client
 					event->achievement->description);
 					gba_dump_trigger(event->achievement->id);
 				char title_buf[96];
-				char desc_buf[192];
 				ra_format_text(event->achievement->title, title_buf, sizeof(title_buf), 28, 28, 2);
-				ra_format_text(event->achievement->description, desc_buf, sizeof(desc_buf), 28, 28, 3);
-				// In multiline mode, prefix desc with "\-> " so it reads as a sub-line of the title
+				// In multiline mode, prefix desc with "\-> " so it reads as a
+				// sub-line of the title. The prefix is added BEFORE wrapping so
+				// its 4 chars count toward the first line's width (adding it
+				// after wrapping pushed the first line past the OSD width).
 				char desc_display[200];
-				if (g_multiline_desc)
-					snprintf(desc_display, sizeof(desc_display), "\\-> %s", desc_buf);
-				else
-					snprintf(desc_display, sizeof(desc_display), "%s", desc_buf);
+				if (g_multiline_desc) {
+					char desc_prefixed[224];
+					snprintf(desc_prefixed, sizeof(desc_prefixed), "\\-> %s",
+						event->achievement->description);
+					ra_format_text(desc_prefixed, desc_display, sizeof(desc_display), 28, 28, 3);
+				} else {
+					ra_format_text(event->achievement->description, desc_display, sizeof(desc_display), 28, 28, 3);
+				}
 				char buf[NOTIF_TEXT_MAX];
 				snprintf(buf, sizeof(buf),
 					">> ACHIEVEMENT <<\n\n%s\n%s",

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <netdb.h>
@@ -273,8 +274,28 @@ static void *ra_play_thread(void *arg)
 {
 	(void)arg;
 	// Only play if the file exists — silent no-op otherwise
-	if (access(RA_SFX_PATH, R_OK) == 0)
-		system("aplay -q " RA_SFX_PATH " 2>/dev/null");
+	if (access(RA_SFX_PATH, R_OK) != 0) return NULL;
+
+	// fork/exec instead of system(): on cores built with MISTER_DISABLE_ALSA
+	// (e.g. N64, PSX) the FPGA never drains the ALSA ring buffer, so aplay
+	// blocks forever and every unlock would leak a process + thread. Kill it
+	// after a timeout instead.
+	pid_t pid = fork();
+	if (pid == 0) {
+		int fd = open("/dev/null", O_RDWR);
+		if (fd >= 0) { dup2(fd, 1); dup2(fd, 2); if (fd > 2) close(fd); }
+		execlp("aplay", "aplay", "-q", RA_SFX_PATH, (char *)NULL);
+		_exit(127);
+	}
+	if (pid < 0) return NULL;
+
+	// The jingle lasts ~1s; allow 5s before declaring aplay stuck.
+	for (int i = 0; i < 50; i++) {
+		if (waitpid(pid, NULL, WNOHANG) == pid) return NULL;
+		usleep(100000);
+	}
+	kill(pid, SIGKILL);
+	waitpid(pid, NULL, 0);
 	return NULL;
 }
 
@@ -620,15 +641,45 @@ static void ra_format_text(const char *text, char *out, size_t out_size, int tru
 		for (int line = 0; line < max_lines && pos < len && written + 1 < out_size; line++) {
 			if (line > 0) { out[written++] = '\n'; out[written] = '\0'; }
 			size_t take = len - pos;
-			if (take > (size_t)wrap_width) take = (size_t)wrap_width;
+			if (take > (size_t)wrap_width) {
+				take = (size_t)wrap_width;
+				// Word wrap: if the cut lands inside a word, break at the last
+				// space instead so the whole word moves to the next line.
+				// (A single word longer than the line still hard-breaks.)
+				if (text[pos + take] != ' ') {
+					size_t s = take;
+					while (s > 0 && text[pos + s - 1] != ' ') s--;
+					if (s > 0) take = s;
+				}
+			}
 			size_t avail = out_size - written - 1;
 			if (take > avail) take = avail;
 			memcpy(out + written, text + pos, take);
+			// Drop trailing spaces from the line end
+			while (take > 0 && out[written + take - 1] == ' ') take--;
 			written += take;
 			out[written] = '\0';
 			pos += take;
+			// Skip spaces at the start of the next line
+			while (pos < len && text[pos] == ' ') pos++;
 		}
-		if (pos < len && written + 3 < out_size) strcat(out, "...");
+		if (pos < len && written + 3 < out_size) {
+			// The "..." must also fit in wrap_width: shrink the last line to
+			// wrap_width-3, preferring a word boundary.
+			size_t line_start = written;
+			while (line_start > 0 && out[line_start - 1] != '\n') line_start--;
+			size_t line_len = written - line_start;
+			if (line_len + 3 > (size_t)wrap_width) {
+				size_t keep = (size_t)wrap_width - 3;
+				size_t s = keep;
+				while (s > 0 && out[line_start + s - 1] != ' ') s--;
+				if (s > 0) keep = s;
+				while (keep > 0 && out[line_start + keep - 1] == ' ') keep--;
+				written = line_start + keep;
+				out[written] = '\0';
+			}
+			strcat(out, "...");
+		}
 	}
 }
 

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -670,12 +670,15 @@ static void ra_server_call(const rc_api_request_t *request,
 {
 	(void)client;
 
-	// Log the request (mask token for security)
+	// Log the request (mask token and password for security)
 	if (request->post_data) {
 		const char *token_pos = strstr(request->post_data, "&t=");
-		if (token_pos) {
-			int prefix_len = (int)(token_pos - request->post_data);
-			RA_LOG("HTTP: POST %s [%.*s&t=***]", request->url, prefix_len, request->post_data);
+		const char *pass_pos  = strstr(request->post_data, "&p=");
+		const char *mask_pos  = token_pos ? token_pos : pass_pos;
+		const char *mask_key  = token_pos ? "&t=" : "&p=";
+		if (mask_pos) {
+			int prefix_len = (int)(mask_pos - request->post_data);
+			RA_LOG("HTTP: POST %s [%.*s%s***]", request->url, prefix_len, request->post_data, mask_key);
 		} else {
 			RA_LOG("HTTP: POST %s [%.80s%s]", request->url,
 				request->post_data, strlen(request->post_data) > 80 ? "..." : "");
@@ -1311,6 +1314,18 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
         RA_LOG("ROM path: %s", rom_path);
         RA_LOG("CRC32: %08X", crc32);
 
+#ifdef HAS_RCHEEVOS
+        // Switching game without a core restart: drop the previous rc_client
+        // session (also aborts an in-flight async load) before loading the new
+        // one, so unlock state/deltas from the old game can't leak into it.
+        if (g_client && (g_game_loaded || g_game_load_pending)) {
+                RA_LOG("Previous game session active -- unloading before new load");
+                rc_client_unload_game(g_client);
+                g_game_loaded = 0;
+                g_game_load_pending = 0;
+        }
+#endif
+
         // Store ROM path
         snprintf(g_rom_path, sizeof(g_rom_path), "%s", rom_path);
 
@@ -1324,6 +1339,18 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
                 } else {
                         extern const console_handler_t g_console_nes;
                         g_active_handler = &g_console_nes;
+                }
+        }
+
+        // Shared ATARI7800 core runs both consoles: .a78 ROMs use the 7800
+        // handler (4KB RAM mirror, ID 51), everything else the 2600 one (RIOT).
+        if (g_active_handler && (g_active_handler->console_id == 25 || g_active_handler->console_id == 51)) {
+                size_t len = strlen(rom_path);
+                if (len >= 4 && strcasecmp(rom_path + len - 4, ".a78") == 0) {
+                        g_active_handler = &g_console_atari7800;
+                        RA_LOG("A78 ROM detected, switching handler to Atari 7800 (ID 51)");
+                } else {
+                        g_active_handler = &g_console_atari2600;
                 }
         }
 

--- a/achievements.h
+++ b/achievements.h
@@ -74,4 +74,9 @@ int achievements_recollect_interval(void);
 int achievements_smart_cache_enabled(void);
 int achievements_n64_snapshot_enabled(void);
 
+// Debug watch list from retroachievements.cfg (watch=<hex>,<hex>,...).
+// Returns the count and sets *addrs to the RA-address array. Console handlers
+// log every per-frame value change of these addresses.
+int achievements_watch_list(const uint32_t **addrs);
+
 #endif // ACHIEVEMENTS_H

--- a/achievements_atari7800.cpp
+++ b/achievements_atari7800.cpp
@@ -1,0 +1,299 @@
+// achievements_atari7800.cpp -- RetroAchievements Atari 7800 handler
+//
+// The Atari 7800 core shares the "ATARI7800" MiSTer core with the Atari 2600.
+// When the loaded ROM is a .a78 file, achievements.cpp switches g_active_handler
+// to this handler (console_id=51, RC_CONSOLE_ATARI_7800).
+//
+// DDRAM memory map (set by ra_7800_mirror.sv):
+//   map + 0x0000 : RACH header (magic, region_count=2, flags, version)
+//   map + 0x0008 : frame_counter + reserved
+//   map + 0x0010 : region 0 descriptor (size=2048, ddram_offset=0x0100)
+//   map + 0x0018 : region 1 descriptor (size=2048, ddram_offset=0x0900)
+//   map + 0x0100 : ram0 (2048 bytes) -- CPU $2000-$27FF
+//   map + 0x0900 : ram1 (2048 bytes) -- CPU $1800-$1FFF
+//
+// Address mapping for rcheevos (hardware address -> BRAM index -> map offset):
+//   $2000-$27FF  ->  BRAM[addr & 0x7FF]  ->  map + 0x100 + (addr & 0x7FF)
+//   $0040-$00FF  ->  BRAM[addr & 0x7FF]  ->  map + 0x100 + (addr & 0x7FF)  (zero-page mirror)
+//   $0140-$01FF  ->  BRAM[addr & 0x7FF]  ->  map + 0x100 + (addr & 0x7FF)  (stack mirror)
+//   $1800-$1FFF  ->  BRAM[addr & 0x7FF]  ->  map + 0x900 + (addr & 0x7FF)
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "lib/md5/md5.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_consoles.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// Atari 7800 hash calculation
+//
+// The RetroAchievements database hashes Atari 7800 ROMs by stripping the
+// 128-byte .a78 header (if present) and computing MD5 of the remaining data.
+// The header is identified by the 9-byte magic "ATARI7800" at byte offset 1.
+// This matches the algorithm in rcheevos rc_hash_7800().
+// ---------------------------------------------------------------------------
+static int atari7800_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+    // rom_path is usually relative to the MiSTer root (e.g. "games/ATARI7800/x.a78")
+    char abs_path[1024];
+    if (rom_path[0] == '/') {
+        snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
+    } else {
+        extern const char *getRootDir(void);
+        snprintf(abs_path, sizeof(abs_path), "%s/%s", getRootDir(), rom_path);
+    }
+
+    FILE *f = fopen(abs_path, "rb");
+    if (!f) {
+        ra_log_write("ATARI7800: Failed to open ROM: %s\n", abs_path);
+        return 0;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    if (file_size <= 0) {
+        fclose(f);
+        return 0;
+    }
+
+    uint8_t *rom_data = (uint8_t *)malloc((size_t)file_size);
+    if (!rom_data) {
+        fclose(f);
+        return 0;
+    }
+
+    size_t nread = fread(rom_data, 1, (size_t)file_size, f);
+    fclose(f);
+
+    if ((long)nread != file_size) {
+        free(rom_data);
+        return 0;
+    }
+
+    // Strip 128-byte header if the .a78 magic is present at offset 1
+    const uint8_t *hash_data = rom_data;
+    size_t hash_size = (size_t)file_size;
+    if (file_size > 128 && memcmp(rom_data + 1, "ATARI7800", 9) == 0) {
+        ra_log_write("ATARI7800: .a78 header detected, skipping 128 bytes\n");
+        hash_data = rom_data + 128;
+        hash_size = (size_t)file_size - 128;
+    }
+
+    MD5_CTX ctx;
+    MD5Init(&ctx);
+    MD5Update(&ctx, (unsigned char *)hash_data, hash_size);
+    unsigned char md5_bin[16];
+    MD5Final(md5_bin, &ctx);
+
+    for (int i = 0; i < 16; i++)
+        sprintf(&md5_hex_out[i * 2], "%02x", md5_bin[i]);
+    md5_hex_out[32] = '\0';
+
+    ra_log_write("ATARI7800: hash=%s (rom_size=%ld, hashed=%zu)\n",
+                 md5_hex_out, file_size, hash_size);
+
+    free(rom_data);
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Memory read
+// ---------------------------------------------------------------------------
+static uint8_t s_last_20c4 = 0xFF;
+static uint8_t s_last_205b = 0xFF;
+
+static uint32_t atari7800_read_memory(void *map, uint32_t address,
+                                       uint8_t *buffer, uint32_t num_bytes)
+{
+    uint32_t r = ra_ramread_atari7800_read(map, address, buffer, num_bytes);
+    // Spy on 0x20C4 (hammer state) and 0x205B (ResetIf guard) for debugging
+    if (address <= 0x20C4 && address + num_bytes > 0x20C4) {
+        uint8_t v = buffer[0x20C4 - address];
+        if (v != s_last_20c4) {
+            ra_log_write("A7800 READ 0x20C4: %02X->%02X  0x205B=%02X\n",
+                         s_last_20c4, v, s_last_205b);
+            s_last_20c4 = v;
+        }
+    }
+    if (address <= 0x205B && address + num_bytes > 0x205B) {
+        uint8_t v = buffer[0x205B - address];
+        if (v != s_last_205b) {
+            ra_log_write("A7800 READ 0x205B: %02X->%02X  0x20C4=%02X\n",
+                         s_last_205b, v, s_last_20c4);
+            s_last_205b = v;
+        }
+    }
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Protocol detection
+// ---------------------------------------------------------------------------
+static int atari7800_detect_protocol(void *map)
+{
+    if (!ra_ramread_active(map)) {
+        ra_log_write("ATARI7800: FPGA mirror not detected\n");
+        return 0;
+    }
+    uint8_t region_count = ((const uint8_t *)map)[4];
+    if (region_count != 2) {
+        ra_log_write("ATARI7800: Expected region_count=2, got %u -- "
+                     "FPGA may not have 7800 mirror support\n", region_count);
+        return 0;
+    }
+    ra_log_write("ATARI7800: Protocol OK (region_count=%u)\n", region_count);
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Poll
+// Returns 1 so the default loop is suppressed: rc_client_do_frame is called
+// here only on REAL frame transitions, never from the idle path.
+// This prevents idle calls from consuming delta conditions prematurely.
+// ---------------------------------------------------------------------------
+static uint32_t s_last_frame = 0xFFFFFFFF;
+static uint32_t s_poll_count = 0;
+static uint8_t  s_last_ram0[2048];  // snapshot from previous frame
+
+// Vblank interval tracking (file-level so atari7800_reset() can clear them)
+static struct timespec s_last_vblank    = {0, 0};
+static long   s_vblank_min_us           = 100000L;
+static long   s_vblank_max_us           = 0L;
+static long   s_vblank_sum_us           = 0L;
+static uint32_t s_vblank_count          = 0;
+static uint32_t s_do_frame_count        = 0;
+
+static int atari7800_poll(void *map, void *client, int game_loaded)
+{
+    s_poll_count++;
+
+    const uint8_t *b = (const uint8_t *)map;
+
+    if (!b) return 1;
+
+    uint32_t frame_ctr = b[8]  | ((uint32_t)b[9] << 8)
+                       | ((uint32_t)b[10] << 16) | ((uint32_t)b[11] << 24);
+
+    int frame_changed = (frame_ctr != s_last_frame);
+
+    if (frame_changed) {
+        s_last_frame = frame_ctr;
+
+        // --- Vblank interval measurement ---
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (s_last_vblank.tv_sec != 0 || s_last_vblank.tv_nsec != 0) {
+            long us = (long)(now.tv_sec  - s_last_vblank.tv_sec)  * 1000000L
+                     + (now.tv_nsec - s_last_vblank.tv_nsec) / 1000L;
+            if (us < s_vblank_min_us) s_vblank_min_us = us;
+            if (us > s_vblank_max_us) s_vblank_max_us = us;
+            s_vblank_sum_us += us;
+            s_vblank_count++;
+            // Log anomalies immediately (>25ms or <8ms for ~60Hz signal)
+            if (us > 25000L || us < 8000L)
+                ra_log_write("A7800 VBLANK_ANOMALY: frame=%u interval=%ldus(%.1fHz)\n",
+                             frame_ctr, us, us > 0 ? 1000000.0 / us : 0.0);
+            // Log summary every 60 frames (~1 second)
+            if ((s_vblank_count % 60) == 0) {
+                ra_log_write("A7800 TIMING[%u]: avg=%.0fus(%.1fHz) min=%ldus max=%ldus do_frame=%u\n",
+                             s_vblank_count,
+                             (double)s_vblank_sum_us / s_vblank_count,
+                             60000000.0 / (double)s_vblank_sum_us,
+                             s_vblank_min_us, s_vblank_max_us, s_do_frame_count);
+                s_vblank_min_us = 100000L; s_vblank_max_us = 0L;
+                s_vblank_sum_us = 0L;      s_do_frame_count = 0;
+            }
+        }
+        s_last_vblank = now;
+
+        // --- RAM delta logging ---
+        const uint8_t *ram0 = b + 0x100;
+
+        // Build compact delta line: "[IDX]old>new ..."
+        // Buffer: each entry is " [XXX]XX>XX" = 12 chars, max ~340 entries
+        char delta_buf[4096];
+        int  delta_len    = 0;
+        int  changed_count = 0;
+
+        for (int i = 0; i < 2048 && delta_len < 3800; i++) {
+            if (ram0[i] != s_last_ram0[i]) {
+                delta_len += snprintf(delta_buf + delta_len,
+                                      (int)sizeof(delta_buf) - delta_len,
+                                      " [%03X]%02X>%02X",
+                                      i, s_last_ram0[i], ram0[i]);
+                changed_count++;
+            }
+        }
+
+        if (changed_count > 0)
+            ra_log_write("A7800 frame=%u chg=%d:%s\n",
+                         frame_ctr, changed_count, delta_buf);
+
+        memcpy(s_last_ram0, ram0, 2048);
+
+        // --- rc_client_do_frame: only on real frame transitions ---
+        // NOTE: we return 1 to suppress the default loop's idle calls.
+        // Idle calls between FPGA frames risk reading mid-frame CPU state.
+#ifdef HAS_RCHEEVOS
+        if (game_loaded && client) {
+            s_do_frame_count++;
+            rc_client_do_frame((rc_client_t *)client);
+        }
+#endif
+    }
+
+    return 1;  // suppress default idle rc_client_do_frame calls
+}
+
+// ---------------------------------------------------------------------------
+// Init / reset
+// ---------------------------------------------------------------------------
+static void atari7800_init(void)
+{
+    // nothing
+}
+
+static void atari7800_reset(void)
+{
+    s_last_frame     = 0xFFFFFFFF;
+    s_last_20c4      = 0xFF;
+    s_last_205b      = 0xFF;
+    memset(s_last_ram0, 0, sizeof(s_last_ram0));
+    s_last_vblank.tv_sec  = 0;
+    s_last_vblank.tv_nsec = 0;
+    s_vblank_min_us  = 100000L;
+    s_vblank_max_us  = 0L;
+    s_vblank_sum_us  = 0L;
+    s_vblank_count   = 0;
+    s_do_frame_count = 0;
+}
+
+static void atari7800_set_hardcore(int enabled)
+{
+    (void)enabled;  // no FPGA hardcore bits for 7800
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+const console_handler_t g_console_atari7800 = {
+    .init             = atari7800_init,
+    .reset            = atari7800_reset,
+    .read_memory      = atari7800_read_memory,
+    .poll             = atari7800_poll,
+    .calculate_hash   = atari7800_calculate_hash,
+    .set_hardcore     = atari7800_set_hardcore,
+    .detect_protocol  = atari7800_detect_protocol,
+    .console_id       = 51,    // RC_CONSOLE_ATARI_7800
+    .name             = NULL,  // Not registered by name; switched via .a78 extension
+    .hardcore_protected = 0,
+};

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -75,6 +75,8 @@ extern const console_handler_t g_console_neogeo;
 extern const console_handler_t g_console_gba;
 extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
+extern const console_handler_t g_console_atari7800; // not in lookup table: switched by .a78 extension
+extern const console_handler_t g_console_saturn;
 extern const console_handler_t g_console_tgfx16;
 extern const console_handler_t g_console_s32x;
 
@@ -93,6 +95,16 @@ void init_all_console_handlers(void);
 // Requires: achievements_stall_recovery_enabled() from achievements.h
 int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                                   const char *console_name);
+
+// Shared OptionC backward-frame resync.
+// Call right after reading resp_frame, before comparing it to last_resp_frame.
+// If the FPGA frame counter went backward (core was reset without the ARM
+// being notified — e.g. savestate load, download reset, PAL/NTSC switch, or a
+// stale post-reset response), resyncs last_resp_frame so tracking resumes on
+// the next VBlank instead of stalling until the counter catches up.
+// Returns 1 if a resync happened.
+int optionc_resync_if_backward(console_state_t *state, uint32_t resp_frame,
+                                const char *console_name);
 
 // GBA: dump valcache when an achievement triggers (call from event handler)
 void gba_dump_trigger(uint32_t ach_id);

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -18,6 +18,7 @@ extern const console_handler_t g_console_megacd;
 extern const console_handler_t g_console_atari2600;
 extern const console_handler_t g_console_tgfx16;
 extern const console_handler_t g_console_s32x;
+extern const console_handler_t g_console_saturn;
 
 // Master lookup table
 static const console_handler_t *g_console_handlers[] = {
@@ -34,6 +35,7 @@ static const console_handler_t *g_console_handlers[] = {
 	&g_console_atari2600,
 	&g_console_tgfx16,
 	&g_console_s32x,
+	&g_console_saturn,
 	NULL
 };
 
@@ -126,6 +128,20 @@ int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                 ra_snes_addrlist_init();
                 clock_gettime(CLOCK_MONOTONIC, &state->stall_time);
                 state->stall_frame = 0;
+                return 1;
+        }
+        return 0;
+}
+
+int optionc_resync_if_backward(console_state_t *state, uint32_t resp_frame,
+                                const char *console_name)
+{
+        if (resp_frame < state->last_resp_frame) {
+                ra_log_write("%s OptionC: resp_frame went backward (%u -> %u) -- FPGA reset without notify, resyncing\n",
+                        console_name, state->last_resp_frame, resp_frame);
+                state->last_resp_frame = resp_frame;
+                clock_gettime(CLOCK_MONOTONIC, &state->stall_time);
+                state->stall_frame = resp_frame;
                 return 1;
         }
         return 0;

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -165,6 +165,7 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
 
 			if (g_gb_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
 				g_gb_state.cache_reindexing = 0;
@@ -252,6 +253,7 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
 		if (resp_frame > g_gb_state.last_resp_frame) {
 			g_gb_state.last_resp_frame = resp_frame;
 			g_gb_state.game_frames++;

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -141,6 +141,7 @@ static int gba_poll(void *map, void *client, int game_loaded)
         } else {
                 // Normal frame processing from cache
                 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+                optionc_resync_if_backward(&g_gba_state, resp_frame, "GBA");
                 if (resp_frame > g_gba_state.last_resp_frame) {
                         g_gba_state.last_resp_frame = resp_frame;
                         g_gba_state.game_frames++;

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -137,6 +137,7 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_md_state, resp_frame, "Genesis");
 
 			if (g_md_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
 				g_md_state.cache_reindexing = 0;
@@ -232,6 +233,7 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_md_state, resp_frame, "Genesis");
 		if (resp_frame > g_md_state.last_resp_frame) {
 			g_md_state.last_resp_frame = resp_frame;
 			g_md_state.game_frames++;

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -93,6 +93,7 @@ static int megacd_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_mcd_state, resp_frame, "MegaCD");
 		if (resp_frame > g_mcd_state.last_resp_frame) {
 			g_mcd_state.last_resp_frame = resp_frame;
 			g_mcd_state.game_frames++;

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -166,6 +166,7 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
 
 			if (g_neogeo_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
 				g_neogeo_state.cache_reindexing = 0;
@@ -289,6 +290,7 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Phase 5: Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
 		if (resp_frame > g_neogeo_state.last_resp_frame) {
 			g_neogeo_state.last_resp_frame = resp_frame;
 			g_neogeo_state.game_frames++;

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -155,6 +155,7 @@ static int nes_poll(void *map, void *client, int game_loaded)
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_nes_state, resp_frame, "NES");
 
 			if (g_nes_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
 				g_nes_state.cache_reindexing = 0;
@@ -243,6 +244,7 @@ static int nes_poll(void *map, void *client, int game_loaded)
 		}
 	} else {
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_nes_state, resp_frame, "NES");
 		if (resp_frame > g_nes_state.last_resp_frame) {
 			g_nes_state.last_resp_frame = resp_frame;
 			g_nes_state.game_frames++;

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -367,6 +367,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory via rtquery
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_psx_state, resp_frame, "PSX");
 
 			// Check if FPGA responded after cleanup reindex
 			if (g_psx_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
@@ -556,6 +557,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Phase 5: Normal frame processing
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_psx_state, resp_frame, "PSX");
 		if (resp_frame > g_psx_state.last_resp_frame) {
 			g_psx_state.last_resp_frame = resp_frame;
 			g_psx_state.game_frames++;

--- a/achievements_s32x.cpp
+++ b/achievements_s32x.cpp
@@ -92,6 +92,7 @@ ra_log_write("S32X ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
 } else {
 // Normal frame processing from cache
 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+optionc_resync_if_backward(&g_s32x_state, resp_frame, "S32X");
 if (resp_frame > g_s32x_state.last_resp_frame) {
 g_s32x_state.last_resp_frame = resp_frame;
 g_s32x_state.game_frames++;

--- a/achievements_saturn.cpp
+++ b/achievements_saturn.cpp
@@ -1,0 +1,263 @@
+// achievements_saturn.cpp — RetroAchievements Saturn-specific implementation
+//
+// Memory layout in DDR3 (accessible via shmem_map):
+//   RAML (Work RAM Low,  1MB): physical 0x30000000
+//   RAMH (Work RAM High, 1MB): physical 0x30300000
+//
+// Byte order: Saturn is big-endian. The ddram.sv arbiter stores data MSB
+// at the highest byte address within each 8-byte DDR3 word, so:
+//   rcheevos byte at offset K → DDR3 byte at offset (K ^ 7)
+//
+// rcheevos Saturn memory map (RC_CONSOLE_SATURN = 39):
+//   0x000000–0x0FFFFF: Work RAM Low  (1MB)
+//   0x100000–0x1FFFFF: Work RAM High (1MB)
+
+#include "achievements_console.h"
+#include "achievements.h"
+#include "ra_ramread.h"
+#include "user_io.h"
+#include "shmem.h"
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef HAS_RCHEEVOS
+#include "rc_client.h"
+#include "rc_consoles.h"
+#include "rc_hash.h"
+#endif
+
+// ---------------------------------------------------------------------------
+// Saturn constants
+// ---------------------------------------------------------------------------
+
+#define SATURN_RAML_PHYS     0x30000000u
+#define SATURN_RAML_SIZE     0x00100000u  // 1MB Work RAM Low
+#define SATURN_RAMH_PHYS     0x30300000u
+#define SATURN_RAMH_SIZE     0x00100000u  // 1MB Work RAM High
+
+// rcheevos memory window boundaries
+#define SATURN_RA_RAML_END   0x0FFFFFu   // 1MB Work RAM Low window end
+#define SATURN_RA_RAMH_START 0x100000u
+#define SATURN_RA_RAMH_END   0x1FFFFFu
+
+// ---------------------------------------------------------------------------
+// Saturn state
+// ---------------------------------------------------------------------------
+
+static console_state_t g_saturn_state = {};
+static void *g_saturn_raml = NULL;  // mmap of physical 0x30000000, 256KB
+static void *g_saturn_ramh = NULL;  // mmap of physical 0x30300000, 1MB
+
+// ---------------------------------------------------------------------------
+// Saturn implementation
+// ---------------------------------------------------------------------------
+
+static void saturn_init(void)
+{
+        memset(&g_saturn_state, 0, sizeof(g_saturn_state));
+        g_saturn_raml = NULL;
+        g_saturn_ramh = NULL;
+        // RA header lives in the 12MB gap in Saturn DDR3: physical 0x30F00000
+        // (between RAMH end at 0x303FFFFF and cdbuf at 0x31000000)
+        ra_ramread_set_base(0x30F00000u);
+
+        // The Saturn FPGA channel only writes the frame counter word (offset
+        // 0x08); the static RACH header word is written once here by the ARM.
+        // This keeps the FPGA-side RA logic down to a single-word writer.
+        void *hdr = shmem_map(0x30F00000u, 4096);
+        if (hdr) {
+                volatile uint32_t *w = (volatile uint32_t *)hdr;
+                w[1] = 0x01000000u;   // region_count=0, flags=0, core_version=1.0
+                w[2] = 0;             // frame counter (FPGA overwrites every VBlank)
+                w[3] = 0;
+                w[0] = 0x52414348u;   // magic "RACH" — written last
+                shmem_unmap(hdr, 4096);
+                ra_log_write("Saturn: RACH header written by ARM at 0x30F00000\n");
+        } else {
+                ra_log_write("Saturn: WARNING - failed to map RA header area!\n");
+        }
+}
+
+static void saturn_reset(void)
+{
+        memset(&g_saturn_state, 0, sizeof(g_saturn_state));
+        if (g_saturn_raml) {
+                shmem_unmap(g_saturn_raml, SATURN_RAML_SIZE);
+                g_saturn_raml = NULL;
+        }
+        if (g_saturn_ramh) {
+                shmem_unmap(g_saturn_ramh, SATURN_RAMH_SIZE);
+                g_saturn_ramh = NULL;
+        }
+}
+
+static uint32_t saturn_read_memory(void *map, uint32_t address, uint8_t *buffer,
+        uint32_t num_bytes)
+{
+        (void)map;
+
+        for (uint32_t i = 0; i < num_bytes; i++) {
+                uint32_t addr = address + i;
+                uint8_t byte = 0;
+
+                if (addr <= SATURN_RA_RAML_END) {
+                        // Work RAM Low (256KB): XOR-7 big-endian byte swap
+                        if (g_saturn_raml) {
+                                uint32_t ddr_off = addr ^ 7;
+                                if (ddr_off < SATURN_RAML_SIZE)
+                                        byte = ((const uint8_t *)g_saturn_raml)[ddr_off];
+                        }
+                } else if (addr >= SATURN_RA_RAMH_START && addr <= SATURN_RA_RAMH_END) {
+                        // Work RAM High (1MB): XOR-7 big-endian byte swap
+                        if (g_saturn_ramh) {
+                                uint32_t k = addr - SATURN_RA_RAMH_START;
+                                uint32_t ddr_off = k ^ 7;
+                                if (ddr_off < SATURN_RAMH_SIZE)
+                                        byte = ((const uint8_t *)g_saturn_ramh)[ddr_off];
+                        }
+                }
+
+                buffer[i] = byte;
+        }
+
+        return num_bytes;
+}
+
+static int saturn_poll(void *map, void *client, int game_loaded)
+{
+#ifdef HAS_RCHEEVOS
+        if (!client || !game_loaded) return 0;
+        if (!g_saturn_raml && !g_saturn_ramh) return 0;
+
+        rc_client_t *rc_client = (rc_client_t *)client;
+
+        // Gate on FPGA VBlank frame counter
+        uint32_t frame = ra_ramread_frame(map);
+        if (frame == g_saturn_state.last_resp_frame) return 1;
+
+        g_saturn_state.last_resp_frame = frame;
+        g_saturn_state.game_frames++;
+        ra_frame_processed(g_saturn_state.game_frames);
+
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+
+        // Initialize on first frame
+        if (g_saturn_state.game_frames == 1 && !g_saturn_state.cache_ready) {
+                g_saturn_state.cache_ready = 1;
+                g_saturn_state.poll_logged = 0;
+                g_saturn_state.cache_time = now;
+                ra_log_write("Saturn: VBlank-gated polling active\n");
+        }
+
+        if (g_saturn_state.game_frames <= 5)
+                ra_log_write("Saturn: Frame %u (fpga=%u)\n",
+                        g_saturn_state.game_frames, frame);
+
+        rc_client_do_frame(rc_client);
+
+        // Periodic logging every 5 seconds (300 frames at 60Hz)
+        uint32_t milestone = g_saturn_state.game_frames / 300;
+        if (milestone > 0 && milestone != g_saturn_state.poll_logged) {
+                g_saturn_state.poll_logged = milestone;
+                double elapsed = (now.tv_sec - g_saturn_state.cache_time.tv_sec)
+                        + (now.tv_nsec - g_saturn_state.cache_time.tv_nsec) / 1e9;
+                double ms_per_cycle = (g_saturn_state.game_frames > 0) ?
+                        (elapsed * 1000.0 / g_saturn_state.game_frames) : 0.0;
+                ra_log_write("POLL(SAT): game_frames=%u elapsed=%.1fs ms/cycle=%.1f\n",
+                        g_saturn_state.game_frames, elapsed, ms_per_cycle);
+        }
+
+        return 1;
+#else
+        return 0;
+#endif
+}
+
+static int saturn_calculate_hash(const char *rom_path, char *md5_hex_out)
+{
+#ifdef HAS_RCHEEVOS
+        char abs_path[1024];
+        if (rom_path[0] == '/') {
+                snprintf(abs_path, sizeof(abs_path), "%s", rom_path);
+        } else {
+                extern const char *getRootDir(void);
+                snprintf(abs_path, sizeof(abs_path), "%s/%s",
+                        getRootDir(), rom_path);
+        }
+
+        if (rc_hash_generate_from_file(md5_hex_out, RC_CONSOLE_SATURN, abs_path)) {
+                ra_log_write("Saturn hash: %s\n", md5_hex_out);
+                return 1;
+        }
+        // Not a valid Saturn disc image (e.g. the BIOS .bin selected in the
+        // OSD). A whole-file MD5 fallback is meaningless for disc consoles,
+        // so report "handled" with an empty hash — the load is skipped
+        // quietly instead of querying the server with a bogus hash.
+        ra_log_write("Saturn: not a Saturn disc image, skipping identify: %s\n",
+                abs_path);
+        md5_hex_out[0] = '\0';
+        return 1;
+#else
+        return 0;
+#endif
+}
+
+static void saturn_set_hardcore(int enabled)
+{
+        (void)enabled;
+        // Saturn MiSTer core has no hardware cheat engine; no OSD toggle needed
+}
+
+static int saturn_detect_protocol(void *map)
+{
+        if (!ra_ramread_active(map)) {
+                ra_log_write("Saturn: FPGA mirror not detected -- RA support unavailable\n");
+                return 0;
+        }
+
+        // Map Work RAM Low (RAML) directly: physical 0x30000000, 256KB
+        if (!g_saturn_raml) {
+                g_saturn_raml = shmem_map(SATURN_RAML_PHYS, SATURN_RAML_SIZE);
+                if (g_saturn_raml)
+                        ra_log_write("Saturn: RAML mapped at 0x%08X (%uKB)\n",
+                                SATURN_RAML_PHYS, SATURN_RAML_SIZE / 1024);
+                else
+                        ra_log_write("Saturn: WARNING - failed to map RAML!\n");
+        }
+
+        // Map Work RAM High (RAMH) directly: physical 0x30300000, 1MB
+        if (!g_saturn_ramh) {
+                g_saturn_ramh = shmem_map(SATURN_RAMH_PHYS, SATURN_RAMH_SIZE);
+                if (g_saturn_ramh)
+                        ra_log_write("Saturn: RAMH mapped at 0x%08X (%uKB)\n",
+                                SATURN_RAMH_PHYS, SATURN_RAMH_SIZE / 1024);
+                else
+                        ra_log_write("Saturn: WARNING - failed to map RAMH!\n");
+        }
+
+        ra_log_write("Saturn: Direct RAM mode (RAML=%s RAMH=%s)\n",
+                g_saturn_raml ? "OK" : "FAIL",
+                g_saturn_ramh ? "OK" : "FAIL");
+
+        return (g_saturn_raml || g_saturn_ramh) ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Console handler definition
+// ---------------------------------------------------------------------------
+
+const console_handler_t g_console_saturn = {
+        .init             = saturn_init,
+        .reset            = saturn_reset,
+        .read_memory      = saturn_read_memory,
+        .poll             = saturn_poll,
+        .calculate_hash   = saturn_calculate_hash,
+        .set_hardcore     = saturn_set_hardcore,
+        .detect_protocol  = saturn_detect_protocol,
+        .console_id       = 39,  // RC_CONSOLE_SATURN
+        .name             = "Saturn",
+        .hardcore_protected = 0
+};

--- a/achievements_saturn.cpp
+++ b/achievements_saturn.cpp
@@ -4,9 +4,10 @@
 //   RAML (Work RAM Low,  1MB): physical 0x30000000
 //   RAMH (Work RAM High, 1MB): physical 0x30300000
 //
-// Byte order: Saturn is big-endian. The ddram.sv arbiter stores data MSB
-// at the highest byte address within each 8-byte DDR3 word, so:
-//   rcheevos byte at offset K → DDR3 byte at offset (K ^ 7)
+// Byte order: Saturn is big-endian; the core's DDR3 stores SH-2 byte K at
+// offset K^7 (64-bit big-endian packing). RA sets are authored against
+// beetle-saturn, whose exposed WorkRAM stores SH-2 byte K at index K^1, so:
+//   rcheevos address A → DDR3 byte at offset (A^1)^7 = A ^ 6
 //
 // rcheevos Saturn memory map (RC_CONSOLE_SATURN = 39):
 //   0x000000–0x0FFFFF: Work RAM Low  (1MB)
@@ -47,8 +48,12 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_saturn_state = {};
-static void *g_saturn_raml = NULL;  // mmap of physical 0x30000000, 256KB
+static void *g_saturn_raml = NULL;  // mmap of physical 0x30000000, 1MB
 static void *g_saturn_ramh = NULL;  // mmap of physical 0x30300000, 1MB
+
+// Debug watch (retroachievements.cfg: watch=...): last seen value per address
+static uint8_t g_watch_last[16];
+static int     g_watch_init = 0;
 
 // ---------------------------------------------------------------------------
 // Saturn implementation
@@ -83,6 +88,7 @@ static void saturn_init(void)
 static void saturn_reset(void)
 {
         memset(&g_saturn_state, 0, sizeof(g_saturn_state));
+        g_watch_init = 0;
         if (g_saturn_raml) {
                 shmem_unmap(g_saturn_raml, SATURN_RAML_SIZE);
                 g_saturn_raml = NULL;
@@ -102,18 +108,25 @@ static uint32_t saturn_read_memory(void *map, uint32_t address, uint8_t *buffer,
                 uint32_t addr = address + i;
                 uint8_t byte = 0;
 
+                // Byte order: RA sets are authored against beetle-saturn, whose
+                // exposed WorkRAM array stores SH-2 byte K at index K^1 (16-bit
+                // host swap, ne16_ptr_be). The core's DDR stores SH-2 byte K at
+                // offset K^7 (big-endian packing in 64-bit words). So RA addr A
+                // maps to DDR offset (A^1)^7 = A^6.
+                // (Proof: "Millionaire" scores = b[0x197c59]*25600 + b[0x197c58]*100
+                //  — high byte at the ODD address = beetle-swapped convention.)
                 if (addr <= SATURN_RA_RAML_END) {
-                        // Work RAM Low (256KB): XOR-7 big-endian byte swap
+                        // Work RAM Low (1MB)
                         if (g_saturn_raml) {
-                                uint32_t ddr_off = addr ^ 7;
+                                uint32_t ddr_off = addr ^ 6;
                                 if (ddr_off < SATURN_RAML_SIZE)
                                         byte = ((const uint8_t *)g_saturn_raml)[ddr_off];
                         }
                 } else if (addr >= SATURN_RA_RAMH_START && addr <= SATURN_RA_RAMH_END) {
-                        // Work RAM High (1MB): XOR-7 big-endian byte swap
+                        // Work RAM High (1MB)
                         if (g_saturn_ramh) {
                                 uint32_t k = addr - SATURN_RA_RAMH_START;
-                                uint32_t ddr_off = k ^ 7;
+                                uint32_t ddr_off = k ^ 6;
                                 if (ddr_off < SATURN_RAMH_SIZE)
                                         byte = ((const uint8_t *)g_saturn_ramh)[ddr_off];
                         }
@@ -155,6 +168,25 @@ static int saturn_poll(void *map, void *client, int game_loaded)
         if (g_saturn_state.game_frames <= 5)
                 ra_log_write("Saturn: Frame %u (fpga=%u)\n",
                         g_saturn_state.game_frames, frame);
+
+        // Debug watch: sample the configured RA addresses through the same
+        // read path rcheevos uses and log every change with the frame number.
+        {
+                const uint32_t *waddrs;
+                int wcount = achievements_watch_list(&waddrs);
+                if (wcount > 16) wcount = 16;
+                for (int i = 0; i < wcount; i++) {
+                        uint8_t v = 0;
+                        saturn_read_memory(NULL, waddrs[i], &v, 1);
+                        if (!g_watch_init || v != g_watch_last[i]) {
+                                ra_log_write("SAT WATCH f=%u 0x%06X: %02X->%02X\n",
+                                        frame, waddrs[i],
+                                        g_watch_init ? g_watch_last[i] : v, v);
+                                g_watch_last[i] = v;
+                        }
+                }
+                if (wcount) g_watch_init = 1;
+        }
 
         rc_client_do_frame(rc_client);
 

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -92,6 +92,7 @@ static int sms_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_sms_state, resp_frame, "SMS");
 		if (resp_frame > g_sms_state.last_resp_frame) {
 			g_sms_state.last_resp_frame = resp_frame;
 			g_sms_state.game_frames++;

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -203,6 +203,7 @@ static int snes_poll(void *map, void *client, int game_loaded)
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			optionc_resync_if_backward(&g_snes_state, resp_frame, "SNES");
 
 			if (g_snes_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
 				g_snes_state.cache_reindexing = 0;
@@ -300,6 +301,7 @@ static int snes_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+		optionc_resync_if_backward(&g_snes_state, resp_frame, "SNES");
 		if (resp_frame > g_snes_state.last_resp_frame) {
 			g_snes_state.last_resp_frame = resp_frame;
 			g_snes_state.game_frames++;

--- a/achievements_tgfx16.cpp
+++ b/achievements_tgfx16.cpp
@@ -138,6 +138,7 @@ tgfx16_optionc_dump_valcache("cache-active", map);
 } else {
 // Normal frame processing
 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+optionc_resync_if_backward(&g_tgfx16_state, resp_frame, "TGFX16");
 if (resp_frame > g_tgfx16_state.last_resp_frame) {
 g_tgfx16_state.last_resp_frame = resp_frame;
 g_tgfx16_state.game_frames++;

--- a/menu.cpp
+++ b/menu.cpp
@@ -2557,7 +2557,6 @@ void HandleUI(void)
 											opt = "[0]";
 										}
 									}
-									if (!bit) achievements_notify_core_reset();
 									if (is_pce() && !bit) pcecd_reset();
 									if (is_saturn() && !bit) saturn_reset();
 									if (is_n64() && !bit) n64_reset();
@@ -2568,6 +2567,11 @@ void HandleUI(void)
 
 									user_io_status_set(opt, 1, ex);
 									user_io_status_set(opt, 0, ex);
+
+									// Notify RA only after the reset pulse: notifying before it
+									// leaves a window where an in-flight FPGA VBlank scan rewrites
+									// the response header after the ARM already cleared the mirror.
+									if (!bit) achievements_notify_core_reset();
 
 									menustate = MENU_GENERIC_MAIN1;
 									if (p[0] == 'R' || p[0] == 'r') menustate = MENU_NONE1;
@@ -2796,6 +2800,7 @@ void HandleUI(void)
 				if (!ioctl_index)
 				{
 					saturn_set_image(ioctl_index, selPath);
+					achievements_load_game(selPath, 0);
 				} else {
 					saturn_mount_save(selPath);
 				}

--- a/ra_http.cpp
+++ b/ra_http.cpp
@@ -209,17 +209,23 @@ static void execute_request(ra_http_req *req, ra_http_resp *resp)
 	off += snprintf(cmd + off, cmd_len - off, "'");
 	cmd[off] = '\0';
 
-	// Log the command with token masked
+	// Log the command with sensitive params masked: &t= (token) and &p= (password)
 	{
-		const char *token_pos = strstr(cmd, "&t=");
-		if (token_pos) {
-			const char *token_end = strchr(token_pos + 3, '&');
-			if (!token_end) token_end = strchr(token_pos + 3, '\'');
-			if (!token_end) token_end = token_pos + 3 + strlen(token_pos + 3);
-			HTTP_LOG("CMD: %.*s&t=***%s",
-				(int)(token_pos - cmd), cmd, token_end);
-		} else {
-			HTTP_LOG("CMD: %s", cmd);
+		char *masked = strdup(cmd);
+		if (masked) {
+			static const char *keys[] = { "&t=", "&p=", NULL };
+			for (int k = 0; keys[k]; k++) {
+				char *pos = strstr(masked, keys[k]);
+				if (pos) {
+					char *val = pos + 3;
+					char *end = val;
+					while (*end && *end != '&' && *end != '\'') end++;
+					memmove(val + 3, end, strlen(end) + 1);
+					memcpy(val, "***", 3);
+				}
+			}
+			HTTP_LOG("CMD: %s", masked);
+			free(masked);
 		}
 	}
 

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -206,13 +206,12 @@ uint8_t ra_ramread_atari7800_byte(const void *map, uint16_t addr)
 	// ram1: physical 0x1800-0x1FFF
 	if (addr >= 0x1800 && addr <= 0x1FFF)
 		return ((const uint8_t *)map + 0x900)[addr & 0x7FF];
-	// ram0: physical 0x2000-0x27FF (main) and zero-page/stack mirrors
-	// ProSystem (reference emulator for Atari 7800 achievements) stores game
-	// variables 8 bytes higher in BRAM than our FPGA. The -8 offset compensates.
-	// However, system/BIOS variables in BRAM[0x00-0x7F] map directly (no offset).
-	// Game variables in BRAM[0x80+] need the -8 shift.
-	// Example: RA addr 0x20C4 (bram=0xC4 >=0x80) -> BRAM[0xBC] = hammer timer.
-	//          RA addr 0x205B (bram=0x5B < 0x80) -> BRAM[0x5B] = 0 (no reset).
+	// ram0: physical 0x2000-0x27FF (main) and zero-page/stack mirrors.
+	// RA addresses are plain CPU addresses (identity map in rcheevos console 51),
+	// and the core decodes zero page $0040-$00FF / stack $0140-$01FF into the
+	// same BRAM via AB[10:0] (Maria/control.sv), so no offset is needed here.
+	// (A "-8"/"+1" skew observed in older tests came from a capture-latency bug
+	// in ra_7800_mirror.sv, fixed on the FPGA side — not from this mapping.)
 	if ((addr >= 0x2000 && addr <= 0x27FF) ||
 	    (addr >= 0x0040 && addr <= 0x00FF) ||
 	    (addr >= 0x0140 && addr <= 0x01FF)) {
@@ -318,6 +317,10 @@ static int      s_snes_addr_count = 0;
 static uint32_t s_snes_request_id = 0;
 static int      s_snes_collecting = 0;
 
+// Smart Cache dynamic-add state (see "Smart Cache" section below)
+static int s_dynamic_pending = 0;   // 1 if new addresses added since last flush
+static int s_dynamic_added   = 0;   // count of addresses added this cycle
+
 #define COLLECT_BUF_MAX (RA_SNES_MAX_ADDRS * 4)
 static uint32_t s_collect_buf[COLLECT_BUF_MAX];
 static int      s_collect_count = 0;
@@ -325,9 +328,17 @@ static int      s_collect_count = 0;
 void ra_snes_addrlist_init(void)
 {
 	s_snes_addr_count = 0;
-	s_snes_request_id = 0;
+	// s_snes_request_id is intentionally NOT reset here: it must stay monotonic
+	// for the lifetime of the process. On a core reset the FPGA can complete an
+	// in-flight VBlank scan (started before the reset pulse) and write a stale
+	// response header AFTER the ARM cleared the mirror. If request IDs restarted
+	// at 1, that stale response_id could match the fresh bootstrap request and
+	// poison last_resp_frame with a huge pre-reset frame counter, stalling
+	// achievement tracking until the counter catches up (hours).
 	s_snes_collecting = 0;
 	s_collect_count = 0;
+	s_dynamic_pending = 0;
+	s_dynamic_added = 0;
 }
 
 void ra_snes_addrlist_begin_collect(void)
@@ -484,10 +495,9 @@ void ra_snes_addrlist_diag_dump(const void *map)
 
 // ======================================================================
 // Smart Cache: incremental address management
+// (s_dynamic_pending / s_dynamic_added are declared next to the addrlist
+//  state above so ra_snes_addrlist_init can clear them.)
 // ======================================================================
-
-static int s_dynamic_pending = 0;   // 1 if new addresses added since last flush
-static int s_dynamic_added   = 0;   // count of addresses added this cycle
 
 int ra_snes_addrlist_contains(uint32_t addr)
 {
@@ -606,7 +616,10 @@ static uint8_t s_rtquery_seq = 0;
 
 void ra_rtquery_init(void *map)
 {
-        s_rtquery_seq = 0;
+        // s_rtquery_seq is intentionally NOT reset: it keeps counting (mod 256,
+        // skipping 0) across re-inits. Restarting at 1 after a core reset could
+        // collide with the sequence number the FPGA last latched, making it
+        // ignore the request and costing a full 100ms busy-wait timeout.
         if (!map) return;
 
         // Clear the control word so FPGA sees no pending request


### PR DESCRIPTION
This pull request adds full support for Atari 7800 achievements, improves text formatting and logging, and enhances robustness for achievement handling across multiple cores. The most significant changes include the introduction of a new Atari 7800 handler, improvements to word wrapping and notification formatting, and fixes for edge cases such as switching games or handling FPGA resets.

**Atari 7800 support:**

* Added a new file `achievements_atari7800.cpp` implementing an Atari 7800 achievement handler, including ROM hash calculation, memory mapping, protocol detection, and frame polling logic. The handler is selected automatically for `.a78` ROMs and includes detailed logging and delta tracking.
* Registered the new Atari 7800 handler in `achievements_console.h` and ensured it is selected by file extension rather than through the main lookup table.

**Game switching and handler selection:**

* Updated `achievements_load_game` to properly unload any previous game session before loading a new one, preventing state leakage between games.
* Improved handler selection logic to switch between Atari 2600 and Atari 7800 handlers based on the ROM extension, ensuring correct achievement support for both consoles within the shared core.

**Text formatting and notification improvements:**

* Enhanced `ra_format_text` to implement smarter word wrapping, avoid breaking words across lines, trim trailing spaces, and add ellipses only when appropriate.
* Changed achievement notification formatting so that multiline descriptions are prefixed before wrapping, ensuring the prefix is included in the line width calculation for better OSD display.

**Robustness and logging:**

* Improved HTTP request logging to mask both tokens and passwords for security.
* Added a utility (`optionc_resync_if_backward`) to detect and recover from FPGA frame counter resets, preventing achievement logic from stalling after core resets or savestate loads. Integrated this recovery in the GameBoy handler and made the function available in the console handler header and lookup files. [[1]](diffhunk://#diff-e7454b872b4ddf5145d22cbe9ed6c07e6887d22555e15de2d1e83e506eb77f21R99-R108) [[2]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R135-R148) [[3]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR168) [[4]](diffhunk://#diff-8819fa7e6e9424268246a403a2667d0600dd90b8a36c96f0f998959bb664d7eeR256)

**Audio playback reliability:**

* Replaced the use of `system("aplay ...")` with a fork/exec approach and a timeout to avoid leaking stuck audio processes in cases where the ALSA ring buffer is not drained (e.g., on certain MiSTer cores).

**Miscellaneous:**

* Added missing Saturn handler registration to the console lookup table. [[1]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R21) [[2]](diffhunk://#diff-6943ebe2b7635ac2b24697d766153c349894c7ce74ee90c327902c338dfccfd7R38)
* Included necessary system headers for process management.