### PR TITLE
feature: bug-fixes and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,26 @@ This is a fork of the official [MiSTer Main binary](https://github.com/MiSTer-de
 
 ## Supported Cores
 
-| Core | Console ID | Modified Core Repo |
-|------|-----------|--------------------|
-| NES | 7 | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
-| Famicom Disk System (via NES core) | 91 | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
-| SNES | 3 | [odelot/SNES_MiSTer](https://github.com/odelot/SNES_MiSTer) |
-| Genesis / Mega Drive | 1 | [odelot/MegaDrive_MiSTer](https://github.com/odelot/MegaDrive_MiSTer) |
-| Master System / Game Gear | 11 | [odelot/SMS_MiSTer](https://github.com/odelot/SMS_MiSTer) |
-| Gameboy / Gameboy Color | 4 | [odelot/Gameboy_MiSTer](https://github.com/odelot/Gameboy_MiSTer) |
-| N64 | 2 | [odelot/N64_MiSTer](https://github.com/odelot/N64_MiSTer) |
-| PSX | 12 | [odelot/PSX_MiSTer](https://github.com/odelot/PSX_MiSTer) |
-| GBA (Game Boy Advance) | 5 | [odelot/GBA_MiSTer](https://github.com/odelot/GBA_MiSTer) |
-| Mega CD / Sega CD | 9 | [odelot/MegaCD_MiSTer](https://github.com/odelot/MegaCD_MiSTer) |
-| NeoGeo (MVS / AES / CD) | 27 | [odelot/NeoGeo_MiSTer](https://github.com/odelot/NeoGeo_MiSTer) |
-| TurboGrafx-16 / PC Engine | 8 | [odelot/TurboGrafx16_MiSTer](https://github.com/odelot/TurboGrafx16_MiSTer) |
-| Atari 2600 (via Atari7800 core) | 25 | [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer) |
-| Sega 32X | 10 | [odelot/S32X_MiSTer](https://github.com/odelot/S32X_MiSTer) |
+| Core | Console ID | Hardcore | Modified Core Repo |
+|------|-----------|----------|--------------------|
+| NES | 7 | ✅ enforced | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
+| Famicom Disk System (via NES core) | 81 | ✅ enforced | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
+| SNES (incl. SA-1 / SuperFX) | 3 | ✅ enforced | [odelot/SNES_MiSTer](https://github.com/odelot/SNES_MiSTer) |
+| Genesis / Mega Drive | 1 | ✅ enforced | [odelot/MegaDrive_MiSTer](https://github.com/odelot/MegaDrive_MiSTer) |
+| N64 | 2 | ✅ enforced | [odelot/N64_MiSTer](https://github.com/odelot/N64_MiSTer) |
+| PSX | 12 | ✅ enforced | [odelot/PSX_MiSTer](https://github.com/odelot/PSX_MiSTer) |
+| Master System / Game Gear | 11 / 15 | 🔧 wired, in validation | [odelot/SMS_MiSTer](https://github.com/odelot/SMS_MiSTer) |
+| Gameboy / Gameboy Color | 4 / 6 | 🔧 wired, in validation | [odelot/Gameboy_MiSTer](https://github.com/odelot/Gameboy_MiSTer) |
+| GBA (Game Boy Advance) | 5 | 🔧 wired, in validation | [odelot/GBA_MiSTer](https://github.com/odelot/GBA_MiSTer) |
+| Mega CD / Sega CD | 9 | 🔧 wired, in validation | [odelot/MegaCD_MiSTer](https://github.com/odelot/MegaCD_MiSTer) |
+| TurboGrafx-16 / PC Engine (incl. CD) | 8 / 76 | 🔧 wired, in validation | [odelot/TurboGrafx16_MiSTer](https://github.com/odelot/TurboGrafx16_MiSTer) |
+| Sega 32X | 10 | 🔧 wired, in validation | [odelot/S32X_MiSTer](https://github.com/odelot/S32X_MiSTer) |
+| NeoGeo (MVS / AES / CD) | 27 / 56 | — softcore only | [odelot/NeoGeo_MiSTer](https://github.com/odelot/NeoGeo_MiSTer) |
+| Atari 2600 (via Atari7800 core) | 25 | — softcore only | [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer) |
+| Atari 7800 (via Atari7800 core, `.a78`) | 51 | — softcore only | [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer) |
+| Sega Saturn | 39 | — softcore only | [odelot/Saturn_MiSTer](https://github.com/odelot/Saturn_MiSTer) |
+
+See [Hardcore Mode](#hardcore-mode) for what each status means.
 
 ## How to Test
 
@@ -42,23 +46,23 @@ The [upstream Main_MiSTer](https://github.com/MiSTer-devel/Main_MiSTer) binary m
 
 | File | Purpose |
 |------|--------|
-| `achievements.cpp / .h` | Core lifecycle — init, load game, per-frame poll, unload, OSD popups |
-| `achievements_<console>.cpp` | Per-console handlers (NES, SNES, Genesis, MegaCD, SMS, Gameboy, GBA, N64, PSX, NeoGeo, Atari 2600, Sega 32X) |
+| `achievements.cpp / .h` | Core lifecycle — init, load game, per-frame poll, unload, OSD popups, F6 achievement list |
+| `achievements_<console>.cpp` | Per-console handlers (NES, SNES, Genesis, MegaCD, SMS, Gameboy, GBA, N64, PSX, NeoGeo, TG16, Atari 2600, Atari 7800, Sega 32X, Saturn) |
 | `achievements_console.h` | Console handler interface (`console_handler_t` struct) |
-| `achievements_console_lookup.cpp` | Dispatch table mapping core names to console handlers |
+| `achievements_console_lookup.cpp` | Dispatch table mapping core names to console handlers, plus shared Selective Address stall-recovery / resync helpers |
 | `ra_http.cpp / .h` | Async HTTP worker thread that executes RetroAchievements API calls via `curl` |
-| `ra_ramread.cpp / .h` | Reads emulated console RAM from the DDRAM mirror written by the FPGA core |
-| `ra_cdreader_chd.cpp / .h` | Unified CD reader bridge: `.chd` via MiSTer's `libchdr`, `.cue`/`.gdi` via the rcheevos default handler. Registered at startup, enabling CHD disc support for all disc-based consoles (PSX, Mega CD, PCE-CD, NeoGeo CD). |
+| `ra_ramread.cpp / .h` | Shared DDRAM protocol: full-mirror parsing, the Selective Address list (with the active-snapshot consistency layer), and the RTQuery mailbox client |
+| `ra_cdreader_chd.cpp / .h` | Unified CD reader bridge: `.chd` via MiSTer's `libchdr`, `.cue`/`.gdi` via the rcheevos default handler. Registered at startup, enabling CHD disc support for all disc-based consoles (PSX, Mega CD, PCE-CD, NeoGeo CD, Saturn). |
 | `shmem.cpp / .h` | Thin wrapper around `/dev/mem` + `mmap` for ARM ↔ FPGA shared memory access |
-| `retroachievements.cfg` | User credentials and options (username, password, hardcore mode, leaderboards, popup settings, debug) |
-| `lib/rcheevos/` | The [rcheevos](https://github.com/RetroAchievements/rcheevos) library (achievement logic, server protocol) |
+| `retroachievements.cfg` | User credentials and options — see [Configuration](#configuration) |
+| `lib/rcheevos/` | The [rcheevos](https://github.com/RetroAchievements/rcheevos) library, **v12.x** (achievement logic, server protocol, multiset support) |
 
 ### Files Modified (hooks into the main loop)
 
 | File | Change |
 |------|--------|
 | `scheduler.cpp` | Calls `achievements_poll()` every frame |
-| `menu.cpp` | Calls `achievements_load_game()` when a ROM is selected |
+| `menu.cpp` | Calls `achievements_load_game()` when a ROM is selected; F6 opens the achievement list |
 | `main.cpp` | Calls `achievements_init()` / `achievements_deinit()` at startup/shutdown |
 | `user_io.cpp` | Notifies the RA layer when a core reset is triggered (keyboard or joystick combo) |
 | `Makefile` | Conditionally compiles rcheevos sources and links against them |
@@ -71,22 +75,24 @@ The RetroAchievements integration uses a four-layer pipeline that connects the F
 
 ```
 ┌───────────────────────────────────────────────────────┐
-│  FPGA Core (NES / SNES / Genesis / SMS / GB / GBA / N64 / PSX / MCD / NeoGeo / TG16 / Atari2600 / S32X) │
+│  FPGA Core                                            │
 │  ra_ram_mirror*.sv exposes emulated RAM to DDRAM      │
-│  (N64 uses direct RDRAM read + VBlank heartbeat)      │
-│  every VBlank (~60 Hz)                                │
+│  every VBlank (~60 Hz).                               │
+│  N64 and Saturn instead expose RAM directly in DDR3   │
+│  and only publish a VBlank heartbeat / frame counter. │
 └──────────────────────┬────────────────────────────────┘
-                       │  DDRAM at physical 0x3D000000
+                       │  DDRAM (default base: ARM phys 0x3D000000)
                        ▼
 ┌───────────────────────────────────────────────────────┐
 │  ARM Binary (this repo)                               │
 │  shmem.cpp  — mmap /dev/mem to read DDRAM             │
-│  ra_ramread — parse header, map console addresses     │
+│  ra_ramread — protocol parsing, Selective Address     │
+│               list + active snapshot, RTQuery mailbox │
 └──────────────────────┬────────────────────────────────┘
                        │
                        ▼
 ┌───────────────────────────────────────────────────────┐
-│  rcheevos SDK                                         │
+│  rcheevos SDK (v12, multiset-aware)                   │
 │  Evaluates achievement conditions against RAM         │
 │  Manages unlock state, leaderboards, progress         │
 └──────────────────────┬────────────────────────────────┘
@@ -100,187 +106,209 @@ The RetroAchievements integration uses a four-layer pipeline that connects the F
 
 ### How It Works
 
-1. **Init** — On startup, the ARM binary maps the DDRAM mirror region, starts an HTTP worker thread, and loads credentials from `retroachievements.cfg`.
-2. **Load Game** — When a ROM is selected in the MiSTer menu, the binary checks internet connectivity (DNS + non-blocking TCP probe to `retroachievements.org`). If online and not yet logged in, it logs in to RetroAchievements on the spot, then computes the ROM's MD5 hash and identifies the game against the RA database. If no internet is detected, an OSD message is shown and login is deferred. Loading the **standard community core** (which lacks the RA mirror module) silently suppresses all RA activity — no spurious login or network calls are made.
-3. **Per-Frame Poll** — Every frame (~60 Hz), `achievements_poll()` checks whether the FPGA has written new data. If a new frame is available, it calls `rc_client_do_frame()` from the rcheevos library, which evaluates achievement conditions against the current RAM state.
+1. **Init** — On startup, the ARM binary maps the DDRAM mirror region, starts an HTTP worker thread, and loads credentials from `retroachievements.cfg`. The hardcore FPGA bits are applied (or explicitly cleared) at core init so stale restrictions never leak between sessions.
+2. **Load Game** — When a ROM is selected in the MiSTer menu, the binary checks internet connectivity (DNS + non-blocking TCP probe to `retroachievements.org`). If online and not yet logged in, it logs in to RetroAchievements on the spot, then computes the ROM's hash and identifies the game against the RA database. `.a78` files automatically switch the Atari7800 core's handler from Atari 2600 to Atari 7800, and `.fds` files switch NES to Famicom Disk System. If no internet is detected, an OSD message is shown and login is deferred. Loading the **standard community core** (which lacks the RA mirror module) silently suppresses all RA activity — no spurious login or network calls are made.
+3. **Per-Frame Poll** — Every frame (~60 Hz), `achievements_poll()` checks whether the FPGA has produced a new frame of data. If so, it calls `rc_client_do_frame()` from the rcheevos library, which evaluates achievement conditions against the current RAM state.
 4. **Unlock / Notify** — When an achievement triggers, the event handler displays an OSD notification and optionally plays a sound (`/media/fat/achievement.wav`). The unlock is reported to the RA server asynchronously. Leaderboard events (start, fail, submit, scoreboard result) also show OSD notifications; a tracker display updates in real time while a leaderboard is active.
-5. **Core Reset** — When the user triggers a core reset (keyboard shortcut or joystick combo), the RA layer is notified so the rcheevos client can reset its internal state correctly.
+5. **Core Reset** — When the user triggers a core reset (keyboard shortcut, joystick combo, or OSD), the RA layer is notified so the rcheevos client can reset its internal state correctly. The FPGA frame counter going backwards (e.g. after a savestate load or PAL/NTSC switch) is also detected and resynced automatically.
 6. **Unload / Shutdown** — State is cleaned up when switching cores or shutting down.
-
-> Achievements run in **softcore mode** by default. Set `hardcore=1` in `retroachievements.cfg` to request hardcore mode.
->
-> Hardcore enforcement is currently implemented for the **NES/FDS path** (core-level restrictions for load-state and cheats). Unsupported cores are automatically forced back to softcore.
 
 ### Achievement List (F6)
 
 While the OSD is open and a game with achievements is loaded, press **F6** to open a scrollable achievement list for the current game. The list shows all core achievements grouped with **unlocked entries first** (marked `►`) followed by **locked entries** (marked `◄`). The OSD title displays the total count, e.g. *Achievements (42)*.
+
+For **multiset games** (rcheevos 12+: a game with subsets, e.g. bonus or challenge sets), the list shows **one page per set**: the footer displays the current set's name with Left/Right arrows, and **← / →** switch between sets.
 
 Navigation inside the list:
 
 | Key | Action |
 |-----|--------|
 | ↑ / ↓ | Move one entry |
-| Page Up / ← | Previous page |
-| Page Down / → | Next page |
-| Home | Jump to first entry |
-| End | Jump to last entry |
+| Page Up / Page Down | Previous / next page |
+| ← / → | Previous / next set (multiset games) |
+| Home / End | Jump to first / last entry |
 | Menu button | Close and return to normal OSD |
+
+## Hardcore Mode
+
+Achievements run in **softcore mode** by default. Set `hardcore=1` in `retroachievements.cfg` to request hardcore mode.
+
+Hardcore is only actually engaged on cores that enforce the restrictions **in hardware** (`hardcore_protected` in the console handler). On those cores, `set_hardcore()` writes FPGA status bits that disable cheats and block savestate restore at the core level — the OSD options are hidden/ignored while hardcore is active. Cores that haven't completed hardware validation are automatically forced back to softcore.
+
+| Status | Cores | Meaning |
+|--------|-------|---------|
+| ✅ **Enforced** | NES, FDS, SNES, Genesis/MD, N64, PSX | FPGA guardrails validated; `hardcore=1` engages real hardcore (cheats disabled, restore-state blocked in hardware) |
+| 🔧 **Wired, in validation** | SMS/GG, GB/GBC, GBA, MegaCD, TG16, 32X | The core RTL has the hardcore guardrails and Main maps the status bits, but the homologation checklist isn't complete — these cores still run softcore unless you set `force_hardcore=1` (for testing at your own risk) |
+| — **Softcore only** | NeoGeo, Atari 2600/7800, Saturn | No hardcore bits wired (2600/7800/Saturn cores have no cheat engine / savestates to block; NeoGeo pending) |
+
+Per-core enforcement details (status bits written by Main):
+
+- **NES/FDS** — hardcore master bit blocks *restore*-state and disables cheats; creating save states remains allowed (they just can't be loaded back in hardcore).
+- **SNES** — cheats disabled + save states disabled.
+- **Genesis / Mega Drive** — cheats disabled + save states disabled.
+- **N64** / **PSX** — dedicated hardcore signal + cheats OSD toggle forced off.
+- **SMS/GG, GB/GBC, GBA, MegaCD, TG16, 32X** — equivalent bits are wired (hardcore signal + cheats off; GBA additionally gates underclock, rewind and fast-forward) pending hardware validation.
+
+`force_hardcore=1` bypasses the per-core gate and requests hardcore everywhere — useful for validating a core, not recommended for regular play.
+
+## RAM Exposure Protocols
+
+There are three protocols for exposing emulated RAM to the ARM:
+
+- **Full Mirror** — The FPGA copies all relevant RAM to DDRAM every VBlank. Simple, but only viable for small RAM spaces (NES fallback, Atari 2600/7800).
+- **Selective Address** — The ARM writes the list of addresses rcheevos needs; the FPGA reads only those values each VBlank and writes them back to a value cache. Used by most cores. FPGA **v2** mirrors additionally implement an **RTQuery mailbox** (a small request/response area polled between VBlanks) that lets the ARM read arbitrary bytes on demand. (Source code and logs still refer to this protocol by its historical working name, "Option C".)
+- **Direct DDR3 mapping** — For cores whose work RAM already lives in DDR3 (N64, Saturn), the ARM simply `mmap`s the RAM region and reads bytes directly; the FPGA only publishes a frame counter / VBlank heartbeat to pace evaluation.
+
+### Selective Address operating modes
+
+- **Smart Cache (default for every Selective Address core when the FPGA is v2, except SMS)** — one bootstrap collection seeds the FPGA cache; from then on, cache misses (typically `AddAddress` pointer targets that moved) are answered **live** through the RTQuery mailbox and appended to the FPGA list incrementally. There is no periodic re-collection; a cleanup pass (~1/min, growth-gated) prunes stale dynamic addresses, which simply re-add themselves via misses if still needed. SMS has no RTQuery mailbox on the FPGA side yet, so it always runs Legacy. `smart_cache=0` can still be set to force Legacy mode on any core (e.g. for debugging), and `smart_cache=1` force-enables it even on a v1 FPGA (harmless — it will just never see cache misses answered, falling back to 0 until the next recollect).
+- **Legacy** — for v1 FPGAs (no mailbox): periodic re-collection (default every ~5 min, `recollect_interval`) refreshes the address list; misses read as 0 until the next recollect.
+
+### Consistency layer — the active snapshot
+
+The Selective Address value cache is *positional*: the FPGA writes values in the order of the address list it last read. Naively indexing it with the ARM's live list would return the *neighbour's* byte whenever the list changes (a dynamic insert shifts every index after it) — enough to fire spurious achievements. The shared `ra_ramread` layer prevents this by construction:
+
+- Three list copies are kept: the **pending** list (mutated live by dynamic adds), the **published** list (exactly what was last written to DDRAM with the current `request_id`), and the **active snapshot** (the last revision the FPGA *confirmed* via `response_id`). All cached reads go through the active snapshot, so static addresses never misalign and never lose the cache, across every insert / prune / recollect.
+- **Revisions are serialized**: a new list is only published after the FPGA confirmed the previous one, so at most one revision is ever in flight. Until the FPGA confirms, addresses not yet in the active snapshot are simply served by RTQuery (Smart Cache) or read as 0 with achievement processing gated (legacy).
+- `request_id` is **monotonic for the process lifetime**, so a posthumous FPGA response written across a core reset can never be mistaken for a fresh one.
+
+### Anti-false-positive guards (all Selective Address cores)
+
+- **Bootstrap re-prime** — the bootstrap collection frame runs with all reads returning zero. `rc_client_reset()` is called *before* it (so a mid-game re-bootstrap can't fire active triggers on zeros) and again when the cache becomes active (so delta conditions can't see spurious 0 → real transitions). Cores with multi-pass pointer resolution (PSX, NeoGeo) only re-prime after zero-read bootstraps, preserving hit counts across real-value re-collections.
+- **Stall recovery** (opt-in, `stall_recovery=1`) — if the FPGA stops responding for ≥5 s, the pipeline re-bootstraps automatically.
+- **Backward-frame resync** — a frame counter that goes backwards (core reset, savestate load) resyncs tracking instead of stalling it.
+- **GBA RAM clear** (`gba_reset_ram=1`) — IWRAM/EWRAM are zeroed and the cart/flash save region is filled with `0xFF` (erased state) before each game load, in both SDRAM and DDR3 storage modes, so stale RAM from a previous game can't satisfy conditions.
 
 ### DDRAM Mirror Layout
 
-Every supported core writes a structured block at ARM physical address `0x3D000000`:
+Every Selective Address / Full Mirror core writes a structured block at the RA base address (default ARM physical `0x3D000000`; N64 uses `0x38000000`, Saturn `0x30F00000`):
 
 | Offset | Content |
 |--------|---------|
-| `0x00000` | Header: magic `"RACH"`, region count, flags (busy bit), frame counter |
-| `0x00100+` | RAM data area (layout varies per core — used by Full Mirror protocol) |
-| `0x40000` | Address request list — ARM writes here (Selective Address protocol) |
-| `0x48000` | Value response cache — FPGA writes results here (Selective Address protocol) |
+| `0x00000` | Header: magic `"RACH"`, region count, flags (busy bit), FPGA core version, frame counter |
+| `0x00040` | ARM-written config bits (e.g. RTQuery arming, GBA clear enable) |
+| `0x00100+` | RAM data area (layout varies per core — Full Mirror protocol) |
+| `0x40000` | Address request list — ARM writes `{addr_count, request_id}` + addresses |
+| `0x48000` | Value response cache — FPGA writes `{response_id, response_frame}` + values |
+| `0x50000` | RTQuery mailbox (v2 FPGAs): control word + 16 request/response slots |
 
-### Per-Core RAM Exposure Strategy
+## Per-Core Details
 
-There are two protocols for exposing emulated RAM to the ARM:
-
-- **Full Mirror** — The FPGA copies all relevant RAM to DDRAM every VBlank. Simple but only viable for small RAM spaces.
-- **Selective Address (Option C)** — The ARM writes a list of addresses it needs; the FPGA reads only those values and writes them back. Required for cores with large address spaces.
-
-#### NES / Famicom Disk System — Full Mirror (`ra_ram_mirror.sv`)
-The FPGA copies all relevant RAM to DDRAM on every VBlank (~10 KB total):
+#### NES / Famicom Disk System — Smart Cache + Realtime Query (`ra_ram_mirror_nes.sv`)
+Current FPGA is v2: selective address reading with RTQuery mailbox, Smart Cache **on by default**. Older v1 cores fall back to the original full mirror (`ra_ram_mirror.sv`, ~10 KB per VBlank), which the ARM auto-detects via the header's region count.
 - **CPU-RAM** ($0000–$07FF) — 2 KB
 - **Cart SRAM** ($6000–$7FFF) — 8 KB
 
-When a `.fds` file is loaded, the ARM side automatically switches from NES console ID 7 to **Famicom Disk System ID 91** for correct RetroAchievements game identification. FDS hashing skips the 16-byte fwNES header (`FDS\x1A`) before MD5.
+When a `.fds` file is loaded, the ARM side automatically switches from NES console ID 7 to **Famicom Disk System ID 81** for correct game identification. FDS hashing skips the 16-byte fwNES header (`FDS\x1A`) before MD5.
 
-#### SNES — Selective Address (`ra_ram_mirror_snes.sv`)
-Due to the larger RAM space, the ARM binary writes the list of addresses it needs, and the FPGA reads only those (~185 per frame):
-- **WRAM** ($000000–$01FFFF) — 128 KB
-- **BSRAM** ($020000+) — up to 256 KB
+#### SNES — Smart Cache + Realtime Query (`ra_ram_mirror_snes.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default. The scan is triggered **pre-VBlank (~line 215)** so WRAM is captured before the NMI handler runs, matching the timing RA sets are authored against (RASnes9x):
+- **WRAM** ($000000–$01FFFF) — 128 KB (read live from SDRAM via the SNI-shared port)
+- **BSRAM** ($020000+) — up to 256 KB (includes SA-1 BWRAM, so SA-1 games like Super Mario RPG work; BSRAM reads are VBlank-gated to stay frame-coherent with WRAM)
 
-#### Genesis / Mega Drive — Selective Address (`ra_ram_mirror_md.sv`)
-Same request/response protocol. The FPGA reads requested addresses directly from the 68K Work RAM BRAM:
+The core also thrashes WRAM/VRAM/ARAM/BSRAM with init patterns on every cart load, so a previous game's RAM can never leak into a new session.
+
+#### Genesis / Mega Drive — Smart Cache + Realtime Query (`ra_ram_mirror_md.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default. The FPGA reads requested addresses directly from the 68K Work RAM BRAM:
 - **68K Work RAM** ($000000–$00FFFF) — 64 KB
 - Includes hardware-accurate FC1004 address bit-13 inversion for correct BRAM mapping
 
-#### GBA (Game Boy Advance) — Selective Address (`ra_ram_mirror_gba.sv`)
-Same request/response protocol. The FPGA reads from three distinct memory backends:
+#### GBA (Game Boy Advance) — Smart Cache + Realtime Query (`ra_ram_mirror_gba.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default — required here because Pokémon R/S/E/FR/LG relocate their SaveBlocks in EWRAM at runtime (anti-cheat DMA), so pointer targets change constantly. The FPGA reads from three distinct memory backends:
 - **IWRAM** ($00000–$07FFF) — 32 KB (on-chip block RAM, Port B read with double-read collision detection)
-- **EWRAM** ($08000–$47FFF) — 256 KB (DDRAM, via `Softmap_GBA_WRam_ADDR`)
-- **Cart RAM / Flash** ($48000–$57FFF) — up to 64 KB (DDRAM, via `Softmap_GBA_FLASH_ADDR`)
+- **EWRAM** ($08000–$47FFF) — 256 KB (DDR3 or SDRAM depending on core storage mode)
+- **Cart RAM / Flash** ($48000–$57FFF) — up to 64 KB
 
-The GBA core's existing `ddram.sv` module was extended with a dedicated lowest-priority RA channel for both reads and writes. No separate arbiter file is needed — the RA port is integrated directly into the DDRAM controller. IWRAM reads use the BRAM Port B of `gba_memorymux`, with a read-verify-retry mechanism (up to 4 retries) to handle occasional collisions when the CPU writes on Port A at the same cycle.
+The GBA core's `ddram.sv` was extended with a dedicated RA channel that never disturbs the ROM prefetch cache, and `sdram.sv` gained an RA read/write channel for SDRAM storage mode. On game load (with `gba_reset_ram=1`) the FPGA clears IWRAM/EWRAM and fills the flash region with `0xFF` (erased state) in both storage modes, before the game starts. Out-of-range pointer targets (garbage mid-update) are answered with 0 without polluting the dynamic list. Total exposed: **352 KB**.
 
-A unique GBA-specific feature: the ARM binary pre-fills the Flash DDRAM region (128 KB at 0x30000000) with `0xFF` on game load when no save file is present, since real GBA Flash reads `0xFF` when erased and many RA conditions check for this sentinel value. Total exposed: **352 KB**.
-
-#### Mega CD / Sega CD — Selective Address (`ra_ram_mirror_mcd.sv`)
-Same request/response protocol. The FPGA reads from SDRAM (not BRAM), handling two distinct memory regions:
+#### Mega CD / Sega CD — Smart Cache + Realtime Query (`ra_ram_mirror_mcd.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default. The FPGA reads from SDRAM (not BRAM), handling two distinct memory regions:
 - **68K Work RAM** ($00000–$0FFFF) — 64 KB (SDRAM bank 1)
 - **MCD Program RAM** ($10000–$8FFFF) — 512 KB (SDRAM banks 0/1 with bank switching)
 
 Unlike the MegaDrive core, no DDRAM arbitration is needed (`ddram_ra_mcd.sv` is a simple pass-through) because the Mega CD core has no other DDRAM consumer. Total exposed: **576 KB**.
 
 #### Master System / Game Gear — Selective Address (`ra_ram_mirror_sms.sv`)
-Uses the same selective address protocol. The FPGA reads from dual-ported System RAM and NVRAM:
+Selective address protocol (legacy mode). The FPGA reads from dual-ported System RAM and NVRAM:
 - **System RAM** ($0000–$1FFF) — 8 KB (Z80 $C000–$DFFF mirrored)
 - **NVRAM / Cart RAM** ($2000–$9FFF) — up to 32 KB
 
-The SMS core converts its existing single-port RAMs to dual-port (`dpram`) so the RA mirror can read on Port B without disturbing the CPU on Port A. A custom DDRAM arbiter (`ddram_arb_sms.sv`) shares bus access between the framebuffer and the RA mirror.
+The SMS core converts its existing single-port RAMs to dual-port (`dpram`) so the RA mirror can read on Port B without disturbing the CPU on Port A. A custom DDRAM arbiter (`ddram_arb_sms.sv`) shares bus access between the framebuffer and the RA mirror. Game Gear titles (console ID 15) are handled by the same handler.
 
-#### Gameboy / Gameboy Color — Selective Address (`ra_ram_mirror_gb.sv`)
-Uses the selective address protocol. The FPGA reads from dual-ported WRAM and ZPRAM (HRAM), plus cart RAM via a dedicated SDRAM channel:
+#### Gameboy / Gameboy Color — Smart Cache + Realtime Query (`ra_ram_mirror_gb.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default. The FPGA reads from dual-ported WRAM and ZPRAM (HRAM), plus cart RAM via a dedicated SDRAM channel:
 - **WRAM** ($C000–$DFFF + GBC banks 2–7 via $10000–$15FFF) — up to 32 KB
 - **Cart RAM** ($A000–$BFFF + banks 1–15 via $16000–$33FFF) — up to 128 KB via SDRAM ch2
 - **HRAM / ZPRAM** ($FF80–$FFFE) — 127 bytes
 - **Echo RAM** ($E000–$FDFF) — automatically translated to $C000–$DDFF
 
-The Gameboy core multiplexes Port B of existing dual-port WRAM and ZPRAM BRAMs between savestate access and RA reads (RA takes priority when `ra_wram_req` / `ra_zpram_req` is asserted). Cart RAM is accessed read-only through SDRAM channel 2 with busy handshaking. A 2-cycle BRAM read path is used (address latch → output valid). The DDRAM arbiter in the core's `ddram.sv` module provides a dedicated channel for RA read/write operations alongside the savestate channel.
+The Gameboy core multiplexes Port B of existing dual-port WRAM and ZPRAM BRAMs between savestate access and RA reads (RA takes priority when requested). Cart RAM is accessed read-only through SDRAM channel 2 with busy handshaking.
 
 #### N64 — Direct RDRAM Mapping + VBlank Heartbeat (`ra_ram_mirror_n64.sv`)
-N64 now uses a hybrid model closer to emulator-style memory access than classic Option C. The ARM side maps RDRAM directly and reads bytes on demand; the FPGA mirror only provides a reliable frame heartbeat.
-- **RDRAM** ($000000–$7FFFFF) — 4 to 8 MB (ARM direct mmap at physical 0x30000000)
+N64 uses a hybrid model closer to emulator-style memory access than Selective Address. The ARM maps RDRAM directly and reads bytes on demand; the FPGA mirror only provides a reliable frame heartbeat.
+- **RDRAM** ($000000–$7FFFFF) — 4 to 8 MB (ARM direct mmap at physical 0x30000000, `addr ^ 3` byte-order correction)
 
-Key differences from other cores:
-- **No per-VBlank address/value transfer** — unlike Option C cores, N64 no longer pushes address lists and value caches every frame.
-- **VBlank heartbeat only** — `ra_ram_mirror_n64.sv` (v4) writes a compact header at ARM physical 0x38000000 (`RACH` magic, frame counter, debug/version) and increments on each VI interrupt.
-- **Reliable VBlank source** — heartbeat is driven from VI interrupt (`vi_irq`) instead of video VBlank, which is more stable during transitions.
-- **Direct byte reads from RDRAM** — `achievements_n64.cpp` reads RDRAM directly, applying `addr ^ 3` for correct byte endianness mapping.
-- **Optional snapshot mode** — when `n64_snapshot=1`, Main_MiSTer copies 8 MB of RDRAM at each VBlank and evaluates achievements against this consistent snapshot.
-- **Separate RA base preserved** — heartbeat region remains at 0x38000000 to avoid N64 savestate slots at 0x3C000000–0x3FFFFFFF.
+Key points:
+- **VBlank heartbeat only** — `ra_ram_mirror_n64.sv` writes a compact header at ARM physical 0x38000000 (`RACH` magic, frame counter, version) and increments on each VI interrupt (more stable than video VBlank during transitions).
+- **Optional snapshot mode** — with `n64_snapshot=1`, Main copies 8 MB of RDRAM at each VBlank and evaluates achievements against this consistent snapshot instead of live RAM.
+- The RA base stays at 0x38000000 to avoid the N64 savestate slots at 0x3C000000–0x3FFFFFFF.
 
-#### PSX — Smart Option C + Realtime Query (`ra_ram_mirror_psx.sv`)
-PSX still uses selective-address transport on FPGA, but Main_MiSTer now runs a Smart Cache algorithm with realtime query fallback for dynamic addresses (`AddAddress`/`AddSource` chains):
+#### PSX — Smart Cache + Realtime Query + flat mirror (`ra_ram_mirror_psx.sv`)
+PSX uses selective-address transport with Smart Cache + RTQuery (default on), plus an ARM-side optimization: a **flat 2 MB mirror keyed by address** (O(1) lookup instead of binary search) that is refreshed from the FPGA value cache once per VBlank — but only when the FPGA has confirmed the current list revision, so ordering changes can never corrupt it.
 - **Main RAM** ($000000–$1FFFFF) — 2 MB
 
-Key behavior:
-- **Initial bootstrap only** — a first collect pass seeds the FPGA cache.
-- **Realtime miss resolution** — cache misses are read immediately through RTQuery mailbox transactions (`ra_rtquery_read`) instead of waiting for the next recollect cycle.
-- **Dynamic growth** — newly discovered runtime addresses are appended and flushed into the FPGA cache incrementally.
-- **No periodic pointer re-collection path** in Smart Cache mode — pointer-dependent reads are handled live via RTQuery; periodic cleanup only prunes stale entries and reindexes cache.
-- **FPGA v2 mailbox support** — PSX mirror exposes query control/request/response mailboxes (0x50000 region) used by runtime queries.
+Cache misses are resolved live through the RTQuery mailbox; a growth-gated cleanup (~every 10 s, only if the list grew >50% over the bootstrap baseline) re-collects and prunes stale entries. Newly collected addresses stay unmonitored until they get a real value, self-healing via RTQuery misses.
 
-#### NeoGeo (MVS / AES / CD) — Selective Address (`ra_ram_mirror_neogeo.sv`)
-Uses the selective address protocol. The FPGA reads from dual-ported 68K Work RAM BRAMs (WRAML + WRAMU, 8-bit each):
+#### NeoGeo (MVS / AES / CD) — Smart Cache + Realtime Query (`ra_ram_mirror_neogeo.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default, with multi-pass pointer resolution at load. The FPGA reads from dual-ported 68K Work RAM BRAMs (WRAML + WRAMU, 8-bit each):
 - **68K Work RAM** ($00000–$0FFFF) — 64 KB
 
-The NeoGeo core stores 68K Work RAM in two separate 15-bit DPRAMs — WRAML (low byte, `M68K_DATA[7:0]`) and WRAMU (high byte, `M68K_DATA[15:8]`). The RA mirror reads Port B of both BRAMs using the byte address: even addresses (`addr[0]=0`) select WRAMU and odd addresses (`addr[0]=1`) select WRAML, following the 68K big-endian convention. No address inversion or byte reordering is needed.
+Even addresses select WRAMU and odd addresses WRAML, following the 68K big-endian convention. In **CD mode** (console ID 56), the WRAML/WRAMU BRAMs are repurposed for Z80 RAM and the 68K Work RAM lives in SDRAM; shadow DPRAMs capture both CPU and DMA writes so RA keeps working, muxed automatically by system mode. A custom DDRAM arbiter (`ddram_arb_neogeo.sv`) lets the RA mirror steal bus cycles when the ADPCM/Z80-ROM master is idle, with two-stage synchronizers between CLK_48M and CLK_96M.
 
-In **CD mode**, the WRAML/WRAMU BRAMs are repurposed for Z80 RAM and the 68K Work RAM lives in SDRAM. To keep RA working, shadow DPRAMs capture both CPU writes (via `~nWWL`/`~nWWU`) and DMA writes (targeting `$100000–$10FFFF`). The RA mirror automatically muxes between the MVS BRAMs and the CD shadow BRAMs depending on the active system mode.
+#### TurboGrafx-16 / PC Engine — Smart Cache + Realtime Query (`ra_ram_mirror_tgfx16.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default, with a dual-path memory architecture:
+- **Work RAM** ($000000–$001FFF) — 8 KB (BRAM Port B via `pce_top`)
+- **CD RAM** ($002000–$011FFF) — 64 KB (DDRAM)
+- **Super CD RAM** ($012000–$041FFF) — 192 KB (DDRAM)
 
-A custom DDRAM arbiter (`ddram_arb_neogeo.sv`) sits between the existing DDRAM controller (ADPCM samples / Z80 ROM reads) and the physical DDRAM interface, letting the RA mirror steal bus cycles when the primary master is idle. Two-stage flip-flop synchronizers handle clock domain crossing between CLK_48M (RA mirror) and CLK_96M (DDRAM).
-
-#### TurboGrafx-16 / PC Engine — Selective Address (`ra_ram_mirror_tgfx16.sv`)
-Uses the selective address protocol with a dual-path memory architecture. The FPGA reads from BRAM for Work RAM and from DDRAM for CD/SCD RAM:
-- **Work RAM** ($000000–$001FFF) — 8 KB (BRAM Port B via `pce_top`, 1-cycle latency)
-- **CD RAM** ($002000–$011FFF) — 64 KB (DDRAM at offset 0x0600000)
-- **Super CD RAM** ($012000–$041FFF) — 192 KB (DDRAM at offset 0x0610000)
-
-The core's existing `ddram.sv` was extended with an RA arbiter that gives RA secondary priority behind the core. When the core has no pending request and DDRAM is idle, the RA mirror takes over for one transaction. CD/SCD RAM is accessed as 64-bit DDRAM words with byte extraction. The module runs on `clk_sys` (~21.477 MHz) and supports both HuCard-only games (8 KB Work RAM) and CD-ROM/Super CD-ROM titles (up to 264 KB). Total exposed: **264 KB**.
+The core's `ddram.sv` was extended with an RA arbiter that gives RA secondary priority behind the core. Supports both HuCard-only games (8 KB) and CD-ROM/Super CD-ROM titles (up to 264 KB; PCE-CD games use console ID 76). Total exposed: **264 KB**.
 
 #### Atari 2600 (via Atari7800 core) — Full Mirror (`ra_riot_mirror.sv`)
 The simplest mirror in the project — the entire 128-byte RIOT (M6532) internal RAM is copied to DDRAM on every VBlank. No address list or handshake is needed.
-- **RIOT RAM** ($0080–$00FF) — 128 bytes (M6532 internal BRAM, async read port)
+- **RIOT RAM** ($0080–$00FF) — 128 bytes
 
-The Atari7800 core supports both native 7800 games and a 2600 compatibility mode (auto-detected via game header). RA is active **only in 2600 mode** (`tia_en=1`); the mirror writes nothing when a 7800 game is loaded. The M6532 BRAM already had a read port exposed from the emulation; the `ra_riot_mirror.sv` module reads all 128 bytes sequentially via an async port and writes them in 16 × 64-bit chunks to DDRAM channel 2 (a dedicated write-only channel added to the existing `ddram.sv`). Total exposed: **128 bytes**.
+Active only in 2600 compatibility mode (`tia_en=1`).
 
-#### Sega 32X — Selective Address (`ra_ram_mirror_s32x.sv`)
-The most architecturally complex core in the project — the 32X exposes two RAM regions from two entirely different physical backends:
-- **68K Work RAM** ($00000–$0FFFF) — 64 KB (on-chip BRAM inside the GEN module, Port B read, 2-cycle latency)
-- **SH2 SDRAM / 32X RAM** ($10000–$4FFFF) — 256 KB (DDR3, accessed via the `ddram_arb_s32x` interposer)
+#### Atari 7800 (via Atari7800 core) — Full Mirror (`ra_7800_mirror.sv`)
+When a `.a78` ROM is loaded, Main switches to the Atari 7800 handler (console ID 51) and the FPGA mirrors the 7800's two 2 KB RAM banks every VBlank as two header-described regions:
+- **RAM0** (CPU $2000–$27FF, with $0040–$00FF / $0140–$01FF zero-page and stack mirrors) — 2 KB
+- **RAM1** (CPU $1800–$1FFF) — 2 KB
 
-Rather than adding a new channel to `ddram.sv`, a dedicated arbiter (`ddram_arb_s32x.sv`) is inserted as an **interposer** between `ddram.sv` and the physical DDR3 pins. When `ddram.sv` is idle (no burst in flight), the arbiter steals one read or write transaction for the RA mirror. Clock domain crossing between `clk_sys` (RA mirror) and `clk_ram` (DDR3 controller) is handled with two-stage flip-flop synchronisers on all toggle signals.
+Hashing strips the 128-byte `.a78` header (identified by the `ATARI7800` magic) before MD5, matching `rc_hash_7800()`.
 
-The SH2 is big-endian: byte 0 is at DDR word bits [63:56]. rcheevos expects little-endian byte order within each halfword, so the byte-lane extraction applies `offset ^ 3'd1` to swap lanes correctly. The GEN module was extended with three new ports (`RA_BRAM_ADDR[14:0]`, `RA_BRAM_U[7:0]`, `RA_BRAM_L[7:0]`) exposing a secondary read port on the 68K Work RAM BRAM — no FC1004 address inversion is needed here (unlike the standalone Genesis core). Total exposed: **320 KB**.
+#### Sega 32X — Smart Cache + Realtime Query (`ra_ram_mirror_s32x.sv`)
+Selective address reading with RTQuery mailbox; Smart Cache on by default. The 32X exposes two RAM regions from two entirely different physical backends:
+- **68K Work RAM** ($00000–$0FFFF) — 64 KB (on-chip BRAM inside the GEN module, Port B read)
+- **SH2 SDRAM / 32X RAM** ($10000–$4FFFF) — 256 KB (DDR3, via the `ddram_arb_s32x` interposer)
+
+A dedicated arbiter (`ddram_arb_s32x.sv`) is inserted as an **interposer** between `ddram.sv` and the physical DDR3 pins, stealing one transaction when the core is idle, with two-stage synchronizers between `clk_sys` and `clk_ram`. The SH2 is big-endian; byte-lane extraction applies `offset ^ 1` so rcheevos sees the expected byte order. Total exposed: **320 KB**.
+
+#### Sega Saturn — Direct DDR3 Mapping + frame counter
+Like N64, no per-address FPGA transport at all — the Saturn core's work RAM already lives in DDR3, so the ARM maps it directly:
+- **Work RAM Low** ($000000–$0FFFFF) — 1 MB (physical 0x30000000)
+- **Work RAM High** ($100000–$1FFFFF) — 1 MB (physical 0x30300000)
+
+The FPGA-side RA logic is a single-word writer: it only updates a frame counter in a 12 MB DDR3 gap (0x30F00000); the static `RACH` header is written once by the ARM at init. Byte-order note: the core's DDR3 stores SH-2 byte K at offset `K^7` while RA sets are authored against beetle-saturn (`K^1`), so reads apply `addr ^ 6`.
 
 ### `AddAddress` Support — Pointer Resolution
 
-Several achievement conditions use pointer operators (`AddAddress`/`AddSource`) that derive effective addresses at runtime. In classic Selective Address pipelines, this creates a bootstrapping problem: on first collection, cached values are zero, so pointer expressions initially resolve to incomplete targets.
+Several achievement conditions use pointer operators (`AddAddress`/`AddSource`) that derive effective addresses at runtime. In Selective Address pipelines this creates a bootstrapping problem: on first collection, cached values are zero, so pointer expressions initially resolve to incomplete targets.
 
-To solve this, cores use one of two strategies:
+- **Smart Cache mode (default on NES / SNES / Genesis / PSX / GBA)** — pointer targets are discovered *live*: a miss is answered immediately by RTQuery and the address joins the FPGA batch from the next VBlank. No pointer re-collection loop exists at all.
+- **Legacy mode** — the bootstrap pass discovers base addresses; the FPGA fills real values; a pointer-resolution pass (PSX/NeoGeo run up to 4) re-collects with real pointer values; then periodic re-collection (default ~5 min, `recollect_interval`) tracks pointers that move later. Achievement processing is paused for the 1–2 frames while a new list revision is in flight.
+- **N64 / Saturn (direct mapping)** — pointer operators are evaluated directly against mapped RAM every frame; nothing to resolve.
 
-1. **Bootstrap** — `rc_client_do_frame()` runs once in *collect mode* with all values assumed zero. This discovers the initial set of addresses, including pointer base addresses.
-2. **FPGA response** — The ARM waits for the FPGA to fill the value cache with real data.
-3. **Pointer-resolution pass** — `rc_client_do_frame()` runs again in collect mode, now with real pointer values. This resolves derived target addresses that were invisible in the bootstrap pass.
-4. **Resume normal processing** — Once the address list stabilises and the final FPGA response arrives, the pipeline enters its normal per-frame polling loop.
-
-For **PSX Smart Cache (default)**, misses are resolved in real time via RTQuery, so pointer targets can be discovered during normal frame execution without periodic pointer re-collect loops.
-
-For **N64**, pointer operators are evaluated directly against mapped RDRAM bytes (or snapshot data), gated by VI heartbeat frames.
-
-**State preservation**: Before and after each bootstrap or resolution pass, the rcheevos client state is serialized (`rc_client_serialize_progress`) and restored afterwards. This prevents zero-value reads during collection from spuriously incrementing hit counters or triggering delta conditions, keeping achievement evaluation correct.
-
-**Periodic re-collection**: During normal gameplay the address list is refreshed to account for pointer changes at runtime (e.g., a game reallocating a data structure):
-
-| Core | Re-collection interval | Re-resolves on change? |
-|------|------------------------|------------------------|
-| SNES | every ~5 min (~18 000 frames) | No |
-| Genesis | every ~5 min (~18 000 frames) | No |
-| GBA | every ~5 min (~18 000 frames) | No |
-| Mega CD | every ~5 min (~18 000 frames) | No |
-| NeoGeo | every ~5 min (~18 000 frames) | No |
-| TG16 | every ~5 min (~18 000 frames) | No |
-| Atari 2600 | every frame (full mirror, no re-collection needed) | N/A |
-| Sega 32X | every ~5 min (~18 000 frames) | No |
-| PSX (Smart Cache default) | no periodic pointer recollect; runtime RTQuery + periodic stale-cache cleanup (~10 s) | Live (runtime) |
-| N64 (direct mode) | no Option C recollect (direct RDRAM reads each VI frame) | Live (runtime) |
+In all modes, the bootstrap's zero-value frame is neutralized with `rc_client_reset()` (see [Anti-false-positive guards](#anti-false-positive-guards-all-option-c-cores)) so it can neither fire triggers nor poison delta conditions.
 
 ### ROM / Disc Hashing
 
@@ -290,16 +318,46 @@ For **N64**, pointer operators are evaluated directly against mapped RDRAM bytes
 | Famicom Disk System (FDS) | MD5 of disk data, skipping 16-byte fwNES FDS header (`FDS\x1A`) |
 | SNES | MD5 of ROM data, skipping optional 512-byte SMC/SWC copier header (detected when `file_size % 1024 == 512`) |
 | Genesis | MD5 of the raw ROM file (no header skipping needed) |
+| Master System / Game Gear | MD5 of the raw ROM file |
+| Gameboy / GBC | MD5 of the raw ROM file |
 | Mega CD | `rc_hash_generate_from_file()` from rcheevos — handles `.cue+.bin` and `.chd` disc images natively |
-| Gameboy / GBC | MD5 of the raw ROM file (no header skipping needed) |
 | GBA | `rc_hash_generate_from_file()` from rcheevos — handles `.gba` ROM files natively |
 | N64 | `rc_hash_generate_from_file()` from rcheevos — handles `.z64`, `.n64`, and `.v64` byte orders natively |
 | PSX | `rc_hash_generate_from_file()` from rcheevos — handles `.cue+.bin`, `.chd`, and `.iso` disc images natively |
-| NeoGeo | `rc_hash_generate_from_file()` from rcheevos — handles filename-based hashing for arcade ROM sets natively |
-| TG16 (HuCard) | MD5 of ROM data, skipping optional 512-byte copier header (detected when `file_size % 1024 == 512`) |
+| NeoGeo | `rc_hash_generate_from_file()` from rcheevos — filename-based hashing for arcade ROM sets |
+| TG16 (HuCard) | MD5 of ROM data, skipping optional 512-byte copier header |
 | TG16 (CD-ROM) | `rc_hash_generate_from_file()` from rcheevos — handles `.cue+.bin`, `.chd`, `.ccd`, `.iso`, and `.img` disc images natively |
-| Atari 2600 | MD5 of the raw ROM file (`.a26`) — no header stripping needed |
+| Atari 2600 | MD5 of the raw ROM file (`.a26`) |
+| Atari 7800 | MD5 of ROM data, skipping the 128-byte `.a78` header when present (matches `rc_hash_7800`) |
 | Sega 32X | `rc_hash_generate_from_file()` from rcheevos — handles `.32x` ROM files natively |
+| Saturn | `rc_hash_generate_from_file()` from rcheevos — handles `.cue+.bin` and `.chd` disc images natively |
+
+## Configuration
+
+All options live in `/media/fat/retroachievements.cfg`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `username` / `password` | — | RetroAchievements credentials |
+| `hardcore` | 0 | Request hardcore mode on cores with validated hardware enforcement |
+| `force_hardcore` | 0 | Force hardcore even on unvalidated cores (testing only) |
+| `show_challenge_show_popup` | 1 | Popup when a challenge indicator appears |
+| `show_challenge_hide_popup` | 0 | Popup when a challenge indicator disappears |
+| `show_progress_popups` | 1 | Popups for achievement progress updates |
+| `show_progress_name` | 1 | Include achievement name in progress popups |
+| `show_leaderboards_updates` | 1 | Leaderboard start/fail/tracker popups |
+| `show_leaderboards_submission` | 1 | Leaderboard submit/scoreboard popups |
+| `leaderboards_enabled` | 1 | Enable leaderboard processing |
+| `multiline_desc` | 0 | Two-line achievement text in OSD popups |
+| `smart_cache` | auto | Force Smart Cache on (`1`) / off (`0`); default: on for every Selective Address core except SMS (v2 FPGAs) |
+| `rtquery` | 1 | Enable the RTQuery mailbox (v2 FPGAs) |
+| `smart_cleanup` | 1 | Periodic pruning of stale dynamic addresses |
+| `recollect_interval` | 600 | Legacy-mode re-collection interval, in frames (PSX/GBA legacy; SNES-style cores use ~18000) |
+| `stall_recovery` | 0 | Re-bootstrap automatically if the FPGA stops responding ≥5 s |
+| `n64_snapshot` | 0 | N64: evaluate against an 8 MB RDRAM snapshot per VBlank |
+| `gba_reset_ram` | 1 | GBA: clear IWRAM/EWRAM and fill flash with `0xFF` before each game load |
+| `watch` | — | Debug: comma-separated RA addresses to log on change |
+| `debug` | 0 | Verbose RA logging |
 
 ## How to Try It
 
@@ -322,8 +380,9 @@ For **N64**, pointer operators are evaluated directly against mapped RDRAM bytes
    - **Mega CD / Sega CD**: [odelot/MegaCD_MiSTer](https://github.com/odelot/MegaCD_MiSTer)
    - **NeoGeo (MVS / AES / CD)**: [odelot/NeoGeo_MiSTer](https://github.com/odelot/NeoGeo_MiSTer)
    - **TurboGrafx-16 / PC Engine**: [odelot/TurboGrafx16_MiSTer](https://github.com/odelot/TurboGrafx16_MiSTer)
-   - **Atari 2600** (load a `.a26` ROM in the Atari7800 core): [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer)
+   - **Atari 2600 / 7800** (load a `.a26` or `.a78` ROM in the Atari7800 core): [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer)
    - **Sega 32X**: [odelot/S32X_MiSTer](https://github.com/odelot/S32X_MiSTer)
+   - **Sega Saturn**: [odelot/Saturn_MiSTer](https://github.com/odelot/Saturn_MiSTer)
 5. Reboot your MiSTer, load the core, and open a game that has achievements on [retroachievements.org](https://retroachievements.org/).
 6. (Optional) Place an `achievement.wav` file in `/media/fat/` to hear a sound effect on unlock.
 
@@ -358,7 +417,8 @@ The Makefile automatically detects the rcheevos library and enables it if presen
 - Modified MegaCD core: [odelot/MegaCD_MiSTer](https://github.com/odelot/MegaCD_MiSTer)
 - Modified NeoGeo core: [odelot/NeoGeo_MiSTer](https://github.com/odelot/NeoGeo_MiSTer)
 - Modified TurboGrafx-16 core: [odelot/TurboGrafx16_MiSTer](https://github.com/odelot/TurboGrafx16_MiSTer)
-- Modified Atari7800 core (Atari 2600 RA): [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer)
+- Modified Atari7800 core (Atari 2600 + 7800 RA): [odelot/Atari7800_MiSTer](https://github.com/odelot/Atari7800_MiSTer)
 - Modified Sega 32X core: [odelot/S32X_MiSTer](https://github.com/odelot/S32X_MiSTer)
+- Modified Saturn core: [odelot/Saturn_MiSTer](https://github.com/odelot/Saturn_MiSTer)
 - RetroAchievements: [retroachievements.org](https://retroachievements.org/)
 - rcheevos library: [RetroAchievements/rcheevos](https://github.com/RetroAchievements/rcheevos)

--- a/achievements.cpp
+++ b/achievements.cpp
@@ -196,7 +196,7 @@ static int g_show_leaderboards_updates = 1; // 1 = show STARTED/FAILED/TRACKER S
 static int g_show_leaderboards_submission = 1; // 1 = show SUBMITTED/SCOREBOARD popups
 static int g_hardcore                  = 0; // 1 = hardcore mode (disables cheats & save states)
 static int g_force_hardcore            = 0; // 1 = force hardcore mode even if core doesn't support it
-static int g_stall_recovery            = 0; // 1 = enable OptionC stall recovery (disabled by default)
+static int g_stall_recovery            = 0; // 1 = enable SelAddr stall recovery (disabled by default)
 static int g_rtquery_enabled           = 1; // 1 = enable realtime queries for AddAddress resolution
 static int g_gba_reset_ram             = 1; // 1 = clear IWRAM+EWRAM on game load (retroachievements.cfg: gba_reset_ram)
 static int g_recollect_interval        = 600; // frames between address re-collections (PSX default 600, SNES 18000)
@@ -732,7 +732,7 @@ static uint32_t ra_read_memory(uint32_t address, uint8_t *buffer,
 	int console = ra_get_console_id();
 	if (console == 7)  // NES
 		return ra_ramread_nes_read(g_ra_map, address, buffer, num_bytes);
-	if (console == 3)  // SNES VBlank-gated (handler returned 0 = not optionc)
+	if (console == 3)  // SNES VBlank-gated (handler returned 0 = not seladdr)
 		return ra_ramread_snes_read(g_ra_map, address, buffer, num_bytes);
 
 	memset(buffer, 0, num_bytes);
@@ -1360,7 +1360,7 @@ void achievements_init(void)
 	signal(SIGFPE,  ra_crash_handler);
 
 	RA_LOG("=== RetroAchievements for MiSTer ===");
-	RA_LOG("Build: OptionC v29-b1 (2026-04-19)");
+	RA_LOG("Build: SelAddr v29-b1 (2026-04-19)");
 	RA_LOG("Phase 5 — Handler dispatch: all per-console logic in separate files");
 
 	const char *core = user_io_get_core_name(1);
@@ -1608,6 +1608,43 @@ void achievements_load_game(const char *rom_path, uint32_t crc32)
         }
 }
 
+// ---------------------------------------------------------------------------
+// Save I/O guard
+//
+// While the core streams its save RAM to/from the ARM (autosave triggered by
+// opening the OSD, manual save/load backup), cores that share the save port
+// with the RA read path serve the SD transfer address instead of the requested
+// one — the SNES routes both through BSRAM Port B (bk_state mux), so every
+// BSRAM/BWRAM read returns a byte from wherever the transfer pointer is.
+// Evaluating rcheevos against those values fires delta conditions spuriously
+// (confirmed: SMRPG unlocks on OSD-open with autosave enabled).
+//
+// The guard suspends achievement evaluation from the first notification until
+// RA_SAVE_IO_GRACE_MS after the last one. The game keeps running; memrefs keep
+// their pre-save values, so deltas resume cleanly against real data. The OSD
+// open itself also arms the guard (see OsdEnable) to close the sub-millisecond
+// race between bk_state rising and the first serviced sector.
+// ---------------------------------------------------------------------------
+#define RA_SAVE_IO_GRACE_MS 700
+
+static struct timespec g_save_io_last = {0, 0};
+static int g_save_io_paused = 0; // evaluation currently suspended (for logs)
+
+void achievements_notify_save_io(void)
+{
+	clock_gettime(CLOCK_MONOTONIC, &g_save_io_last);
+}
+
+static int ra_save_io_active(void)
+{
+	if (!g_save_io_last.tv_sec) return 0;
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	double ms = (now.tv_sec - g_save_io_last.tv_sec) * 1000.0
+	          + (now.tv_nsec - g_save_io_last.tv_nsec) / 1e6;
+	return ms < RA_SAVE_IO_GRACE_MS;
+}
+
 void achievements_poll(void)
 {
 	static uint32_t poll_calls = 0;
@@ -1744,8 +1781,24 @@ void achievements_poll(void)
 
 	(void)busy;
 
+	// Save I/O guard: suspend evaluation while save RAM streams between the
+	// core and the ARM (see achievements_notify_save_io). Everything above
+	// (HTTP pump, OSD popups, mirror validation) keeps running.
+	if (ra_save_io_active()) {
+		if (!g_save_io_paused && g_game_loaded) {
+			g_save_io_paused = 1;
+			RA_LOG("Save I/O detected — achievement evaluation paused");
+		}
+		return;
+	}
+	if (g_save_io_paused) {
+		g_save_io_paused = 0;
+		if (g_game_loaded)
+			RA_LOG("Save I/O finished — achievement evaluation resumed");
+	}
+
 #ifdef HAS_RCHEEVOS
-	// Dispatch to active console handler (handles all Option C consoles)
+	// Dispatch to active console handler (handles all Selective Address consoles)
 	if (g_active_handler && g_active_handler->poll) {
 		if (g_active_handler->poll(g_ra_map, g_client, g_game_loaded))
 			return;
@@ -1987,7 +2040,14 @@ int achievements_smart_cache_enabled(void)
 
 #ifdef HAS_RCHEEVOS
 	int cid = ra_get_console_id();
-	if (cid == RC_CONSOLE_PLAYSTATION || cid == RC_CONSOLE_NINTENDO || cid == RC_CONSOLE_MEGA_DRIVE || cid == RC_CONSOLE_SUPER_NINTENDO || cid == RC_CONSOLE_GAMEBOY_ADVANCE) {
+	// All Selective Address cores except SMS now support the RTQuery mailbox
+	// (SMS is Legacy-only: no FPGA-side realtime-query support yet).
+	if (cid == RC_CONSOLE_PLAYSTATION || cid == RC_CONSOLE_NINTENDO || cid == RC_CONSOLE_MEGA_DRIVE ||
+	    cid == RC_CONSOLE_SUPER_NINTENDO || cid == RC_CONSOLE_GAMEBOY_ADVANCE ||
+	    cid == RC_CONSOLE_GAMEBOY || cid == RC_CONSOLE_GAMEBOY_COLOR ||
+	    cid == RC_CONSOLE_SEGA_CD || cid == RC_CONSOLE_SEGA_32X ||
+	    cid == RC_CONSOLE_PC_ENGINE || cid == RC_CONSOLE_PC_ENGINE_CD ||
+	    cid == RC_CONSOLE_ARCADE || cid == RC_CONSOLE_NEO_GEO_CD) {
 		return 1;
 	}
 #endif

--- a/achievements.h
+++ b/achievements.h
@@ -33,6 +33,14 @@ void achievements_unload_game(void);
 // Notify RA runtime that an in-core reset happened (without unloading the game).
 void achievements_notify_core_reset(void);
 
+// Notify that save-RAM I/O between the core and the ARM is happening (autosave
+// on OSD-open, manual save/load backup). Cores that share the save port with
+// the RA read path (e.g. SNES BSRAM Port B) return bytes from the SD transfer
+// pointer instead of the requested address while the transfer runs, so
+// achievement evaluation is suspended for the burst plus a grace period.
+// Call once per serviced sector (cheap: just stamps a timestamp).
+void achievements_notify_save_io(void);
+
 // Shutdown. Frees all resources.
 void achievements_deinit(void);
 

--- a/achievements_console.h
+++ b/achievements_console.h
@@ -8,9 +8,9 @@
 #include "rc_client.h"
 #endif
 
-// Common console state structure for Option C consoles
+// Common console state structure for Selective Address consoles
 typedef struct {
-	int optionc;              // 1 if FPGA has Option C protocol
+	int seladdr;              // 1 if FPGA has Selective Address protocol
 	int collecting;           // 1 during address collection do_frame
 	int cache_ready;          // 1 when FPGA response matches request
 	int needs_recollect;      // 1 if re-collection needed (PSX/N64/NeoGeo)
@@ -21,7 +21,6 @@ typedef struct {
 	struct timespec cache_time; // Timestamp when cache became active
 	struct timespec stall_time; // Timestamp when resp_frame last advanced
 	uint32_t stall_frame;       // resp_frame value when stall tracking started
-	int cache_reindexing;       // 1 after cleanup prune, until FPGA responds with new index order
 } console_state_t;
 
 // Console-specific interface
@@ -89,21 +88,21 @@ const console_handler_t *get_console_handler_by_id(int console_id);
 // Initialize all console handlers (called once at startup)
 void init_all_console_handlers(void);
 
-// Shared OptionC stall recovery check.
+// Shared SelAddr stall recovery check.
 // Call from the else branch of 'if (resp_frame > state->last_resp_frame)'.
 // Returns 1 if recovery was triggered (caller should reset cache_ready etc).
 // Requires: achievements_stall_recovery_enabled() from achievements.h
-int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
+int seladdr_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                                   const char *console_name);
 
-// Shared OptionC backward-frame resync.
+// Shared SelAddr backward-frame resync.
 // Call right after reading resp_frame, before comparing it to last_resp_frame.
 // If the FPGA frame counter went backward (core was reset without the ARM
 // being notified — e.g. savestate load, download reset, PAL/NTSC switch, or a
 // stale post-reset response), resyncs last_resp_frame so tracking resumes on
 // the next VBlank instead of stalling until the counter catches up.
 // Returns 1 if a resync happened.
-int optionc_resync_if_backward(console_state_t *state, uint32_t resp_frame,
+int seladdr_resync_if_backward(console_state_t *state, uint32_t resp_frame,
                                 const char *console_name);
 
 // GBA: dump valcache when an achievement triggers (call from event handler)

--- a/achievements_console_lookup.cpp
+++ b/achievements_console_lookup.cpp
@@ -104,13 +104,13 @@ void init_all_console_handlers(void)
 
 
 // ---------------------------------------------------------------------------
-// Shared OptionC stall recovery
+// Shared SelAddr stall recovery
 // ---------------------------------------------------------------------------
 
 #include "achievements.h"
 #include "ra_ramread.h"
 
-int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
+int seladdr_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                                   const char *console_name)
 {
         if (!achievements_stall_recovery_enabled()) return 0;
@@ -121,7 +121,7 @@ int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
                 + (now.tv_nsec - state->stall_time.tv_nsec) / 1e9;
 
         if (stall_secs >= 5.0 && state->stall_frame == resp_frame) {
-                ra_log_write("%s OptionC: STALL RECOVERY -- resp_frame=%u stuck for %.1fs, re-collecting\n",
+                ra_log_write("%s SelAddr: STALL RECOVERY -- resp_frame=%u stuck for %.1fs, re-collecting\n",
                         console_name, resp_frame, stall_secs);
                 state->cache_ready = 0;
                 state->needs_recollect = 0;
@@ -133,11 +133,11 @@ int optionc_check_stall_recovery(console_state_t *state, uint32_t resp_frame,
         return 0;
 }
 
-int optionc_resync_if_backward(console_state_t *state, uint32_t resp_frame,
+int seladdr_resync_if_backward(console_state_t *state, uint32_t resp_frame,
                                 const char *console_name)
 {
         if (resp_frame < state->last_resp_frame) {
-                ra_log_write("%s OptionC: resp_frame went backward (%u -> %u) -- FPGA reset without notify, resyncing\n",
+                ra_log_write("%s SelAddr: resp_frame went backward (%u -> %u) -- FPGA reset without notify, resyncing\n",
                         console_name, state->last_resp_frame, resp_frame);
                 state->last_resp_frame = resp_frame;
                 clock_gettime(CLOCK_MONOTONIC, &state->stall_time);

--- a/achievements_gameboy.cpp
+++ b/achievements_gameboy.cpp
@@ -66,26 +66,15 @@ static void gameboy_reset(void)
 
 static uint32_t gameboy_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_gb_state.optionc) {
+	if (g_gb_state.seladdr) {
 		if (g_gb_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_gb_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_gb_rtquery) {
-				if (g_gb_state.cache_reindexing) {
-					if (num_bytes <= 4) {
-						uint32_t val = ra_rtquery_read(map, address, num_bytes);
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = (uint8_t)(val >> (i * 8));
-						return num_bytes;
-					}
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						uint32_t val = ra_rtquery_read(map, address + i, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
+				// List-change misalignment is handled inside ra_snes_addrlist_*
+				// (active-snapshot mapping) — no rtquery-all reindex needed.
 				int any_miss = 0;
 				for (uint32_t i = 0; i < num_bytes; i++) {
 					if (ra_snes_addrlist_contains(address + i) < 0) {
@@ -135,7 +124,7 @@ static uint32_t gameboy_read_memory(void *map, uint32_t address, uint8_t *buffer
 static int gameboy_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_gb_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_gb_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
@@ -145,6 +134,9 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 	if (achievements_smart_cache_enabled() && g_gb_rtquery) {
 
 		if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
+			// Re-prime to WAITING before the all-zero collection frame so a
+			// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
 			g_gb_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -161,16 +153,14 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 				g_gb_state.game_frames = 0;
 				g_gb_state.poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_gb_state.cache_time);
-				ra_log_write("GB SmartCache: Cache active! %d addrs\n", ra_snes_addrlist_count());
+				// Discard the zero-primed bootstrap state (delta conditions
+				// would otherwise see 0 -> real transitions and fire).
+				rc_client_reset(rc_client);
+				ra_log_write("GB SmartCache: Cache active! %d addrs (rc_client reset)\n", ra_snes_addrlist_count());
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
-
-			if (g_gb_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_gb_state.cache_reindexing = 0;
-				ra_log_write("GB SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
 
 			if (resp_frame > g_gb_state.last_resp_frame) {
 				g_gb_state.last_resp_frame = resp_frame;
@@ -181,9 +171,12 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 					ra_log_write("GB SmartCache: GameFrame %u (resp_frame=%u, addrs=%d)\n",
 						g_gb_state.game_frames, resp_frame, ra_snes_addrlist_count());
 
+				// Cleanup recollect only when the FPGA confirmed the current
+				// list — keeps a single revision in flight so the active
+				// snapshot stays valid for cached reads during the switch.
 				int cleanup_frame = (g_gb_state.game_frames % 600 == 0)
 					&& (g_gb_state.game_frames > 0)
-					&& !g_gb_state.cache_reindexing;
+					&& ra_snes_addrlist_is_ready(map);
 				if (cleanup_frame) {
 					g_gb_state.collecting = 1;
 					ra_snes_addrlist_begin_collect();
@@ -198,7 +191,6 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 						int new_count = ra_snes_addrlist_count();
 						ra_log_write("GB SmartCache: Cleanup — pruned %d stale (%d -> %d)\n",
 							old_count - new_count, old_count, new_count);
-						g_gb_state.cache_reindexing = 1;
 					}
 				} else {
 					if (ra_snes_addrlist_has_pending())
@@ -228,17 +220,19 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_gb_state.cache_ready) {
-		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		// Bootstrap: run one do_frame with zeros to discover needed addresses.
+		// Re-prime to WAITING first (see smart-cache bootstrap).
+		rc_client_reset(rc_client);
 		g_gb_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_gb_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("GB OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("GB SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		} else {
-			ra_log_write("GB OptionC: No addresses collected — achievements may have no memory refs\n");
+			ra_log_write("GB SelAddr: No addresses collected — achievements may have no memory refs\n");
 		}
 	} else if (!g_gb_state.cache_ready) {
 		// Wait for FPGA to respond with cached values
@@ -248,12 +242,14 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 			g_gb_state.game_frames = 0;
 			g_gb_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_gb_state.cache_time);
-			ra_log_write("GB OptionC: Cache active! FPGA response matched request.\n");
+			// Discard the zero-primed bootstrap state (see smart-cache path).
+			rc_client_reset(rc_client);
+			ra_log_write("GB SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
 		}
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
+		seladdr_resync_if_backward(&g_gb_state, resp_frame, "GameBoy");
 		if (resp_frame > g_gb_state.last_resp_frame) {
 			g_gb_state.last_resp_frame = resp_frame;
 			g_gb_state.game_frames++;
@@ -261,40 +257,44 @@ static int gameboy_poll(void *map, void *client, int game_loaded)
 			clock_gettime(CLOCK_MONOTONIC, &g_gb_state.stall_time);
 			g_gb_state.stall_frame = resp_frame;
 
-			// Periodically re-collect to catch address changes (every ~5 min)
-			// Smart cache mode: skip re-collect (no dynamic pointers in GameBoy)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_gb_state.game_frames % 18000 == 0) && (g_gb_state.game_frames > 0);
-			if (re_collect) {
-				g_gb_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
-
-			rc_client_do_frame(rc_client);
-
-			// Value-change watchers
-			for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
-				uint8_t cur = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
-				if (!g_gb_watchers[i].initialized) {
-					g_gb_watchers[i].last_val = cur;
-					g_gb_watchers[i].initialized = 1;
-				} else if (cur != g_gb_watchers[i].last_val) {
-					ra_log_write("GB Watch[%s @ 0x%04X]: 0x%02X -> 0x%02X (frame %u)\n",
-						g_gb_watchers[i].name, g_gb_watchers[i].addr,
-						g_gb_watchers[i].last_val, cur, g_gb_state.game_frames);
-					g_gb_watchers[i].last_val = cur;
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Periodically re-collect to catch address changes (every ~5 min)
+				// Smart cache mode: skip re-collect (no dynamic pointers in GameBoy)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_gb_state.game_frames % 18000 == 0) && (g_gb_state.game_frames > 0);
+				if (re_collect) {
+					g_gb_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
 				}
-			}
 
-			if (re_collect) {
-				g_gb_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("GB OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				rc_client_do_frame(rc_client);
+
+				// Value-change watchers
+				for (unsigned int i = 0; i < GB_WATCHER_COUNT; i++) {
+					uint8_t cur = ra_snes_addrlist_read_cached(map, g_gb_watchers[i].addr);
+					if (!g_gb_watchers[i].initialized) {
+						g_gb_watchers[i].last_val = cur;
+						g_gb_watchers[i].initialized = 1;
+					} else if (cur != g_gb_watchers[i].last_val) {
+						ra_log_write("GB Watch[%s @ 0x%04X]: 0x%02X -> 0x%02X (frame %u)\n",
+							g_gb_watchers[i].name, g_gb_watchers[i].addr,
+							g_gb_watchers[i].last_val, cur, g_gb_state.game_frames);
+						g_gb_watchers[i].last_val = cur;
+					}
+				}
+
+				if (re_collect) {
+					g_gb_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("GB SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_gb_state, resp_frame, "GameBoy");
+			seladdr_check_stall_recovery(&g_gb_state, resp_frame, "GameBoy");
 		}
 	}
 
@@ -339,8 +339,8 @@ static int gameboy_detect_protocol(void *map)
 		ra_log_write("Gameboy: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	g_gb_state.optionc = 1;
-	ra_log_write("Gameboy FPGA protocol: Option C (selective address reading)\n");
+	g_gb_state.seladdr = 1;
+	ra_log_write("Gameboy FPGA protocol: Selective Address (selective address reading)\n");
 
 	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
 		g_gb_rtquery = 1;

--- a/achievements_gba.cpp
+++ b/achievements_gba.cpp
@@ -29,10 +29,10 @@ static int g_gba_rtquery = 0; // 1 if FPGA supports realtime queries (core v2+)
 static void *g_gba_last_map = NULL;
 
 // ---------------------------------------------------------------------------
-// GBA Option C Diagnostics
+// GBA Selective Address Diagnostics
 // ---------------------------------------------------------------------------
 
-static void gba_optionc_dump_valcache(const char *label, void *map)
+static void gba_seladdr_dump_valcache(const char *label, void *map)
 {
         if (!map) return;
         const uint8_t *base = (const uint8_t *)map;
@@ -96,7 +96,7 @@ static void gba_reset(void)
 
 static uint32_t gba_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-        if (!g_gba_state.optionc)
+        if (!g_gba_state.seladdr)
                 return 0;
 
         if (g_gba_state.collecting) {
@@ -113,21 +113,10 @@ static uint32_t gba_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
                                 memset(buffer, 0, num_bytes);
                                 return num_bytes;
                         }
-                        // While the FPGA is re-syncing to a new address list the
-                        // valcache still reflects the OLD list ordering — indexed
-                        // reads would return the neighbour's byte. Use rtquery for
-                        // everything until the response_id matches again.
-                        if (g_gba_state.cache_reindexing) {
-                                if (num_bytes <= 4) {
-                                        uint32_t val = ra_rtquery_read(map, address, num_bytes);
-                                        for (uint32_t i = 0; i < num_bytes; i++)
-                                                buffer[i] = (uint8_t)(val >> (i * 8));
-                                        return num_bytes;
-                                }
-                                for (uint32_t i = 0; i < num_bytes; i++)
-                                        buffer[i] = (uint8_t)ra_rtquery_read(map, address + i, 1);
-                                return num_bytes;
-                        }
+                        // List-change misalignment is handled inside
+                        // ra_snes_addrlist_* (active-snapshot mapping): cached
+                        // lookups always follow the ordering the FPGA confirmed,
+                        // so no rtquery-all reindex window is needed.
                         // Smart Cache: batch-cached bytes come from the valcache;
                         // misses are answered by rtquery and scheduled for the
                         // FPGA batch via add_dynamic.
@@ -186,7 +175,7 @@ static uint32_t gba_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 static int gba_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-        if (!client || !game_loaded || !map || !g_gba_state.optionc)
+        if (!client || !game_loaded || !map || !g_gba_state.seladdr)
                 return 0;
 
         g_gba_last_map = map;
@@ -200,7 +189,10 @@ static int gba_poll(void *map, void *client, int game_loaded)
         if (achievements_smart_cache_enabled() && g_gba_rtquery) {
 
                 if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
-                        // Phase 1: Bootstrap (reads answered via rtquery fallback)
+                        // Phase 1: Bootstrap (reads return zero during collection).
+                        // Re-prime to WAITING first so active triggers (mid-game
+                        // re-bootstrap after stall recovery) cannot fire on zeros.
+                        rc_client_reset(rc_client);
                         g_gba_state.collecting = 1;
                         ra_snes_addrlist_begin_collect();
                         rc_client_do_frame(rc_client);
@@ -226,18 +218,12 @@ static int gba_poll(void *map, void *client, int game_loaded)
                                 rc_client_reset(rc_client);
                                 ra_log_write("GBA SmartCache: Cache active! %d addrs monitored (rc_client reset)\n",
                                         ra_snes_addrlist_count());
-                                gba_optionc_dump_valcache("smart-active", map);
+                                gba_seladdr_dump_valcache("smart-active", map);
                         }
                 } else {
                         // Phase 3: Normal — cache miss handled in read_memory
                         uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-                        optionc_resync_if_backward(&g_gba_state, resp_frame, "GBA");
-
-                        if (g_gba_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-                                g_gba_state.cache_reindexing = 0;
-                                ra_log_write("GBA SmartCache: Reindex complete (%d addrs)\n",
-                                        ra_snes_addrlist_count());
-                        }
+                        seladdr_resync_if_backward(&g_gba_state, resp_frame, "GBA");
 
                         if (resp_frame > g_gba_state.last_resp_frame) {
                                 g_gba_state.last_resp_frame = resp_frame;
@@ -258,22 +244,17 @@ static int gba_poll(void *map, void *client, int game_loaded)
                                 // re-add themselves via rtquery misses next frame.
                                 if (achievements_smart_cleanup_enabled()
                                                 && (g_gba_state.game_frames % 3600 == 0)
-                                                && !g_gba_state.cache_reindexing
                                                 && ra_snes_addrlist_dyn_count() > 128) {
                                         int removed = ra_snes_addrlist_prune_dynamic(map);
                                         if (removed) {
                                                 ra_log_write("GBA SmartCache: pruned %d dynamic addrs (%d static kept)\n",
                                                         removed, ra_snes_addrlist_count());
-                                                g_gba_state.cache_reindexing = 1;
                                         }
                                 } else if (ra_snes_addrlist_has_pending()) {
-                                        // List order changed: reads go through rtquery
-                                        // until the FPGA answers with the new index order.
-                                        if (ra_snes_addrlist_flush_dynamic(map))
-                                                g_gba_state.cache_reindexing = 1;
+                                        ra_snes_addrlist_flush_dynamic(map);
                                 }
                         } else {
-                                optionc_check_stall_recovery(&g_gba_state, resp_frame, "GBA");
+                                seladdr_check_stall_recovery(&g_gba_state, resp_frame, "GBA");
                         }
                 }
 
@@ -287,12 +268,11 @@ static int gba_poll(void *map, void *client, int game_loaded)
                                 + (now.tv_nsec - g_gba_state.cache_time.tv_nsec) / 1e9;
                         double ms_per_cycle = (g_gba_state.game_frames > 0) ?
                                 (elapsed * 1000.0 / g_gba_state.game_frames) : 0.0;
-                        ra_log_write("POLL(GBA-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d dyn=%d reindexing=%d\n",
+                        ra_log_write("POLL(GBA-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d dyn=%d\n",
                                 g_gba_state.last_resp_frame, g_gba_state.game_frames, elapsed, ms_per_cycle,
-                                ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count(),
-                                g_gba_state.cache_reindexing);
+                                ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
                         if ((g_gba_state.game_frames % 1800) < 300)
-                                gba_optionc_dump_valcache("periodic-sc", map);
+                                gba_seladdr_dump_valcache("periodic-sc", map);
                 }
 
                 return 1;
@@ -303,18 +283,21 @@ static int gba_poll(void *map, void *client, int game_loaded)
         // ===================================================================
 
         if (ra_snes_addrlist_count() == 0 && !g_gba_state.cache_ready) {
-                // Bootstrap: run one do_frame with zeros to discover needed addresses
+                // Bootstrap: run one do_frame with zeros to discover needed addresses.
+                // Re-prime to WAITING first so active triggers (mid-game re-bootstrap
+                // after stall recovery) cannot fire on the all-zero reads.
+                rc_client_reset(rc_client);
                 g_gba_state.collecting = 1;
                 ra_snes_addrlist_begin_collect();
                 rc_client_do_frame(rc_client);
                 g_gba_state.collecting = 0;
                 int changed = ra_snes_addrlist_end_collect(map);
                 if (changed) {
-                        ra_log_write("GBA OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+                        ra_log_write("GBA SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
                                 ra_snes_addrlist_count());
-                        gba_optionc_dump_valcache("bootstrap", map);
+                        gba_seladdr_dump_valcache("bootstrap", map);
                 } else {
-                        ra_log_write("GBA OptionC: No addresses collected\n");
+                        ra_log_write("GBA SelAddr: No addresses collected\n");
                 }
         } else if (!g_gba_state.cache_ready) {
                 // Wait for FPGA response
@@ -328,22 +311,13 @@ static int gba_poll(void *map, void *client, int game_loaded)
                         // achievement already satisfied by the real state cannot pop
                         // on the first genuine frame.
                         rc_client_reset(rc_client);
-                        ra_log_write("GBA OptionC: Cache active! FPGA response matched request (rc_client reset).\n");
-                        gba_optionc_dump_valcache("cache-active", map);
+                        ra_log_write("GBA SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
+                        gba_seladdr_dump_valcache("cache-active", map);
                 }
         } else {
                 // Normal frame processing from cache
                 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-                optionc_resync_if_backward(&g_gba_state, resp_frame, "GBA");
-
-                // After a recollect changed the list, the valcache is misaligned
-                // (old ordering) until the FPGA answers the new request_id. Skip
-                // achievement processing for those 1-2 frames.
-                if (g_gba_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-                        g_gba_state.cache_reindexing = 0;
-                        ra_log_write("GBA OptionC: Recollect sync complete (%d addrs)\n",
-                                ra_snes_addrlist_count());
-                }
+                seladdr_resync_if_backward(&g_gba_state, resp_frame, "GBA");
 
                 if (resp_frame > g_gba_state.last_resp_frame) {
                         g_gba_state.last_resp_frame = resp_frame;
@@ -353,12 +327,17 @@ static int gba_poll(void *map, void *client, int game_loaded)
                         g_gba_state.stall_frame = resp_frame;
 
                         if (g_gba_state.game_frames <= 5) {
-                                ra_log_write("GBA OptionC: GameFrame %u (resp_frame=%u)\n",
+                                ra_log_write("GBA SelAddr: GameFrame %u (resp_frame=%u)\n",
                                         g_gba_state.game_frames, resp_frame);
-                                gba_optionc_dump_valcache("early-frame", map);
+                                gba_seladdr_dump_valcache("early-frame", map);
                         }
 
-                        if (!g_gba_state.cache_reindexing) {
+                        // While a list revision is in flight (recollect published,
+                        // FPGA not yet confirmed) newly collected addresses would
+                        // read as 0 — skip achievement processing for those 1-2
+                        // frames. Addresses from the confirmed snapshot stay valid
+                        // throughout, so nothing else is lost.
+                        if (ra_snes_addrlist_is_ready(map)) {
                                 // Periodic re-collect catches AddAddress pointer moves
                                 // (Pokémon SaveBlock relocation) without rtquery support.
                                 uint32_t interval = (uint32_t)achievements_recollect_interval();
@@ -375,14 +354,13 @@ static int gba_poll(void *map, void *client, int game_loaded)
                                 if (re_collect) {
                                         g_gba_state.collecting = 0;
                                         if (ra_snes_addrlist_end_collect(map)) {
-                                                g_gba_state.cache_reindexing = 1;
-                                                ra_log_write("GBA OptionC: Address list refreshed, %d addrs\n",
+                                                ra_log_write("GBA SelAddr: Address list refreshed, %d addrs\n",
                                                         ra_snes_addrlist_count());
                                         }
                                 }
                         }
                 } else {
-                	optionc_check_stall_recovery(&g_gba_state, resp_frame, "GBA");
+                	seladdr_check_stall_recovery(&g_gba_state, resp_frame, "GBA");
                 }
         }
 
@@ -400,10 +378,10 @@ static int gba_poll(void *map, void *client, int game_loaded)
                         g_gba_state.last_resp_frame, g_gba_state.game_frames, elapsed, ms_per_cycle,
                         ra_snes_addrlist_count());
                 if ((g_gba_state.game_frames % 1800) < 300)
-                        gba_optionc_dump_valcache("periodic", map);
+                        gba_seladdr_dump_valcache("periodic", map);
         }
 
-        return 1; // GBA Option C handled
+        return 1; // GBA Selective Address handled
 #else
         return 0;
 #endif
@@ -415,7 +393,7 @@ void gba_dump_trigger(uint32_t ach_id)
         if (!g_gba_last_map) return;
         char label[32];
         snprintf(label, sizeof(label), "trigger-%u", ach_id);
-        gba_optionc_dump_valcache(label, g_gba_last_map);
+        gba_seladdr_dump_valcache(label, g_gba_last_map);
 #endif
 }
 
@@ -495,8 +473,8 @@ static int gba_detect_protocol(void *map)
                 ra_log_write("GBA: FPGA mirror not detected -- RA support unavailable\n");
                 return 0;
         }
-        // GBA always uses Option C
-        g_gba_state.optionc = 1;
+        // GBA always uses Selective Address
+        g_gba_state.seladdr = 1;
         gba_init_flash_ddram();
         if (achievements_gba_reset_ram())
                 ra_clear_en_set(map);    // FPGA clears IWRAM/EWRAM + fills flash on game load
@@ -515,7 +493,7 @@ static int gba_detect_protocol(void *map)
                 ra_log_write("GBA: Realtime queries NOT supported (FPGA v1)\n");
         }
 
-        ra_log_write("GBA FPGA protocol: Option C (%s)\n",
+        ra_log_write("GBA FPGA protocol: Selective Address (%s)\n",
                 g_gba_rtquery ? "smart cache + rtquery" : "selective address reading");
         return 1;
 }

--- a/achievements_genesis.cpp
+++ b/achievements_genesis.cpp
@@ -38,26 +38,15 @@ static void genesis_reset(void)
 
 static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_md_state.optionc) {
+	if (g_md_state.seladdr) {
 		if (g_md_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_md_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_md_rtquery) {
-				if (g_md_state.cache_reindexing) {
-					if (num_bytes <= 4) {
-						uint32_t val = ra_rtquery_read(map, address, num_bytes);
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = (uint8_t)(val >> (i * 8));
-						return num_bytes;
-					}
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						uint32_t val = ra_rtquery_read(map, address + i, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
+				// List-change misalignment is handled inside ra_snes_addrlist_*
+				// (active-snapshot mapping) — no rtquery-all reindex needed.
 				int any_miss = 0;
 				for (uint32_t i = 0; i < num_bytes; i++) {
 					if (ra_snes_addrlist_contains(address + i) < 0) {
@@ -107,7 +96,7 @@ static uint32_t genesis_read_memory(void *map, uint32_t address, uint8_t *buffer
 static int genesis_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_md_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_md_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
@@ -117,6 +106,9 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 	if (achievements_smart_cache_enabled() && g_md_rtquery) {
 
 		if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
+			// Re-prime to WAITING before the all-zero collection frame so a
+			// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
 			g_md_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -133,16 +125,14 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 				g_md_state.game_frames = 0;
 				g_md_state.poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_md_state.cache_time);
-				ra_log_write("MD SmartCache: Cache active! %d addrs\n", ra_snes_addrlist_count());
+				// Discard the zero-primed bootstrap state (delta conditions
+				// would otherwise see 0 -> real transitions and fire).
+				rc_client_reset(rc_client);
+				ra_log_write("MD SmartCache: Cache active! %d addrs (rc_client reset)\n", ra_snes_addrlist_count());
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_md_state, resp_frame, "Genesis");
-
-			if (g_md_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_md_state.cache_reindexing = 0;
-				ra_log_write("MD SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_md_state, resp_frame, "Genesis");
 
 			if (resp_frame > g_md_state.last_resp_frame) {
 				g_md_state.last_resp_frame = resp_frame;
@@ -160,13 +150,11 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 				// re-add themselves via rtquery misses next frame.
 				if (achievements_smart_cleanup_enabled()
 						&& (g_md_state.game_frames % 3600 == 0)
-						&& !g_md_state.cache_reindexing
 						&& ra_snes_addrlist_dyn_count() > 128) {
 					int removed = ra_snes_addrlist_prune_dynamic(map);
 					if (removed) {
 						ra_log_write("MD SmartCache: pruned %d dynamic addrs (%d static kept)\n",
 							removed, ra_snes_addrlist_count());
-						g_md_state.cache_reindexing = 1;
 					}
 				} else if (ra_snes_addrlist_has_pending()) {
 					ra_snes_addrlist_flush_dynamic(map);
@@ -195,17 +183,19 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_md_state.cache_ready) {
-		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		// Bootstrap: run one do_frame with zeros to discover needed addresses.
+		// Re-prime to WAITING first (see smart-cache bootstrap).
+		rc_client_reset(rc_client);
 		g_md_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_md_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("MD OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("MD SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		} else {
-			ra_log_write("MD OptionC: No addresses collected\n");
+			ra_log_write("MD SelAddr: No addresses collected\n");
 		}
 	} else if (!g_md_state.cache_ready) {
 		// Wait for FPGA to respond with cached values
@@ -215,7 +205,9 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 			g_md_state.game_frames = 0;
 			g_md_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_md_state.cache_time);
-			ra_log_write("MD OptionC: Cache active! FPGA response matched request.\n");
+			// Discard the zero-primed bootstrap state (see smart-cache path).
+			rc_client_reset(rc_client);
+			ra_log_write("MD SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
 			// Dump address list once on activation
 			const uint32_t *a0 = ra_snes_addrlist_addrs();
 			int ac = ra_snes_addrlist_count();
@@ -228,7 +220,7 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_md_state, resp_frame, "Genesis");
+		seladdr_resync_if_backward(&g_md_state, resp_frame, "Genesis");
 		if (resp_frame > g_md_state.last_resp_frame) {
 			g_md_state.last_resp_frame = resp_frame;
 			g_md_state.game_frames++;
@@ -251,26 +243,30 @@ static int genesis_poll(void *map, void *client, int game_loaded)
 					g_md_state.game_frames, eh, enz);
 			}
 
-			// Re-collect every ~5 min to catch address changes
-			// Smart cache mode: skip re-collect (no dynamic pointers in Genesis)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_md_state.game_frames % 18000 == 0) && (g_md_state.game_frames > 0);
-			if (re_collect) {
-				g_md_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Re-collect every ~5 min to catch address changes
+				// Smart cache mode: skip re-collect (no dynamic pointers in Genesis)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_md_state.game_frames % 18000 == 0) && (g_md_state.game_frames > 0);
+				if (re_collect) {
+					g_md_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_md_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("MD OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_md_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("MD SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_md_state, resp_frame, "Genesis");
+			seladdr_check_stall_recovery(&g_md_state, resp_frame, "Genesis");
 		}
 	}
 
@@ -315,8 +311,8 @@ static int genesis_detect_protocol(void *map)
 		ra_log_write("Genesis: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	g_md_state.optionc = 1;
-	ra_log_write("MegaDrive FPGA protocol: Option C (selective address reading)\n");
+	g_md_state.seladdr = 1;
+	ra_log_write("MegaDrive FPGA protocol: Selective Address (selective address reading)\n");
 
 	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
 		g_md_rtquery = 1;

--- a/achievements_megacd.cpp
+++ b/achievements_megacd.cpp
@@ -19,6 +19,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_mcd_state = {};
+static int g_mcd_rtquery = 0; // 1 if FPGA supports realtime queries (v2)
 
 // ---------------------------------------------------------------------------
 // MegaCD/MegaCD Implementation
@@ -27,23 +28,52 @@ static console_state_t g_mcd_state = {};
 static void megacd_init(void)
 {
 	memset(&g_mcd_state, 0, sizeof(g_mcd_state));
+	g_mcd_rtquery = 0;
 }
 
 static void megacd_reset(void)
 {
 	memset(&g_mcd_state, 0, sizeof(g_mcd_state));
+	g_mcd_rtquery = 0;
 }
 
 static uint32_t megacd_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_mcd_state.optionc) {
+	if (g_mcd_state.seladdr) {
 		if (g_mcd_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_mcd_state.cache_ready) {
+			if (achievements_smart_cache_enabled() && g_mcd_rtquery) {
+				// List-change misalignment is handled inside ra_snes_addrlist_*
+				// (active-snapshot mapping) — no rtquery-all reindex needed.
+				int any_miss = 0;
+				for (uint32_t i = 0; i < num_bytes; i++)
+					if (ra_snes_addrlist_contains(address + i) < 0) { any_miss = 1; break; }
+				if (!any_miss) {
+					for (uint32_t i = 0; i < num_bytes; i++)
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					return num_bytes;
+				}
+				for (uint32_t i = 0; i < num_bytes; i++) {
+					if (ra_snes_addrlist_contains(address + i) >= 0) {
+						buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+					} else {
+						buffer[i] = (uint8_t)ra_rtquery_read(map, address + i, 1);
+						ra_snes_addrlist_add_dynamic(address + i);
+					}
+				}
+				return num_bytes;
+			}
 			for (uint32_t i = 0; i < num_bytes; i++)
 				buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+			return num_bytes;
+		}
+		if (g_mcd_rtquery && achievements_rtquery_enabled() && !g_mcd_state.collecting && num_bytes <= 4) {
+			uint32_t val = ra_rtquery_read(map, address, num_bytes);
+			for (uint32_t i = 0; i < num_bytes; i++)
+				buffer[i] = (uint8_t)(val >> (i * 8));
 			return num_bytes;
 		}
 		memset(buffer, 0, num_bytes);
@@ -55,22 +85,86 @@ static uint32_t megacd_read_memory(void *map, uint32_t address, uint8_t *buffer,
 static int megacd_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_mcd_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_mcd_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
+	// ===================================================================
+	// Smart Cache path (Tier 1): rtquery handles misses, dynamic-only prune.
+	// ===================================================================
+	if (achievements_smart_cache_enabled() && g_mcd_rtquery) {
+		if (ra_snes_addrlist_count() == 0 && !g_mcd_state.cache_ready) {
+			// Re-prime to WAITING before the all-zero collection frame so a
+			// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
+			g_mcd_state.collecting = 1;
+			ra_snes_addrlist_begin_collect();
+			rc_client_do_frame(rc_client);
+			g_mcd_state.collecting = 0;
+			if (ra_snes_addrlist_end_collect(map))
+				ra_log_write("MCD SmartCache: Bootstrap done, %d addrs\n", ra_snes_addrlist_count());
+			else
+				ra_log_write("MCD SmartCache: No addresses collected\n");
+		} else if (!g_mcd_state.cache_ready) {
+			if (ra_snes_addrlist_is_ready(map)) {
+				g_mcd_state.cache_ready = 1;
+				g_mcd_state.last_resp_frame = 0;
+				g_mcd_state.game_frames = 0;
+				g_mcd_state.poll_logged = 0;
+				clock_gettime(CLOCK_MONOTONIC, &g_mcd_state.cache_time);
+				// Discard the zero-primed bootstrap state (delta conditions
+				// would otherwise see 0 -> real transitions and fire).
+				rc_client_reset(rc_client);
+				ra_log_write("MCD SmartCache: Cache active! %d addrs (rc_client reset)\n", ra_snes_addrlist_count());
+			}
+		} else {
+			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+			seladdr_resync_if_backward(&g_mcd_state, resp_frame, "MegaCD");
+			if (resp_frame > g_mcd_state.last_resp_frame) {
+				g_mcd_state.last_resp_frame = resp_frame;
+				g_mcd_state.game_frames++;
+				ra_frame_processed(resp_frame);
+				rc_client_do_frame(rc_client);
+				if (achievements_smart_cleanup_enabled()
+					&& (g_mcd_state.game_frames % 3600 == 0)
+					&& ra_snes_addrlist_dyn_count() > 128) {
+					int removed = ra_snes_addrlist_prune_dynamic(map);
+					if (removed) {
+						ra_log_write("MCD SmartCache: pruned %d dynamic addrs (%d static)\n",
+							removed, ra_snes_addrlist_count());
+					}
+				} else if (ra_snes_addrlist_has_pending()) {
+					ra_snes_addrlist_flush_dynamic(map);
+				}
+			}
+		}
+		uint32_t ms = g_mcd_state.game_frames / 300;
+		if (ms > 0 && ms != g_mcd_state.poll_logged) {
+			g_mcd_state.poll_logged = ms;
+			ra_log_write("POLL(MCD-SC): resp_frame=%u game_frames=%u addrs=%d dyn=%d\n",
+				g_mcd_state.last_resp_frame, g_mcd_state.game_frames,
+				ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
+		}
+		return 1;
+	}
+
+	// ===================================================================
+	// Legacy path: periodic recollect (no rtquery)
+	// ===================================================================
 	if (ra_snes_addrlist_count() == 0 && !g_mcd_state.cache_ready) {
-		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		// Bootstrap: run one do_frame with zeros to discover needed addresses.
+		// Re-prime to WAITING first (see smart-cache bootstrap).
+		rc_client_reset(rc_client);
 		g_mcd_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_mcd_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("MCD OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("MCD SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		} else {
-			ra_log_write("MCD OptionC: No addresses collected\n");
+			ra_log_write("MCD SelAddr: No addresses collected\n");
 		}
 	} else if (!g_mcd_state.cache_ready) {
 		// Wait for FPGA to respond with cached values
@@ -80,7 +174,9 @@ static int megacd_poll(void *map, void *client, int game_loaded)
 			g_mcd_state.game_frames = 0;
 			g_mcd_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_mcd_state.cache_time);
-			ra_log_write("MCD OptionC: Cache active! FPGA response matched request.\n");
+			// Discard the zero-primed bootstrap state (see smart-cache path).
+			rc_client_reset(rc_client);
+			ra_log_write("MCD SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
 			// Dump address list once on activation
 			const uint32_t *a0 = ra_snes_addrlist_addrs();
 			int ac = ra_snes_addrlist_count();
@@ -93,7 +189,7 @@ static int megacd_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_mcd_state, resp_frame, "MegaCD");
+		seladdr_resync_if_backward(&g_mcd_state, resp_frame, "MegaCD");
 		if (resp_frame > g_mcd_state.last_resp_frame) {
 			g_mcd_state.last_resp_frame = resp_frame;
 			g_mcd_state.game_frames++;
@@ -140,26 +236,30 @@ static int megacd_poll(void *map, void *client, int game_loaded)
                                         cnt - 1, vbuf, nz);
                         }
 
-			// Re-collect every ~5 min to catch address changes
-			// Smart cache mode: skip re-collect (no dynamic pointers in MegaCD)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_mcd_state.game_frames % 18000 == 0) && (g_mcd_state.game_frames > 0);
-			if (re_collect) {
-				g_mcd_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Re-collect every ~5 min to catch address changes
+				// Smart cache mode: skip re-collect (no dynamic pointers in MegaCD)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_mcd_state.game_frames % 18000 == 0) && (g_mcd_state.game_frames > 0);
+				if (re_collect) {
+					g_mcd_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_mcd_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("MCD OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_mcd_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("MCD SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_mcd_state, resp_frame, "MegaCD");
+			seladdr_check_stall_recovery(&g_mcd_state, resp_frame, "MegaCD");
 		}
 	}
 
@@ -217,9 +317,21 @@ static int megacd_detect_protocol(void *map)
 		ra_log_write("MEGACD: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// MegaCD always uses Option C (no VBlank-gated mode)
-	g_mcd_state.optionc = 1;
-	ra_log_write("MegaCD FPGA protocol: Option C (selective address reading)\n");
+	// MegaCD always uses Selective Address (no VBlank-gated mode)
+	g_mcd_state.seladdr = 1;
+	ra_log_write("MegaCD FPGA protocol: Selective Address (selective address reading)\n");
+
+	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+		g_mcd_rtquery = 1;
+		ra_rtquery_init(map);
+		ra_log_write("MegaCD: Realtime queries supported and ENABLED\n");
+	} else if (ra_rtquery_supported(map)) {
+		g_mcd_rtquery = 0;
+		ra_log_write("MegaCD: Realtime queries supported but DISABLED by config\n");
+	} else {
+		g_mcd_rtquery = 0;
+		ra_log_write("MegaCD: Realtime queries NOT supported (FPGA v1)\n");
+	}
 	return 1;
 }
 

--- a/achievements_neogeo.cpp
+++ b/achievements_neogeo.cpp
@@ -22,6 +22,11 @@ static console_state_t g_neogeo_state = {};
 static int g_neogeo_is_cd = 0;
 static int g_neogeo_rtquery = 0;
 
+// 1 while trigger state is primed from an all-zero bootstrap frame; the next
+// cache activation must rc_client_reset to discard it. Resolve-pass
+// re-activations run with REAL values, where a reset would only lose progress.
+static int g_neogeo_boot_zero = 0;
+
 // ---------------------------------------------------------------------------
 // NeoGeo Implementation
 // ---------------------------------------------------------------------------
@@ -31,6 +36,7 @@ static void neogeo_init(void)
 	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
 	g_neogeo_is_cd = 0;
 	g_neogeo_rtquery = 0;
+	g_neogeo_boot_zero = 0;
 }
 
 static void neogeo_reset(void)
@@ -38,12 +44,13 @@ static void neogeo_reset(void)
 	memset(&g_neogeo_state, 0, sizeof(g_neogeo_state));
 	g_neogeo_is_cd = 0;
 	g_neogeo_rtquery = 0;
+	g_neogeo_boot_zero = 0;
 }
 
 
 static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_neogeo_state.optionc) {
+	if (g_neogeo_state.seladdr) {
 		if (g_neogeo_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++) {
 				uint32_t a = (address + i);
@@ -53,15 +60,8 @@ static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer,
 		}
 		if (g_neogeo_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_neogeo_rtquery) {
-				if (g_neogeo_state.cache_reindexing) {
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						uint32_t a = (address + i);
-						if (!g_neogeo_is_cd) a ^= 1;
-						uint32_t val = ra_rtquery_read(map, a, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
+				// List-change misalignment is handled inside ra_snes_addrlist_*
+				// (active-snapshot mapping) — no rtquery-all reindex needed.
 				int any_miss = 0;
 				for (uint32_t i = 0; i < num_bytes; i++) {
 					uint32_t a = (address + i);
@@ -114,7 +114,7 @@ static uint32_t neogeo_read_memory(void *map, uint32_t address, uint8_t *buffer,
 static int neogeo_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_neogeo_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_neogeo_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
@@ -124,6 +124,10 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 	if (achievements_smart_cache_enabled() && g_neogeo_rtquery) {
 
 		if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
+			// Re-prime to WAITING before the all-zero collection frame so a
+			// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
+			g_neogeo_boot_zero = 1;
 			g_neogeo_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -143,6 +147,12 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 				g_neogeo_state.game_frames = 0;
 				g_neogeo_state.poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.cache_time);
+				// Only the activation right after a zero-read bootstrap needs
+				// the re-prime; resolve passes ran with real values.
+				if (g_neogeo_boot_zero) {
+					rc_client_reset(rc_client);
+					g_neogeo_boot_zero = 0;
+				}
 				if (g_neogeo_state.needs_recollect)
 					ra_log_write("NeoGeo SmartCache: Cache active (pre-resolve)\n");
 				else
@@ -166,12 +176,7 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			}
 		} else {
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
-
-			if (g_neogeo_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_neogeo_state.cache_reindexing = 0;
-				ra_log_write("NeoGeo SmartCache: Reindex complete (%d addrs)\n", ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
 
 			if (resp_frame > g_neogeo_state.last_resp_frame) {
 				g_neogeo_state.last_resp_frame = resp_frame;
@@ -182,9 +187,12 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 					ra_log_write("NeoGeo SmartCache: GameFrame %u (addrs=%d)\n",
 						g_neogeo_state.game_frames, ra_snes_addrlist_count());
 
+				// Cleanup recollect only when the FPGA confirmed the current
+				// list — keeps a single revision in flight for the active
+				// snapshot in ra_snes_addrlist_*.
 				int cleanup_frame = (g_neogeo_state.game_frames % 600 == 0)
 					&& (g_neogeo_state.game_frames > 0)
-					&& !g_neogeo_state.cache_reindexing;
+					&& ra_snes_addrlist_is_ready(map);
 				if (cleanup_frame) {
 					g_neogeo_state.collecting = 1;
 					ra_snes_addrlist_begin_collect();
@@ -198,7 +206,6 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 					if (ra_snes_addrlist_end_collect(map)) {
 						int new_count = ra_snes_addrlist_count();
 						ra_log_write("NeoGeo SmartCache: Cleanup %d -> %d\n", old_count, new_count);
-						g_neogeo_state.cache_reindexing = 1;
 					}
 				} else {
 					if (ra_snes_addrlist_has_pending())
@@ -229,7 +236,10 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_neogeo_state.cache_ready) {
-		// Phase 1: Bootstrap — collect addresses with zeros
+		// Phase 1: Bootstrap — collect addresses with zeros.
+		// Re-prime to WAITING first (see smart-cache bootstrap).
+		rc_client_reset(rc_client);
+		g_neogeo_boot_zero = 1;
 		g_neogeo_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
@@ -238,10 +248,10 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 		if (changed) {
 			g_neogeo_state.needs_recollect = 1;
 			g_neogeo_state.resolve_pass = 0;
-			ra_log_write("NeoGeo OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("NeoGeo SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		} else {
-			ra_log_write("NeoGeo OptionC: No addresses collected\n");
+			ra_log_write("NeoGeo SelAddr: No addresses collected\n");
 		}
 	} else if (!g_neogeo_state.cache_ready) {
 		// Phase 2/4: Wait for FPGA cache
@@ -251,10 +261,16 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			g_neogeo_state.game_frames = 0;
 			g_neogeo_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.cache_time);
+			// Only the activation right after a zero-read bootstrap needs the
+			// re-prime; resolve passes ran with real values.
+			if (g_neogeo_boot_zero) {
+				rc_client_reset(rc_client);
+				g_neogeo_boot_zero = 0;
+			}
 			if (g_neogeo_state.needs_recollect) {
-				ra_log_write("NeoGeo OptionC: Cache active (pre-recollect). Will resolve pointers.\n");
+				ra_log_write("NeoGeo SelAddr: Cache active (pre-recollect). Will resolve pointers.\n");
 			} else {
-				ra_log_write("NeoGeo OptionC: Cache active! FPGA response matched request.\n");
+				ra_log_write("NeoGeo SelAddr: Cache active! FPGA response matched request.\n");
 			}
 			const uint32_t *a0 = ra_snes_addrlist_addrs();
 			int ac = ra_snes_addrlist_count();
@@ -273,24 +289,24 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 		g_neogeo_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed && g_neogeo_state.resolve_pass < 4) {
-			ra_log_write("NeoGeo OptionC: Pointer-resolve pass %d, %d addrs (changed, retrying)\n",
+			ra_log_write("NeoGeo SelAddr: Pointer-resolve pass %d, %d addrs (changed, retrying)\n",
 				g_neogeo_state.resolve_pass, ra_snes_addrlist_count());
 			g_neogeo_state.cache_ready = 0; // wait for new FPGA data
 		} else {
 			g_neogeo_state.needs_recollect = 0;
 			if (changed) {
-				ra_log_write("NeoGeo OptionC: Pointer-resolve done (max passes), %d addrs\n",
+				ra_log_write("NeoGeo SelAddr: Pointer-resolve done (max passes), %d addrs\n",
 					ra_snes_addrlist_count());
 				g_neogeo_state.cache_ready = 0;
 			} else {
-				ra_log_write("NeoGeo OptionC: Pointer-resolve complete, no address changes (%d addrs)\n",
+				ra_log_write("NeoGeo SelAddr: Pointer-resolve complete, no address changes (%d addrs)\n",
 					ra_snes_addrlist_count());
 			}
 		}
 	} else {
 		// Phase 5: Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
+		seladdr_resync_if_backward(&g_neogeo_state, resp_frame, "NeoGeo");
 		if (resp_frame > g_neogeo_state.last_resp_frame) {
 			g_neogeo_state.last_resp_frame = resp_frame;
 			g_neogeo_state.game_frames++;
@@ -298,26 +314,30 @@ static int neogeo_poll(void *map, void *client, int game_loaded)
 			clock_gettime(CLOCK_MONOTONIC, &g_neogeo_state.stall_time);
 			g_neogeo_state.stall_frame = resp_frame;
 
-			// Re-collect every 18000 frames (~5min).
-			// Smart cache mode: skip re-collect
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_neogeo_state.game_frames % 18000 == 0) && (g_neogeo_state.game_frames > 0);
-			if (re_collect) {
-				g_neogeo_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Re-collect every 18000 frames (~5min).
+				// Smart cache mode: skip re-collect
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_neogeo_state.game_frames % 18000 == 0) && (g_neogeo_state.game_frames > 0);
+				if (re_collect) {
+					g_neogeo_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_neogeo_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("NeoGeo OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_neogeo_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("NeoGeo SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_neogeo_state, resp_frame, "NeoGeo");
+			seladdr_check_stall_recovery(&g_neogeo_state, resp_frame, "NeoGeo");
 		}
 	}
 
@@ -417,9 +437,9 @@ static int neogeo_detect_protocol(void *map)
 		ra_log_write("NeoGeo: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	g_neogeo_state.optionc = 1;
+	g_neogeo_state.seladdr = 1;
 	g_neogeo_is_cd = is_neogeo_cd();
-	ra_log_write("%s FPGA protocol: Option C (selective address reading)\n",
+	ra_log_write("%s FPGA protocol: Selective Address (selective address reading)\n",
 		g_neogeo_is_cd ? "NeoGeoCD" : "NeoGeo");
 
 	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {

--- a/achievements_nes.cpp
+++ b/achievements_nes.cpp
@@ -1,5 +1,5 @@
 // achievements_nes.cpp — RetroAchievements NES-specific implementation
-// Option C + Smart Cache (Tier 1) — selective address reading with RTQuery
+// Selective Address + Smart Cache (Tier 1) — selective address reading with RTQuery
 
 #include "achievements_console.h"
 #include "achievements.h"
@@ -41,27 +41,15 @@ static void nes_reset(void)
 
 static uint32_t nes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_nes_state.optionc) {
+	if (g_nes_state.seladdr) {
 		if (g_nes_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_nes_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_nes_rtquery) {
-				// During reindexing, use rtquery for all reads
-				if (g_nes_state.cache_reindexing) {
-					if (num_bytes <= 4) {
-						uint32_t val = ra_rtquery_read(map, address, num_bytes);
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = (uint8_t)(val >> (i * 8));
-						return num_bytes;
-					}
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						uint32_t val = ra_rtquery_read(map, address + i, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
+				// List-change misalignment is handled inside ra_snes_addrlist_*
+				// (active-snapshot mapping) — no rtquery-all reindex needed.
 				// Smart Cache: check each byte, rtquery on miss
 				int any_miss = 0;
 				for (uint32_t i = 0; i < num_bytes; i++) {
@@ -118,7 +106,7 @@ static uint32_t nes_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 static int nes_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_nes_state.optionc)
+	if (!client || !game_loaded || !map || !g_nes_state.seladdr)
 		return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
@@ -129,7 +117,10 @@ static int nes_poll(void *map, void *client, int game_loaded)
 	if (achievements_smart_cache_enabled() && g_nes_rtquery) {
 
 		if (ra_snes_addrlist_count() == 0 && !g_nes_state.cache_ready) {
-			// Phase 1: Bootstrap
+			// Phase 1: Bootstrap (reads return zero during collection).
+			// Re-prime to WAITING first so active triggers (mid-game
+			// re-bootstrap after stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
 			g_nes_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -149,19 +140,16 @@ static int nes_poll(void *map, void *client, int game_loaded)
 				g_nes_state.game_frames = 0;
 				g_nes_state.poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_nes_state.cache_time);
-				ra_log_write("NES SmartCache: Cache active! %d addrs monitored\n",
+				// Discard the zero-primed bootstrap state (delta conditions
+				// would otherwise see 0 -> real transitions and fire).
+				rc_client_reset(rc_client);
+				ra_log_write("NES SmartCache: Cache active! %d addrs monitored (rc_client reset)\n",
 					ra_snes_addrlist_count());
 			}
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_nes_state, resp_frame, "NES");
-
-			if (g_nes_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_nes_state.cache_reindexing = 0;
-				ra_log_write("NES SmartCache: Reindex complete (%d addrs)\n",
-					ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_nes_state, resp_frame, "NES");
 
 			if (resp_frame > g_nes_state.last_resp_frame) {
 				g_nes_state.last_resp_frame = resp_frame;
@@ -180,13 +168,11 @@ static int nes_poll(void *map, void *client, int game_loaded)
 				// re-add themselves via rtquery misses next frame.
 				if (achievements_smart_cleanup_enabled()
 						&& (g_nes_state.game_frames % 3600 == 0)
-						&& !g_nes_state.cache_reindexing
 						&& ra_snes_addrlist_dyn_count() > 128) {
 					int removed = ra_snes_addrlist_prune_dynamic(map);
 					if (removed) {
 						ra_log_write("NES SmartCache: pruned %d dynamic addrs (%d static kept)\n",
 							removed, ra_snes_addrlist_count());
-						g_nes_state.cache_reindexing = 1;
 					}
 				} else if (ra_snes_addrlist_has_pending()) {
 					ra_snes_addrlist_flush_dynamic(map);
@@ -204,9 +190,9 @@ static int nes_poll(void *map, void *client, int game_loaded)
 				+ (now.tv_nsec - g_nes_state.cache_time.tv_nsec) / 1e9;
 			double ms_per_cycle = (g_nes_state.game_frames > 0) ?
 				(elapsed * 1000.0 / g_nes_state.game_frames) : 0.0;
-			ra_log_write("POLL(NES-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d reindexing=%d\n",
+			ra_log_write("POLL(NES-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d dyn=%d\n",
 				g_nes_state.last_resp_frame, g_nes_state.game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count(), g_nes_state.cache_reindexing);
+				ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
 		}
 
 		return 1;
@@ -217,13 +203,16 @@ static int nes_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_nes_state.cache_ready) {
+		// Re-prime to WAITING before the all-zero collection frame (see
+		// smart-cache bootstrap).
+		rc_client_reset(rc_client);
 		g_nes_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_nes_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("NES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("NES SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		}
 	} else if (!g_nes_state.cache_ready) {
@@ -233,11 +222,13 @@ static int nes_poll(void *map, void *client, int game_loaded)
 			g_nes_state.game_frames = 0;
 			g_nes_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_nes_state.cache_time);
-			ra_log_write("NES OptionC: Cache active!\n");
+			// Discard the zero-primed bootstrap state (see smart-cache path).
+			rc_client_reset(rc_client);
+			ra_log_write("NES SelAddr: Cache active! (rc_client reset)\n");
 		}
 	} else {
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_nes_state, resp_frame, "NES");
+		seladdr_resync_if_backward(&g_nes_state, resp_frame, "NES");
 		if (resp_frame > g_nes_state.last_resp_frame) {
 			g_nes_state.last_resp_frame = resp_frame;
 			g_nes_state.game_frames++;
@@ -246,29 +237,33 @@ static int nes_poll(void *map, void *client, int game_loaded)
 			g_nes_state.stall_frame = resp_frame;
 
 			if (g_nes_state.game_frames <= 5) {
-				ra_log_write("NES OptionC: GameFrame %u (resp_frame=%u)\n",
+				ra_log_write("NES SelAddr: GameFrame %u (resp_frame=%u)\n",
 					g_nes_state.game_frames, resp_frame);
 			}
 
-			// Periodically re-collect (~5 min)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_nes_state.game_frames % 18000 == 0) && (g_nes_state.game_frames > 0);
-			if (re_collect) {
-				g_nes_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Periodically re-collect (~5 min)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_nes_state.game_frames % 18000 == 0) && (g_nes_state.game_frames > 0);
+				if (re_collect) {
+					g_nes_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_nes_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("NES OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_nes_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("NES SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_nes_state, resp_frame, "NES");
+			seladdr_check_stall_recovery(&g_nes_state, resp_frame, "NES");
 		}
 	}
 
@@ -301,15 +296,15 @@ static int nes_detect_protocol(void *map)
 	}
 	const ra_header_t *hdr = (const ra_header_t *)map;
 	if (hdr->region_count == 0) {
-		g_nes_state.optionc = 1;
-		ra_log_write("NES FPGA protocol: Option C (selective address reading)\n");
+		g_nes_state.seladdr = 1;
+		ra_log_write("NES FPGA protocol: Selective Address (selective address reading)\n");
 	} else {
-		g_nes_state.optionc = 0;
+		g_nes_state.seladdr = 0;
 		ra_log_write("NES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n",
 			hdr->region_count);
 	}
 
-	if (g_nes_state.optionc) {
+	if (g_nes_state.seladdr) {
 		if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
 			g_nes_rtquery = 1;
 			ra_rtquery_init(map);

--- a/achievements_psx.cpp
+++ b/achievements_psx.cpp
@@ -21,7 +21,6 @@
 static console_state_t g_psx_state = {};
 static int g_psx_rtquery = 0; // 1 if FPGA supports realtime queries
 static uint32_t g_psx_rtquery_calls = 0;       // rtquery_read calls since last milestone
-static uint32_t g_psx_rtquery_reindex = 0;     // calls made while cache_reindexing
 static uint32_t g_psx_rtquery_miss = 0;        // calls made from cache-miss path
 // ARM-side activity counters (reset each milestone log).
 static uint32_t g_psx_flush_calls   = 0;       // ra_snes_addrlist_flush_dynamic calls (writes addrlist+request_id to DDR3)
@@ -51,12 +50,18 @@ static uint16_t psx_dbg_delta_u16(uint16_t cur, uint16_t prev) {
 //       size right after bootstrap.
 //
 // Rationale: cleanup is the most expensive ARM-side op (qsort + memcmp +
-// DDR3 writes + cache_reindexing window). When the list is stable or only
-// grew a little, the cleanup work doesn't pay for itself.
+// DDR3 writes). When the list is stable or only grew a little, the cleanup
+// work doesn't pay for itself.
 // ---------------------------------------------------------------------------
 #define PSX_CLEANUP_GROWTH_PCT 50  // run cleanup once count > initial * 1.5
 static uint32_t g_psx_initial_addr_count   = 0;
 static int      g_psx_changes_since_cleanup = 0;
+
+// 1 while the trigger state is primed from an all-zero bootstrap frame; the
+// next cache activation must rc_client_reset to discard it. Legacy recollects
+// re-enter the activation phase with REAL values, where a reset would only
+// throw away hit counts — hence a flag instead of an unconditional reset.
+static int g_psx_boot_zero = 0;
 
 // ---------------------------------------------------------------------------
 // Flat-array RAM mirror (PSX-specific O(1) lookup).
@@ -103,13 +108,27 @@ static inline uint8_t psx_mirror_lookup(uint32_t addr, int *hit)
 // Rebuild the monitored flags from the current sorted address list. Called
 // after bootstrap or cleanup-style end_collect, when the entire list may
 // have changed in one shot.
-static void psx_mirror_rebuild_flags(void)
+//
+// values_valid=1 (bootstrap): mark every listed address — the mirror values
+// are filled by psx_mirror_sync before any read happens (cache_ready gates).
+// values_valid=0 (cleanup): only addresses that were already monitored keep
+// the flag. A genuinely-new address must NOT be marked yet: its mirror byte
+// is stale garbage, and a marked lookup would return it as a "hit". Left
+// unmonitored, it misses to rtquery, which stores a real value and marks it.
+static void psx_mirror_rebuild_flags(int values_valid)
 {
-	memset(g_psx_ram_monitored, 0, sizeof(g_psx_ram_monitored));
 	int count = ra_snes_addrlist_count();
 	const uint32_t *addrs = ra_snes_addrlist_addrs();
-	for (int i = 0; i < count; i++)
-		psx_mirror_mark_monitored(addrs[i]);
+	static uint8_t keep[RA_SNES_MAX_ADDRS];
+	if (!values_valid) {
+		for (int i = 0; i < count; i++)
+			keep[i] = (addrs[i] < PSX_RAM_SIZE) ? g_psx_ram_monitored[addrs[i]] : 0;
+	}
+	memset(g_psx_ram_monitored, 0, sizeof(g_psx_ram_monitored));
+	for (int i = 0; i < count; i++) {
+		if (values_valid || keep[i])
+			psx_mirror_mark_monitored(addrs[i]);
+	}
 }
 
 // Pull the freshest values from the FPGA's valcache (DDR3, memory-mapped)
@@ -117,16 +136,16 @@ static void psx_mirror_rebuild_flags(void)
 //
 // Gated on is_ready(map): if the FPGA hasn't yet processed our latest
 // request_id (after add_dynamic+flush or end_collect), the valcache still
-// reflects the OLD list ordering and copying it through our NEW s_snes_addrs[]
-// would corrupt the mirror. Skip the sync in that case and let the mirror
-// stay one frame stale until the FPGA catches up.
+// reflects the OLD list ordering. Iterate the ACTIVE snapshot — the pending
+// list may already contain unpublished insertions that would shift the
+// index-to-address pairing and corrupt the mirror.
 static void psx_mirror_sync(const void *map)
 {
 	if (!map) return;
 	if (!ra_snes_addrlist_is_ready(map)) return;
 	const uint8_t *vals  = (const uint8_t *)map + RA_SNES_VALCACHE_OFFSET + 8;
-	int            count = ra_snes_addrlist_count();
-	const uint32_t *addrs = ra_snes_addrlist_addrs();
+	int            count = ra_snes_addrlist_active_count();
+	const uint32_t *addrs = ra_snes_addrlist_active_addrs();
 	for (int i = 0; i < count; i++) {
 		uint32_t a = addrs[i];
 		if (a < PSX_RAM_SIZE) g_psx_ram_mirror[a] = vals[i];
@@ -142,10 +161,10 @@ static void psx_mirror_reset(void)
 
 
 // ---------------------------------------------------------------------------
-// PSX Option C Diagnostics
+// PSX Selective Address Diagnostics
 // ---------------------------------------------------------------------------
 
-static void psx_optionc_dump_valcache(const char *label, void *map)
+static void psx_seladdr_dump_valcache(const char *label, void *map)
 {
 	if (!map) return;
 	const uint8_t *base = (const uint8_t *)map;
@@ -180,7 +199,6 @@ static void psx_init(void)
 	g_psx_rtquery = 0;
 	g_psx_rtquery_calls = 0;
 	g_psx_rtquery_miss = 0;
-	g_psx_rtquery_reindex = 0;
 	g_psx_flush_calls = 0;
 	g_psx_collect_calls = 0;
 	g_psx_list_changes = 0;
@@ -194,6 +212,7 @@ static void psx_init(void)
 	g_psx_prev_qry_serves = 0;
 	g_psx_initial_addr_count   = 0;
 	g_psx_changes_since_cleanup = 0;
+	g_psx_boot_zero = 0;
 	psx_mirror_reset();
 }
 
@@ -203,7 +222,6 @@ static void psx_reset(void)
 	g_psx_rtquery = 0;
 	g_psx_rtquery_calls = 0;
 	g_psx_rtquery_miss = 0;
-	g_psx_rtquery_reindex = 0;
 	g_psx_flush_calls = 0;
 	g_psx_collect_calls = 0;
 	g_psx_list_changes = 0;
@@ -217,37 +235,22 @@ static void psx_reset(void)
 	g_psx_prev_qry_serves = 0;
 	g_psx_initial_addr_count   = 0;
 	g_psx_changes_since_cleanup = 0;
+	g_psx_boot_zero = 0;
 	psx_mirror_reset();
 }
 
 static uint32_t psx_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_psx_state.optionc) {
+	if (g_psx_state.seladdr) {
 		if (g_psx_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_psx_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_psx_rtquery) {
-				// During reindexing (after cleanup prune), FPGA cache indices are stale.
-				// Use rtquery for all reads until FPGA responds with updated indices.
-				if (g_psx_state.cache_reindexing) {
-					if (num_bytes <= 4) {
-						g_psx_rtquery_calls++;
-						g_psx_rtquery_reindex++;
-						uint32_t val = ra_rtquery_read(map, address, num_bytes);
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = (uint8_t)(val >> (i * 8));
-						return num_bytes;
-					}
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						g_psx_rtquery_calls++;
-						g_psx_rtquery_reindex++;
-						uint32_t val = ra_rtquery_read(map, address + i, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
+				// List-change misalignment cannot corrupt the flat mirror: it is
+				// keyed by address and psx_mirror_sync only copies the valcache
+				// while is_ready (FPGA confirmed the current list ordering).
 				// Flat-mirror lookup: O(1) per byte via psx_mirror_lookup
 				// (monitored-flag check + value load). Replaces the binary
 				// search of ra_snes_addrlist_lookup_byte. The mirror is kept
@@ -321,7 +324,7 @@ static uint32_t psx_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 static int psx_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_psx_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_psx_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
@@ -331,7 +334,11 @@ static int psx_poll(void *map, void *client, int game_loaded)
 	if (achievements_smart_cache_enabled() && g_psx_rtquery) {
 
 		if (ra_snes_addrlist_count() == 0 && !g_psx_state.cache_ready) {
-			// Phase 1: Bootstrap — collect addresses (values come from rtquery)
+			// Phase 1: Bootstrap — reads return zero during collection.
+			// Re-prime to WAITING first so active triggers (mid-game
+			// re-bootstrap after stall recovery) cannot fire on zeros.
+			rc_client_reset(rc_client);
+			g_psx_boot_zero = 1;
 			g_psx_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -339,7 +346,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 			int changed = ra_snes_addrlist_end_collect(map);
 			if (changed) {
 				// Initialize the flat mirror monitored flags from bootstrap list.
-				psx_mirror_rebuild_flags();
+				psx_mirror_rebuild_flags(1);
 				ra_log_write("PSX SmartCache: Bootstrap done, %d addrs written to DDRAM\n",
 					ra_snes_addrlist_count());
 			} else {
@@ -360,21 +367,18 @@ static int psx_poll(void *map, void *client, int game_loaded)
 				g_psx_changes_since_cleanup = 0;
 				// First-time mirror fill from the valcache the FPGA just wrote.
 				psx_mirror_sync(map);
-				ra_log_write("PSX SmartCache: Cache active! %d addrs monitored (initial=%u)\n",
+				// Discard the zero-primed bootstrap state (delta conditions
+				// would otherwise see 0 -> real transitions and fire).
+				rc_client_reset(rc_client);
+				g_psx_boot_zero = 0;
+				ra_log_write("PSX SmartCache: Cache active! %d addrs monitored (initial=%u, rc_client reset)\n",
 					ra_snes_addrlist_count(), g_psx_initial_addr_count);
-				psx_optionc_dump_valcache("smart-active", map);
+				psx_seladdr_dump_valcache("smart-active", map);
 			}
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory via rtquery
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_psx_state, resp_frame, "PSX");
-
-			// Check if FPGA responded after cleanup reindex
-			if (g_psx_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_psx_state.cache_reindexing = 0;
-				ra_log_write("PSX SmartCache: Reindex complete, FPGA cache synced (%d addrs)\n",
-					ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_psx_state, resp_frame, "PSX");
 
 			if (resp_frame > g_psx_state.last_resp_frame) {
 				g_psx_state.last_resp_frame = resp_frame;
@@ -399,7 +403,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 					* (uint32_t)(100 + PSX_CLEANUP_GROWTH_PCT)) / 100u;
 				int cleanup_frame = (g_psx_state.game_frames % 600 == 0)
 					&& (g_psx_state.game_frames > 0)
-					&& !g_psx_state.cache_reindexing
+					&& ra_snes_addrlist_is_ready(map)
 					&& (g_psx_changes_since_cleanup > 0)
 					&& ((uint32_t)ra_snes_addrlist_count() > growth_threshold);
 				if (cleanup_frame) {
@@ -429,13 +433,12 @@ static int psx_poll(void *map, void *client, int game_loaded)
 						int pruned = old_count - new_count;
 						g_psx_list_changes++;
 						// List was replaced wholesale — rebuild the mirror
-						// monitored flags from the new list (clears for pruned
-						// addresses, sets for any newly captured ones).
-						psx_mirror_rebuild_flags();
+						// monitored flags (preserve-only: newly captured
+						// addresses have no valid mirror byte yet, so they
+						// stay unmonitored and self-heal via rtquery misses).
+						psx_mirror_rebuild_flags(0);
 						ra_log_write("PSX SmartCache: Cleanup — pruned %d stale addrs (%d -> %d)\n",
 							pruned, old_count, new_count);
-						// FPGA cache indices are now stale — use rtquery until FPGA responds
-						g_psx_state.cache_reindexing = 1;
 					}
 					// Reset the gate regardless of whether end_collect detected a
 					// change. A cleanup attempt counts as having reconciled.
@@ -479,16 +482,15 @@ static int psx_poll(void *map, void *client, int game_loaded)
 				? (g_psx_doframe_total_ns / g_psx_doframe_count) / 1000ULL
 				: 0;
 			uint64_t max_us = g_psx_doframe_max_ns / 1000ULL;
-			ra_log_write("POLL(PSX-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d reindexing=%d rtq=%u(m=%u r=%u) ARM[flush=%u col=%u chg=%u miss=%u dofrm_avg=%lluus max=%lluus] FPGA[bram_hit=%u bram_miss=%u qry_poll=%u qry_serve=%u]\n",
+			ra_log_write("POLL(PSX-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d rtq=%u(m=%u) ARM[flush=%u col=%u chg=%u miss=%u dofrm_avg=%lluus max=%lluus] FPGA[bram_hit=%u bram_miss=%u qry_poll=%u qry_serve=%u]\n",
 				g_psx_state.last_resp_frame, g_psx_state.game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count(), g_psx_state.cache_reindexing,
-				g_psx_rtquery_calls, g_psx_rtquery_miss, g_psx_rtquery_reindex,
+				ra_snes_addrlist_count(),
+				g_psx_rtquery_calls, g_psx_rtquery_miss,
 				g_psx_flush_calls, g_psx_collect_calls, g_psx_list_changes, g_psx_addmiss_total,
 				(unsigned long long)avg_us, (unsigned long long)max_us,
 				d_hits, d_miss, d_polls, d_serves);
 			g_psx_rtquery_calls = 0;
 			g_psx_rtquery_miss = 0;
-			g_psx_rtquery_reindex = 0;
 			g_psx_flush_calls = 0;
 			g_psx_collect_calls = 0;
 			g_psx_list_changes = 0;
@@ -497,7 +499,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 			g_psx_doframe_max_ns = 0;
 			g_psx_doframe_count = 0;
 			if ((g_psx_state.game_frames % 1800) < 300)
-				psx_optionc_dump_valcache("periodic-sc", map);
+				psx_seladdr_dump_valcache("periodic-sc", map);
 		}
 
 		return 1;
@@ -508,7 +510,10 @@ static int psx_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_psx_state.cache_ready) {
-		// Phase 1: Bootstrap — collect addresses with zero values
+		// Phase 1: Bootstrap — collect addresses with zero values.
+		// Re-prime to WAITING first (see smart-cache bootstrap).
+		rc_client_reset(rc_client);
+		g_psx_boot_zero = 1;
 		g_psx_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
@@ -516,11 +521,11 @@ static int psx_poll(void *map, void *client, int game_loaded)
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
 			g_psx_state.needs_recollect = 1;
-			ra_log_write("PSX OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("PSX SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
-			psx_optionc_dump_valcache("bootstrap", map);
+			psx_seladdr_dump_valcache("bootstrap", map);
 		} else {
-			ra_log_write("PSX OptionC: No addresses collected\n");
+			ra_log_write("PSX SelAddr: No addresses collected\n");
 		}
 	} else if (!g_psx_state.cache_ready) {
 		// Phase 2/4: Wait for FPGA cache
@@ -530,12 +535,18 @@ static int psx_poll(void *map, void *client, int game_loaded)
 			g_psx_state.game_frames = 0;
 			g_psx_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_psx_state.cache_time);
+			// Only the activation right after a zero-read bootstrap needs the
+			// re-prime; recollect re-activations ran with real values.
+			if (g_psx_boot_zero) {
+				rc_client_reset(rc_client);
+				g_psx_boot_zero = 0;
+			}
 			if (g_psx_state.needs_recollect) {
-				ra_log_write("PSX OptionC: Cache active (pre-recollect). Will resolve pointers.\n");
-				psx_optionc_dump_valcache("pre-recollect", map);
+				ra_log_write("PSX SelAddr: Cache active (pre-recollect). Will resolve pointers.\n");
+				psx_seladdr_dump_valcache("pre-recollect", map);
 			} else {
-				ra_log_write("PSX OptionC: Cache active! FPGA response matched request.\n");
-				psx_optionc_dump_valcache("cache-active", map);
+				ra_log_write("PSX SelAddr: Cache active! FPGA response matched request.\n");
+				psx_seladdr_dump_valcache("cache-active", map);
 			}
 		}
 	} else if (g_psx_state.needs_recollect) {
@@ -547,17 +558,17 @@ static int psx_poll(void *map, void *client, int game_loaded)
 		g_psx_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("PSX OptionC: Pointer-resolve re-collection done, %d addrs (changed)\n",
+			ra_log_write("PSX SelAddr: Pointer-resolve re-collection done, %d addrs (changed)\n",
 				ra_snes_addrlist_count());
 			g_psx_state.cache_ready = 0;
-			psx_optionc_dump_valcache("ptr-resolve", map);
+			psx_seladdr_dump_valcache("ptr-resolve", map);
 		} else {
-			ra_log_write("PSX OptionC: Pointer-resolve complete, no address changes\n");
+			ra_log_write("PSX SelAddr: Pointer-resolve complete, no address changes\n");
 		}
 	} else {
 		// Phase 5: Normal frame processing
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_psx_state, resp_frame, "PSX");
+		seladdr_resync_if_backward(&g_psx_state, resp_frame, "PSX");
 		if (resp_frame > g_psx_state.last_resp_frame) {
 			g_psx_state.last_resp_frame = resp_frame;
 			g_psx_state.game_frames++;
@@ -566,9 +577,9 @@ static int psx_poll(void *map, void *client, int game_loaded)
 			g_psx_state.stall_frame = resp_frame;
 
 			if (g_psx_state.game_frames <= 5) {
-				ra_log_write("PSX OptionC: GameFrame %u (resp_frame=%u)\n",
+				ra_log_write("PSX SelAddr: GameFrame %u (resp_frame=%u)\n",
 					g_psx_state.game_frames, resp_frame);
-				psx_optionc_dump_valcache("early-frame", map);
+				psx_seladdr_dump_valcache("early-frame", map);
 			}
 
 			// Re-collect every N frames to track pointer changes (configurable)
@@ -596,13 +607,13 @@ static int psx_poll(void *map, void *client, int game_loaded)
 				g_psx_state.collecting = 0;
 				if (ra_snes_addrlist_end_collect(map)) {
 					g_psx_list_changes++;
-					ra_log_write("PSX OptionC: Address list refreshed, %d addrs\n",
+					ra_log_write("PSX SelAddr: Address list refreshed, %d addrs\n",
 						ra_snes_addrlist_count());
 					g_psx_state.cache_ready = 0;
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_psx_state, resp_frame, "PSX");
+			seladdr_check_stall_recovery(&g_psx_state, resp_frame, "PSX");
 		}
 	}
 
@@ -646,7 +657,7 @@ static int psx_poll(void *map, void *client, int game_loaded)
 		g_psx_doframe_max_ns = 0;
 		g_psx_doframe_count = 0;
 		if ((g_psx_state.game_frames % 1800) < 300)
-			psx_optionc_dump_valcache("periodic", map);
+			psx_seladdr_dump_valcache("periodic", map);
 	}
 
 	return 1; // PSX handled
@@ -688,9 +699,9 @@ static int psx_detect_protocol(void *map)
 		ra_log_write("PSX: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// PSX always uses Option C (no VBlank-gated mode)
-	g_psx_state.optionc = 1;
-	ra_log_write("PSX FPGA protocol: Option C (selective address reading)\n");
+	// PSX always uses Selective Address (no VBlank-gated mode)
+	g_psx_state.seladdr = 1;
+	ra_log_write("PSX FPGA protocol: Selective Address (selective address reading)\n");
 
 	if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
 		g_psx_rtquery = 1;

--- a/achievements_s32x.cpp
+++ b/achievements_s32x.cpp
@@ -18,6 +18,7 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_s32x_state = {};
+static int g_s32x_rtquery = 0; // 1 if FPGA supports realtime queries (v2)
 
 // ---------------------------------------------------------------------------
 // Sega 32X Implementation
@@ -26,23 +27,52 @@ static console_state_t g_s32x_state = {};
 static void s32x_init(void)
 {
 memset(&g_s32x_state, 0, sizeof(g_s32x_state));
+g_s32x_rtquery = 0;
 }
 
 static void s32x_reset(void)
 {
 memset(&g_s32x_state, 0, sizeof(g_s32x_state));
+g_s32x_rtquery = 0;
 }
 
 static uint32_t s32x_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-if (g_s32x_state.optionc) {
+if (g_s32x_state.seladdr) {
 if (g_s32x_state.collecting) {
 for (uint32_t i = 0; i < num_bytes; i++)
 ra_snes_addrlist_add(address + i);
 }
 if (g_s32x_state.cache_ready) {
+if (achievements_smart_cache_enabled() && g_s32x_rtquery) {
+// List-change misalignment is handled inside ra_snes_addrlist_*
+// (active-snapshot mapping) — no rtquery-all reindex needed.
+int any_miss = 0;
+for (uint32_t i = 0; i < num_bytes; i++)
+if (ra_snes_addrlist_contains(address + i) < 0) { any_miss = 1; break; }
+if (!any_miss) {
 for (uint32_t i = 0; i < num_bytes; i++)
 buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+for (uint32_t i = 0; i < num_bytes; i++) {
+if (ra_snes_addrlist_contains(address + i) >= 0) {
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+} else {
+buffer[i] = (uint8_t)ra_rtquery_read(map, address + i, 1);
+ra_snes_addrlist_add_dynamic(address + i);
+}
+}
+return num_bytes;
+}
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+if (g_s32x_rtquery && achievements_rtquery_enabled() && !g_s32x_state.collecting && num_bytes <= 4) {
+uint32_t val = ra_rtquery_read(map, address, num_bytes);
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = (uint8_t)(val >> (i * 8));
 return num_bytes;
 }
 memset(buffer, 0, num_bytes);
@@ -54,22 +84,86 @@ return 0;
 static int s32x_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-if (!client || !game_loaded || !map || !g_s32x_state.optionc) return 0;
+if (!client || !game_loaded || !map || !g_s32x_state.seladdr) return 0;
 
 rc_client_t *rc_client = (rc_client_t *)client;
 
+// ===================================================================
+// Smart Cache path (Tier 1): rtquery handles misses, dynamic-only prune.
+// ===================================================================
+if (achievements_smart_cache_enabled() && g_s32x_rtquery) {
 if (ra_snes_addrlist_count() == 0 && !g_s32x_state.cache_ready) {
-// Bootstrap: run one do_frame to discover needed addresses
+// Re-prime to WAITING before the all-zero collection frame so a
+// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+rc_client_reset(rc_client);
+g_s32x_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+rc_client_do_frame(rc_client);
+g_s32x_state.collecting = 0;
+if (ra_snes_addrlist_end_collect(map))
+ra_log_write("S32X SmartCache: Bootstrap done, %d addrs\n", ra_snes_addrlist_count());
+else
+ra_log_write("S32X SmartCache: No addresses collected\n");
+} else if (!g_s32x_state.cache_ready) {
+if (ra_snes_addrlist_is_ready(map)) {
+g_s32x_state.cache_ready = 1;
+g_s32x_state.last_resp_frame = 0;
+g_s32x_state.game_frames = 0;
+g_s32x_state.poll_logged = 0;
+clock_gettime(CLOCK_MONOTONIC, &g_s32x_state.cache_time);
+// Discard the zero-primed bootstrap state (delta conditions
+// would otherwise see 0 -> real transitions and fire).
+rc_client_reset(rc_client);
+ra_log_write("S32X SmartCache: Cache active! %d addrs (rc_client reset)\n", ra_snes_addrlist_count());
+}
+} else {
+uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+seladdr_resync_if_backward(&g_s32x_state, resp_frame, "S32X");
+if (resp_frame > g_s32x_state.last_resp_frame) {
+g_s32x_state.last_resp_frame = resp_frame;
+g_s32x_state.game_frames++;
+ra_frame_processed(resp_frame);
+rc_client_do_frame(rc_client);
+if (achievements_smart_cleanup_enabled()
+&& (g_s32x_state.game_frames % 3600 == 0)
+&& ra_snes_addrlist_dyn_count() > 128) {
+int removed = ra_snes_addrlist_prune_dynamic(map);
+if (removed) {
+ra_log_write("S32X SmartCache: pruned %d dynamic addrs (%d static)\n",
+removed, ra_snes_addrlist_count());
+}
+} else if (ra_snes_addrlist_has_pending()) {
+ra_snes_addrlist_flush_dynamic(map);
+}
+}
+}
+uint32_t ms = g_s32x_state.game_frames / 300;
+if (ms > 0 && ms != g_s32x_state.poll_logged) {
+g_s32x_state.poll_logged = ms;
+ra_log_write("POLL(S32X-SC): resp_frame=%u game_frames=%u addrs=%d dyn=%d\n",
+g_s32x_state.last_resp_frame, g_s32x_state.game_frames,
+ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
+}
+return 1;
+}
+
+// ===================================================================
+// Legacy path: periodic recollect (no rtquery)
+// ===================================================================
+if (ra_snes_addrlist_count() == 0 && !g_s32x_state.cache_ready) {
+// Bootstrap: run one do_frame to discover needed addresses.
+// Re-prime to WAITING first (see smart-cache bootstrap).
+rc_client_reset(rc_client);
 g_s32x_state.collecting = 1;
 ra_snes_addrlist_begin_collect();
 rc_client_do_frame(rc_client);
 g_s32x_state.collecting = 0;
 int changed = ra_snes_addrlist_end_collect(map);
 if (changed) {
-ra_log_write("S32X OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+ra_log_write("S32X SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 ra_snes_addrlist_count());
 } else {
-ra_log_write("S32X OptionC: No addresses collected\n");
+ra_log_write("S32X SelAddr: No addresses collected\n");
 }
 } else if (!g_s32x_state.cache_ready) {
 // Wait for FPGA to respond with cached values
@@ -79,7 +173,9 @@ g_s32x_state.last_resp_frame = 0;
 g_s32x_state.game_frames = 0;
 g_s32x_state.poll_logged = 0;
 clock_gettime(CLOCK_MONOTONIC, &g_s32x_state.cache_time);
-ra_log_write("S32X OptionC: Cache active! FPGA response matched request.\n");
+// Discard the zero-primed bootstrap state (see smart-cache path).
+rc_client_reset(rc_client);
+ra_log_write("S32X SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
 // Dump first few addresses on activation
 const uint32_t *a0 = ra_snes_addrlist_addrs();
 int ac = ra_snes_addrlist_count();
@@ -92,7 +188,7 @@ ra_log_write("S32X ADDRLIST[0..%d]: %s (total=%d)\n", ad - 1, ah, ac);
 } else {
 // Normal frame processing from cache
 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-optionc_resync_if_backward(&g_s32x_state, resp_frame, "S32X");
+seladdr_resync_if_backward(&g_s32x_state, resp_frame, "S32X");
 if (resp_frame > g_s32x_state.last_resp_frame) {
 g_s32x_state.last_resp_frame = resp_frame;
 g_s32x_state.game_frames++;
@@ -115,6 +211,9 @@ ra_log_write("S32X early[%u]: VALCACHE %s (%d nz)\n",
 g_s32x_state.game_frames, eh, enz);
 }
 
+// Skip achievement processing while a recollect revision is in
+// flight (newly collected addresses would read as 0).
+if (ra_snes_addrlist_is_ready(map)) {
 // Re-collect every ~5 min to catch address changes
 // Smart cache mode: skip re-collect (no dynamic pointers in S32X)
 int re_collect = !achievements_smart_cache_enabled()
@@ -129,12 +228,13 @@ rc_client_do_frame(rc_client);
 if (re_collect) {
 g_s32x_state.collecting = 0;
 if (ra_snes_addrlist_end_collect(map)) {
-ra_log_write("S32X OptionC: Address list refreshed, %d addrs\n",
+ra_log_write("S32X SelAddr: Address list refreshed, %d addrs\n",
 ra_snes_addrlist_count());
 }
 }
+}
 } else {
-optionc_check_stall_recovery(&g_s32x_state, resp_frame, "S32X");
+seladdr_check_stall_recovery(&g_s32x_state, resp_frame, "S32X");
 }
 }
 
@@ -179,9 +279,21 @@ static int s32x_detect_protocol(void *map)
                 ra_log_write("S32X: FPGA mirror not detected -- RA support unavailable\n");
                 return 0;
         }
-// S32X always uses Option C
-g_s32x_state.optionc = 1;
-ra_log_write("S32X FPGA protocol: Option C (selective address reading)\n");
+// S32X always uses Selective Address
+g_s32x_state.seladdr = 1;
+ra_log_write("S32X FPGA protocol: Selective Address (selective address reading)\n");
+
+if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+g_s32x_rtquery = 1;
+ra_rtquery_init(map);
+ra_log_write("S32X: Realtime queries supported and ENABLED\n");
+} else if (ra_rtquery_supported(map)) {
+g_s32x_rtquery = 0;
+ra_log_write("S32X: Realtime queries supported but DISABLED by config\n");
+} else {
+g_s32x_rtquery = 0;
+ra_log_write("S32X: Realtime queries NOT supported (FPGA v1)\n");
+}
         return 1;
 }
 

--- a/achievements_sms.cpp
+++ b/achievements_sms.cpp
@@ -35,7 +35,7 @@ static void sms_reset(void)
 
 static uint32_t sms_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_sms_state.optionc) {
+	if (g_sms_state.seladdr) {
 		if (g_sms_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
@@ -54,22 +54,25 @@ static uint32_t sms_read_memory(void *map, uint32_t address, uint8_t *buffer, ui
 static int sms_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_sms_state.optionc) return 0;
+	if (!client || !game_loaded || !map || !g_sms_state.seladdr) return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
 
 	if (ra_snes_addrlist_count() == 0 && !g_sms_state.cache_ready) {
-		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		// Bootstrap: run one do_frame with zeros to discover needed addresses.
+		// Re-prime to WAITING first so active triggers (mid-game re-bootstrap
+		// after stall recovery) cannot fire on the all-zero reads.
+		rc_client_reset(rc_client);
 		g_sms_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_sms_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("SMS OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("SMS SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
 		} else {
-			ra_log_write("SMS OptionC: No addresses collected\n");
+			ra_log_write("SMS SelAddr: No addresses collected\n");
 		}
 	} else if (!g_sms_state.cache_ready) {
 		// Wait for FPGA to respond with cached values
@@ -79,7 +82,10 @@ static int sms_poll(void *map, void *client, int game_loaded)
 			g_sms_state.game_frames = 0;
 			g_sms_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_sms_state.cache_time);
-			ra_log_write("SMS OptionC: Cache active! FPGA response matched request.\n");
+			// Discard the zero-primed bootstrap state: delta conditions would
+			// otherwise see 0 -> real transitions on the first genuine frame.
+			rc_client_reset(rc_client);
+			ra_log_write("SMS SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
 			// Dump address list on activation
 			const uint32_t *a0 = ra_snes_addrlist_addrs();
 			int ac = ra_snes_addrlist_count();
@@ -92,7 +98,7 @@ static int sms_poll(void *map, void *client, int game_loaded)
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_sms_state, resp_frame, "SMS");
+		seladdr_resync_if_backward(&g_sms_state, resp_frame, "SMS");
 		if (resp_frame > g_sms_state.last_resp_frame) {
 			g_sms_state.last_resp_frame = resp_frame;
 			g_sms_state.game_frames++;
@@ -100,26 +106,30 @@ static int sms_poll(void *map, void *client, int game_loaded)
 			clock_gettime(CLOCK_MONOTONIC, &g_sms_state.stall_time);
 			g_sms_state.stall_frame = resp_frame;
 
-			// Re-collect every ~5 min to catch address changes
-			// Smart cache mode: skip re-collect (no dynamic pointers in SMS)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_sms_state.game_frames % 18000 == 0) && (g_sms_state.game_frames > 0);
-			if (re_collect) {
-				g_sms_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// Skip achievement processing while a recollect revision is in
+			// flight (newly collected addresses would read as 0).
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Re-collect every ~5 min to catch address changes
+				// Smart cache mode: skip re-collect (no dynamic pointers in SMS)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_sms_state.game_frames % 18000 == 0) && (g_sms_state.game_frames > 0);
+				if (re_collect) {
+					g_sms_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_sms_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("SMS OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_sms_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("SMS SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_sms_state, resp_frame, "SMS");
+			seladdr_check_stall_recovery(&g_sms_state, resp_frame, "SMS");
 		}
 	}
 
@@ -152,7 +162,9 @@ static int sms_calculate_hash(const char *rom_path, char *md5_hex_out)
 
 static void sms_set_hardcore(int enabled)
 {
-	user_io_status_set("[55]", enabled ? 1 : 0); // hardcore signal
+	// bit 63: hardcore signal (moved from 55 — upstream SMS 20260603+ uses
+	// status[56:55] for USERIO SNAC/Gear2Gear)
+	user_io_status_set("[63]", enabled ? 1 : 0);
 	user_io_status_set("[24]", enabled ? 1 : 0); // disable cheats OSD toggle
 	ra_log_write("SMS: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
@@ -163,9 +175,9 @@ static int sms_detect_protocol(void *map)
 		ra_log_write("SMS: FPGA mirror not detected -- RA support unavailable\n");
 		return 0;
 	}
-	// SMS always uses Option C
-	g_sms_state.optionc = 1;
-	ra_log_write("SMS FPGA protocol: Option C (selective address reading)\n");
+	// SMS always uses Selective Address
+	g_sms_state.seladdr = 1;
+	ra_log_write("SMS FPGA protocol: Selective Address (selective address reading)\n");
 	return 1;
 }
 

--- a/achievements_snes.cpp
+++ b/achievements_snes.cpp
@@ -23,10 +23,10 @@ static console_state_t g_snes_state = {0};
 static int g_snes_rtquery = 0; // 1 if FPGA supports realtime queries
 
 // ---------------------------------------------------------------------------
-// SNES Option C Diagnostics
+// SNES Selective Address Diagnostics
 // ---------------------------------------------------------------------------
 
-static void snes_optionc_dump_valcache(const char *label, void *map)
+static void snes_seladdr_dump_valcache(const char *label, void *map)
 {
 	if (!map) return;
 	const uint8_t *base = (const uint8_t *)map;
@@ -88,28 +88,18 @@ static void snes_reset(void)
 
 static uint32_t snes_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-	if (g_snes_state.optionc) {
+	if (g_snes_state.seladdr) {
 		if (g_snes_state.collecting) {
 			for (uint32_t i = 0; i < num_bytes; i++)
 				ra_snes_addrlist_add(address + i);
 		}
 		if (g_snes_state.cache_ready) {
 			if (achievements_smart_cache_enabled() && g_snes_rtquery) {
-				// During reindexing, use rtquery for all reads
-				if (g_snes_state.cache_reindexing) {
-					if (num_bytes <= 4) {
-						uint32_t val = ra_rtquery_read(map, address, num_bytes);
-						for (uint32_t i = 0; i < num_bytes; i++)
-							buffer[i] = (uint8_t)(val >> (i * 8));
-						return num_bytes;
-					}
-					for (uint32_t i = 0; i < num_bytes; i++) {
-						uint32_t val = ra_rtquery_read(map, address + i, 1);
-						buffer[i] = (uint8_t)val;
-					}
-					return num_bytes;
-				}
-				// Smart Cache: check each byte, rtquery on miss
+				// Smart Cache: check each byte, rtquery on miss.
+				// Misalignment after list changes is handled inside
+				// ra_snes_addrlist_* (active-snapshot mapping): cached
+				// lookups always follow the ordering the FPGA confirmed,
+				// so no rtquery-all reindex window is needed.
 				int any_miss = 0;
 				for (uint32_t i = 0; i < num_bytes; i++) {
 					if (ra_snes_addrlist_contains(address + i) < 0) {
@@ -165,7 +155,7 @@ static uint32_t snes_read_memory(void *map, uint32_t address, uint8_t *buffer, u
 static int snes_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-	if (!client || !game_loaded || !map || !g_snes_state.optionc)
+	if (!client || !game_loaded || !map || !g_snes_state.seladdr)
 		return 0;
 
 	rc_client_t *rc_client = (rc_client_t *)client;
@@ -177,6 +167,11 @@ static int snes_poll(void *map, void *client, int game_loaded)
 
 		if (ra_snes_addrlist_count() == 0 && !g_snes_state.cache_ready) {
 			// Phase 1: Bootstrap
+			// Re-prime triggers to WAITING before the collection frame: it
+			// runs with all reads returning zero, and after a mid-game
+			// re-bootstrap (stall recovery) active triggers could fire on
+			// those zeros. WAITING absorbs conditions that are true here.
+			rc_client_reset(rc_client);
 			g_snes_state.collecting = 1;
 			ra_snes_addrlist_begin_collect();
 			rc_client_do_frame(rc_client);
@@ -196,20 +191,19 @@ static int snes_poll(void *map, void *client, int game_loaded)
 				g_snes_state.game_frames = 0;
 				g_snes_state.poll_logged = 0;
 				clock_gettime(CLOCK_MONOTONIC, &g_snes_state.cache_time);
-				ra_log_write("SNES SmartCache: Cache active! %d addrs monitored\n",
+				// Re-prime all triggers against real memory: the bootstrap
+				// frame ran with zeros, which disarms rcheevos' initial
+				// waiting-state protection and poisons delta conditions
+				// (0 -> real transitions would fire "increased" chains).
+				rc_client_reset(rc_client);
+				ra_log_write("SNES SmartCache: Cache active! %d addrs monitored (rc_client reset)\n",
 					ra_snes_addrlist_count());
-				snes_optionc_dump_valcache("smart-active", map);
+				snes_seladdr_dump_valcache("smart-active", map);
 			}
 		} else {
 			// Phase 3: Normal — cache miss handled in read_memory
 			uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-			optionc_resync_if_backward(&g_snes_state, resp_frame, "SNES");
-
-			if (g_snes_state.cache_reindexing && ra_snes_addrlist_is_ready(map)) {
-				g_snes_state.cache_reindexing = 0;
-				ra_log_write("SNES SmartCache: Reindex complete (%d addrs)\n",
-					ra_snes_addrlist_count());
-			}
+			seladdr_resync_if_backward(&g_snes_state, resp_frame, "SNES");
 
 			if (resp_frame > g_snes_state.last_resp_frame) {
 				g_snes_state.last_resp_frame = resp_frame;
@@ -228,13 +222,11 @@ static int snes_poll(void *map, void *client, int game_loaded)
 				// re-add themselves via rtquery misses next frame.
 				if (achievements_smart_cleanup_enabled()
 						&& (g_snes_state.game_frames % 3600 == 0)
-						&& !g_snes_state.cache_reindexing
 						&& ra_snes_addrlist_dyn_count() > 128) {
 					int removed = ra_snes_addrlist_prune_dynamic(map);
 					if (removed) {
 						ra_log_write("SNES SmartCache: pruned %d dynamic addrs (%d static kept)\n",
 							removed, ra_snes_addrlist_count());
-						g_snes_state.cache_reindexing = 1;
 					}
 				} else if (ra_snes_addrlist_has_pending()) {
 					ra_snes_addrlist_flush_dynamic(map);
@@ -252,11 +244,11 @@ static int snes_poll(void *map, void *client, int game_loaded)
 				+ (now.tv_nsec - g_snes_state.cache_time.tv_nsec) / 1e9;
 			double ms_per_cycle = (g_snes_state.game_frames > 0) ?
 				(elapsed * 1000.0 / g_snes_state.game_frames) : 0.0;
-			ra_log_write("POLL(SNES-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d reindexing=%d\n",
+			ra_log_write("POLL(SNES-SC): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=%.1f addrs=%d dyn=%d\n",
 				g_snes_state.last_resp_frame, g_snes_state.game_frames, elapsed, ms_per_cycle,
-				ra_snes_addrlist_count(), g_snes_state.cache_reindexing);
+				ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
 			if ((g_snes_state.game_frames % 1800) < 300)
-				snes_optionc_dump_valcache("periodic-sc", map);
+				snes_seladdr_dump_valcache("periodic-sc", map);
 		}
 
 		return 1;
@@ -267,18 +259,21 @@ static int snes_poll(void *map, void *client, int game_loaded)
 	// ===================================================================
 
 	if (ra_snes_addrlist_count() == 0 && !g_snes_state.cache_ready) {
-		// Bootstrap: run one do_frame with zeros to discover needed addresses
+		// Bootstrap: run one do_frame with zeros to discover needed addresses.
+		// Re-prime to WAITING first so active triggers (mid-game re-bootstrap
+		// after stall recovery) cannot fire on the all-zero reads.
+		rc_client_reset(rc_client);
 		g_snes_state.collecting = 1;
 		ra_snes_addrlist_begin_collect();
 		rc_client_do_frame(rc_client);
 		g_snes_state.collecting = 0;
 		int changed = ra_snes_addrlist_end_collect(map);
 		if (changed) {
-			ra_log_write("SNES OptionC: Bootstrap collection done, %d addrs written to DDRAM\n",
+			ra_log_write("SNES SelAddr: Bootstrap collection done, %d addrs written to DDRAM\n",
 				ra_snes_addrlist_count());
-			snes_optionc_dump_valcache("bootstrap", map);
+			snes_seladdr_dump_valcache("bootstrap", map);
 		} else {
-			ra_log_write("SNES OptionC: No addresses collected — achievements may have no memory refs\n");
+			ra_log_write("SNES SelAddr: No addresses collected — achievements may have no memory refs\n");
 		}
 	} else if (!g_snes_state.cache_ready) {
 		// Wait for FPGA to respond with cached values
@@ -288,13 +283,15 @@ static int snes_poll(void *map, void *client, int game_loaded)
 			g_snes_state.game_frames = 0;
 			g_snes_state.poll_logged = 0;
 			clock_gettime(CLOCK_MONOTONIC, &g_snes_state.cache_time);
-			ra_log_write("SNES OptionC: Cache active! FPGA response matched request.\n");
-			snes_optionc_dump_valcache("cache-active", map);
+			// Discard the zero-primed bootstrap state (see smart-cache path).
+			rc_client_reset(rc_client);
+			ra_log_write("SNES SelAddr: Cache active! FPGA response matched request (rc_client reset).\n");
+			snes_seladdr_dump_valcache("cache-active", map);
 		}
 	} else {
 		// Normal frame processing from cache
 		uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-		optionc_resync_if_backward(&g_snes_state, resp_frame, "SNES");
+		seladdr_resync_if_backward(&g_snes_state, resp_frame, "SNES");
 		if (resp_frame > g_snes_state.last_resp_frame) {
 			g_snes_state.last_resp_frame = resp_frame;
 			g_snes_state.game_frames++;
@@ -304,31 +301,37 @@ static int snes_poll(void *map, void *client, int game_loaded)
 
 			// Dump first 5 frames after cache became active
 			if (g_snes_state.game_frames <= 5) {
-				ra_log_write("SNES OptionC: GameFrame %u (resp_frame=%u)\n",
+				ra_log_write("SNES SelAddr: GameFrame %u (resp_frame=%u)\n",
 					g_snes_state.game_frames, resp_frame);
-				snes_optionc_dump_valcache("early-frame", map);
+				snes_seladdr_dump_valcache("early-frame", map);
 			}
 
-			// Periodically re-collect to catch address changes (every ~5 min)
-			// Smart cache mode: skip re-collect (no dynamic pointers in SNES)
-			int re_collect = !achievements_smart_cache_enabled()
-				&& (g_snes_state.game_frames % 18000 == 0) && (g_snes_state.game_frames > 0);
-			if (re_collect) {
-				g_snes_state.collecting = 1;
-				ra_snes_addrlist_begin_collect();
-			}
+			// While a recollect revision is in flight (FPGA not yet confirmed)
+			// newly collected addresses would read as 0 — skip achievement
+			// processing for those 1-2 frames. Confirmed-snapshot addresses
+			// stay valid throughout.
+			if (ra_snes_addrlist_is_ready(map)) {
+				// Periodically re-collect to catch address changes (every ~5 min)
+				// Smart cache mode: skip re-collect (no dynamic pointers in SNES)
+				int re_collect = !achievements_smart_cache_enabled()
+					&& (g_snes_state.game_frames % 18000 == 0) && (g_snes_state.game_frames > 0);
+				if (re_collect) {
+					g_snes_state.collecting = 1;
+					ra_snes_addrlist_begin_collect();
+				}
 
-			rc_client_do_frame(rc_client);
+				rc_client_do_frame(rc_client);
 
-			if (re_collect) {
-				g_snes_state.collecting = 0;
-				if (ra_snes_addrlist_end_collect(map)) {
-					ra_log_write("SNES OptionC: Address list refreshed, %d addrs\n",
-						ra_snes_addrlist_count());
+				if (re_collect) {
+					g_snes_state.collecting = 0;
+					if (ra_snes_addrlist_end_collect(map)) {
+						ra_log_write("SNES SelAddr: Address list refreshed, %d addrs\n",
+							ra_snes_addrlist_count());
+					}
 				}
 			}
 		} else {
-			optionc_check_stall_recovery(&g_snes_state, resp_frame, "SNES");
+			seladdr_check_stall_recovery(&g_snes_state, resp_frame, "SNES");
 		}
 	}
 
@@ -346,10 +349,10 @@ static int snes_poll(void *map, void *client, int game_loaded)
 			g_snes_state.last_resp_frame, g_snes_state.game_frames, elapsed, ms_per_cycle,
 			ra_snes_addrlist_count());
 		if ((g_snes_state.game_frames % 1800) < 300)
-			snes_optionc_dump_valcache("periodic", map);
+			snes_seladdr_dump_valcache("periodic", map);
 	}
 
-	return 1; // SNES Option C handled
+	return 1; // SNES Selective Address handled
 #else
 	return 0;
 #endif
@@ -415,15 +418,15 @@ int snes_detect_protocol(void *map)
 	}
 	const ra_header_t *hdr = (const ra_header_t *)map;
 	if (hdr->region_count == 0) {
-		g_snes_state.optionc = 1;
-		ra_log_write("SNES FPGA protocol: Option C (selective address reading)\n");
+		g_snes_state.seladdr = 1;
+		ra_log_write("SNES FPGA protocol: Selective Address (selective address reading)\n");
 	} else {
-		g_snes_state.optionc = 0;
+		g_snes_state.seladdr = 0;
 		ra_log_write("SNES FPGA protocol: VBlank-gated full mirror (region_count=%d)\n",
 			hdr->region_count);
 	}
 
-	if (g_snes_state.optionc) {
+	if (g_snes_state.seladdr) {
 		if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
 			g_snes_rtquery = 1;
 			ra_rtquery_init(map);

--- a/achievements_tgfx16.cpp
+++ b/achievements_tgfx16.cpp
@@ -22,12 +22,13 @@
 // ---------------------------------------------------------------------------
 
 static console_state_t g_tgfx16_state = {0};
+static int g_tgfx16_rtquery = 0; // 1 if FPGA supports realtime queries (v2)
 
 // ---------------------------------------------------------------------------
-// TG16 Option C Diagnostics
+// TG16 Selective Address Diagnostics
 // ---------------------------------------------------------------------------
 
-static void tgfx16_optionc_dump_valcache(const char *label, void *map)
+static void tgfx16_seladdr_dump_valcache(const char *label, void *map)
 {
 if (!map) return;
 const uint8_t *base = (const uint8_t *)map;
@@ -76,23 +77,56 @@ ra_log_write("TGFX16 DUMP[%s]   [%d] addr=0x%05X val=0x%02X\n", label, i, addrs[
 static void tgfx16_init(void)
 {
 memset(&g_tgfx16_state, 0, sizeof(g_tgfx16_state));
+g_tgfx16_rtquery = 0;
 }
 
 static void tgfx16_reset(void)
 {
 memset(&g_tgfx16_state, 0, sizeof(g_tgfx16_state));
+g_tgfx16_rtquery = 0;
 }
 
 static uint32_t tgfx16_read_memory(void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes)
 {
-if (g_tgfx16_state.optionc) {
+if (g_tgfx16_state.seladdr) {
 if (g_tgfx16_state.collecting) {
 for (uint32_t i = 0; i < num_bytes; i++)
 ra_snes_addrlist_add(address + i);
 }
 if (g_tgfx16_state.cache_ready) {
+if (achievements_smart_cache_enabled() && g_tgfx16_rtquery) {
+// List-change misalignment is handled inside ra_snes_addrlist_*
+// (active-snapshot mapping) — no rtquery-all reindex needed.
+// Smart cache: serve from cache, rtquery on miss and schedule the
+// address for the next FPGA batch via add_dynamic.
+int any_miss = 0;
+for (uint32_t i = 0; i < num_bytes; i++)
+if (ra_snes_addrlist_contains(address + i) < 0) { any_miss = 1; break; }
+if (!any_miss) {
 for (uint32_t i = 0; i < num_bytes; i++)
 buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+for (uint32_t i = 0; i < num_bytes; i++) {
+if (ra_snes_addrlist_contains(address + i) >= 0) {
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+} else {
+buffer[i] = (uint8_t)ra_rtquery_read(map, address + i, 1);
+ra_snes_addrlist_add_dynamic(address + i);
+}
+}
+return num_bytes;
+}
+// Legacy path: read from cache
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = ra_snes_addrlist_read_cached(map, address + i);
+return num_bytes;
+}
+// Pre-cache rtquery fallback
+if (g_tgfx16_rtquery && achievements_rtquery_enabled() && !g_tgfx16_state.collecting && num_bytes <= 4) {
+uint32_t val = ra_rtquery_read(map, address, num_bytes);
+for (uint32_t i = 0; i < num_bytes; i++)
+buffer[i] = (uint8_t)(val >> (i * 8));
 return num_bytes;
 }
 memset(buffer, 0, num_bytes);
@@ -105,24 +139,93 @@ return num_bytes;
 static int tgfx16_poll(void *map, void *client, int game_loaded)
 {
 #ifdef HAS_RCHEEVOS
-if (!client || !game_loaded || !map || !g_tgfx16_state.optionc)
+if (!client || !game_loaded || !map || !g_tgfx16_state.seladdr)
 return 0;
 
 rc_client_t *rc_client = (rc_client_t *)client;
 
+// ===================================================================
+// Smart Cache path (Tier 1): rtquery handles cache misses, dynamic-only
+// prune keeps the list bounded. Mirrors the NES/SNES/MD handlers.
+// ===================================================================
+if (achievements_smart_cache_enabled() && g_tgfx16_rtquery) {
 if (ra_snes_addrlist_count() == 0 && !g_tgfx16_state.cache_ready) {
-// Bootstrap: collect addresses
+// Re-prime to WAITING before the all-zero collection frame so a
+// mid-game re-bootstrap (stall recovery) cannot fire on zeros.
+rc_client_reset(rc_client);
+g_tgfx16_state.collecting = 1;
+ra_snes_addrlist_begin_collect();
+rc_client_do_frame(rc_client);
+g_tgfx16_state.collecting = 0;
+if (ra_snes_addrlist_end_collect(map))
+ra_log_write("TGFX16 SmartCache: Bootstrap done, %d addrs\n",
+ra_snes_addrlist_count());
+else
+ra_log_write("TGFX16 SmartCache: No addresses collected\n");
+} else if (!g_tgfx16_state.cache_ready) {
+if (ra_snes_addrlist_is_ready(map)) {
+g_tgfx16_state.cache_ready = 1;
+g_tgfx16_state.last_resp_frame = 0;
+g_tgfx16_state.game_frames = 0;
+g_tgfx16_state.poll_logged = 0;
+clock_gettime(CLOCK_MONOTONIC, &g_tgfx16_state.cache_time);
+// Discard the zero-primed bootstrap state (delta conditions
+// would otherwise see 0 -> real transitions and fire).
+rc_client_reset(rc_client);
+ra_log_write("TGFX16 SmartCache: Cache active! %d addrs (rc_client reset)\n",
+ra_snes_addrlist_count());
+}
+} else {
+uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
+seladdr_resync_if_backward(&g_tgfx16_state, resp_frame, "TGFX16");
+if (resp_frame > g_tgfx16_state.last_resp_frame) {
+g_tgfx16_state.last_resp_frame = resp_frame;
+g_tgfx16_state.game_frames++;
+ra_frame_processed(resp_frame);
+
+rc_client_do_frame(rc_client);
+
+if (achievements_smart_cleanup_enabled()
+&& (g_tgfx16_state.game_frames % 3600 == 0)
+&& ra_snes_addrlist_dyn_count() > 128) {
+int removed = ra_snes_addrlist_prune_dynamic(map);
+if (removed) {
+ra_log_write("TGFX16 SmartCache: pruned %d dynamic addrs (%d static)\n",
+removed, ra_snes_addrlist_count());
+}
+} else if (ra_snes_addrlist_has_pending()) {
+ra_snes_addrlist_flush_dynamic(map);
+}
+}
+}
+uint32_t ms = g_tgfx16_state.game_frames / 300;
+if (ms > 0 && ms != g_tgfx16_state.poll_logged) {
+g_tgfx16_state.poll_logged = ms;
+ra_log_write("POLL(TGFX16-SC): resp_frame=%u game_frames=%u addrs=%d dyn=%d\n",
+g_tgfx16_state.last_resp_frame, g_tgfx16_state.game_frames,
+ra_snes_addrlist_count(), ra_snes_addrlist_dyn_count());
+}
+return 1;
+}
+
+// ===================================================================
+// Legacy path: periodic recollect (no rtquery)
+// ===================================================================
+if (ra_snes_addrlist_count() == 0 && !g_tgfx16_state.cache_ready) {
+// Bootstrap: collect addresses.
+// Re-prime to WAITING first (see smart-cache bootstrap).
+rc_client_reset(rc_client);
 g_tgfx16_state.collecting = 1;
 ra_snes_addrlist_begin_collect();
 rc_client_do_frame(rc_client);
 g_tgfx16_state.collecting = 0;
 int changed = ra_snes_addrlist_end_collect(map);
 if (changed) {
-ra_log_write("TGFX16 OptionC: Bootstrap done, %d addrs\n",
+ra_log_write("TGFX16 SelAddr: Bootstrap done, %d addrs\n",
 ra_snes_addrlist_count());
-tgfx16_optionc_dump_valcache("bootstrap", map);
+tgfx16_seladdr_dump_valcache("bootstrap", map);
 } else {
-ra_log_write("TGFX16 OptionC: No addresses collected\n");
+ra_log_write("TGFX16 SelAddr: No addresses collected\n");
 }
 } else if (!g_tgfx16_state.cache_ready) {
 // Wait for FPGA response
@@ -132,13 +235,15 @@ g_tgfx16_state.last_resp_frame = 0;
 g_tgfx16_state.game_frames = 0;
 g_tgfx16_state.poll_logged = 0;
 clock_gettime(CLOCK_MONOTONIC, &g_tgfx16_state.cache_time);
-ra_log_write("TGFX16 OptionC: Cache active!\n");
-tgfx16_optionc_dump_valcache("cache-active", map);
+// Discard the zero-primed bootstrap state (see smart-cache path).
+rc_client_reset(rc_client);
+ra_log_write("TGFX16 SelAddr: Cache active! (rc_client reset)\n");
+tgfx16_seladdr_dump_valcache("cache-active", map);
 }
 } else {
 // Normal frame processing
 uint32_t resp_frame = ra_snes_addrlist_response_frame(map);
-optionc_resync_if_backward(&g_tgfx16_state, resp_frame, "TGFX16");
+seladdr_resync_if_backward(&g_tgfx16_state, resp_frame, "TGFX16");
 if (resp_frame > g_tgfx16_state.last_resp_frame) {
 g_tgfx16_state.last_resp_frame = resp_frame;
 g_tgfx16_state.game_frames++;
@@ -147,11 +252,14 @@ clock_gettime(CLOCK_MONOTONIC, &g_tgfx16_state.stall_time);
 g_tgfx16_state.stall_frame = resp_frame;
 
 if (g_tgfx16_state.game_frames <= 5) {
-ra_log_write("TGFX16 OptionC: GameFrame %u (resp_frame=%u)\n",
+ra_log_write("TGFX16 SelAddr: GameFrame %u (resp_frame=%u)\n",
 g_tgfx16_state.game_frames, resp_frame);
-tgfx16_optionc_dump_valcache("early-frame", map);
+tgfx16_seladdr_dump_valcache("early-frame", map);
 }
 
+// Skip achievement processing while a recollect revision is in
+// flight (newly collected addresses would read as 0).
+if (ra_snes_addrlist_is_ready(map)) {
 // Re-collect every ~5 min
 // Smart cache mode: skip re-collect (no dynamic pointers in TGFx16)
 int re_collect = !achievements_smart_cache_enabled()
@@ -166,13 +274,14 @@ rc_client_do_frame(rc_client);
 if (re_collect) {
 g_tgfx16_state.collecting = 0;
 if (ra_snes_addrlist_end_collect(map)) {
-ra_log_write("TGFX16 OptionC: Address list refreshed, %d addrs\n",
+ra_log_write("TGFX16 SelAddr: Address list refreshed, %d addrs\n",
 ra_snes_addrlist_count());
+}
 }
 }
 
 } else {
-	optionc_check_stall_recovery(&g_tgfx16_state, resp_frame, "TGFX16");
+	seladdr_check_stall_recovery(&g_tgfx16_state, resp_frame, "TGFX16");
 }
 }
 
@@ -190,7 +299,7 @@ ra_log_write("POLL(TGFX16): resp_frame=%u game_frames=%u elapsed=%.1fs ms/cycle=
 g_tgfx16_state.last_resp_frame, g_tgfx16_state.game_frames, elapsed, ms_per_cycle,
 ra_snes_addrlist_count());
 if ((g_tgfx16_state.game_frames % 1800) < 300)
-tgfx16_optionc_dump_valcache("periodic", map);
+tgfx16_seladdr_dump_valcache("periodic", map);
 }
 
 return 1;
@@ -279,7 +388,10 @@ return 1;
 
 static void tgfx16_set_hardcore(int enabled)
 {
-// TG16 core: disable cheats (status bit 5)
+// FPGA hardcore signal (status[39]): forces the Game Genie engine off and
+// hides the Cheats menu in hardware.
+user_io_status_set("[39]", enabled ? 1 : 0);
+// Legacy OSD "Cheats enabled" toggle (status[5], 1 = OFF)
 user_io_status_set("[5]", enabled ? 1 : 0);
 ra_log_write("TGFX16: Hardcore mode %s\n", enabled ? "enabled" : "disabled");
 }
@@ -292,12 +404,26 @@ if (!ra_ramread_active(map)) {
 }
 const ra_header_t *hdr = (const ra_header_t *)map;
 if (hdr->region_count == 0) {
-g_tgfx16_state.optionc = 1;
-ra_log_write("TGFX16 FPGA protocol: Option C (selective address reading)\n");
+g_tgfx16_state.seladdr = 1;
+ra_log_write("TGFX16 FPGA protocol: Selective Address (selective address reading)\n");
 } else {
-g_tgfx16_state.optionc = 0;
+g_tgfx16_state.seladdr = 0;
 ra_log_write("TGFX16 FPGA protocol: VBlank-gated mirror (region_count=%d)\n",
 hdr->region_count);
+}
+
+if (g_tgfx16_state.seladdr) {
+if (ra_rtquery_supported(map) && achievements_rtquery_enabled()) {
+g_tgfx16_rtquery = 1;
+ra_rtquery_init(map);
+ra_log_write("TGFX16: Realtime queries supported and ENABLED\n");
+} else if (ra_rtquery_supported(map)) {
+g_tgfx16_rtquery = 0;
+ra_log_write("TGFX16: Realtime queries supported but DISABLED by config\n");
+} else {
+g_tgfx16_rtquery = 0;
+ra_log_write("TGFX16: Realtime queries NOT supported (FPGA v1)\n");
+}
 }
 return 1;
 }

--- a/osd.cpp
+++ b/osd.cpp
@@ -40,6 +40,7 @@ as rotated copies of the first 128 entries.  -- AMR
 
 #include "osd.h"
 #include "spi.h"
+#include "achievements.h"
 
 #include "charrom.h"
 #include "logo.h"
@@ -500,6 +501,14 @@ void OsdClear(void)
 // enable displaying of OSD
 void OsdEnable(unsigned char mode)
 {
+	// Cores with autosave start streaming their save RAM the moment the OSD
+	// status bit rises. Arm the RA save-I/O guard BEFORE enabling the OSD so
+	// no achievement evaluation can race the first sectors of that transfer
+	// (the per-sector notifications then keep the guard armed for the burst).
+	// OSD_MSG windows (info/achievement popups) never raise OSD_STATUS in the
+	// core (sys/osd.v gates it on the mode bits), so they can't trigger the
+	// autosave and must not pause evaluation.
+	if (!(mode & OSD_MSG)) achievements_notify_save_io();
 	user_io_osd_key_enable(mode & DISABLE_KEYBOARD);
 	mode &= (DISABLE_KEYBOARD | OSD_MSG);
 	spi_osd_cmd(OSD_CMD_ENABLE | mode);

--- a/ra_ramread.cpp
+++ b/ra_ramread.cpp
@@ -302,7 +302,7 @@ void ra_ramread_debug_status(const void *map)
 }
 
 // ======================================================================
-// Option C: Selective Address Reading (SNES)
+// Selective Address Reading (shared "SNES-style" addrlist)
 // ======================================================================
 
 static int s_addr_cmp(const void *a, const void *b)
@@ -318,6 +318,58 @@ static int      s_snes_dyn_count = 0;               // how many entries have the
 static int      s_snes_addr_count = 0;
 static uint32_t s_snes_request_id = 0;
 static int      s_snes_collecting = 0;
+
+// Active mapping snapshot: the address ordering the FPGA's VALCACHE currently
+// follows (the list revision it last confirmed via response_id). All cached
+// reads (read_cached/lookup_byte/contains) go through this snapshot, never
+// through the live pending list: a list mutation (add_dynamic insert, prune,
+// recollect) shifts indices in the pending list immediately, but the VALCACHE
+// keeps the old ordering until the FPGA picks up the new request_id — indexing
+// it with the new list would return the neighbouring address's byte. Static
+// addresses therefore stay cache-served across every revision; only addresses
+// not yet in the active snapshot fall back to rtquery.
+static uint32_t s_active_addrs[RA_SNES_MAX_ADDRS];
+static int      s_active_count = 0;
+static uint32_t s_active_id = 0;   // request_id the active snapshot reflects (0 = none)
+
+// The list exactly as last written to DDRAM (what s_snes_request_id refers
+// to). The live pending list (s_snes_addrs) keeps mutating between publishes
+// via add_dynamic, so promotion must copy from here, not from the pending
+// list — otherwise unpublished inserts would shift the promoted ordering.
+static uint32_t s_published_addrs[RA_SNES_MAX_ADDRS];
+static int      s_published_count = 0;
+
+static void s_publish_snapshot(void)
+{
+	memcpy(s_published_addrs, s_snes_addrs, s_snes_addr_count * sizeof(uint32_t));
+	s_published_count = s_snes_addr_count;
+}
+
+// Promote published → active when the FPGA has confirmed the current revision.
+// Revisions are serialized (see flush/prune), so response_id is either the
+// active id (transition in flight, keep old mapping) or the current request_id
+// (promote). Any other value means a wholesale list replacement raced the
+// FPGA; end_collect handles that case by invalidating the active snapshot.
+static void s_sync_active(const void *map)
+{
+	if (!map) return;
+	const ra_val_resp_hdr_t *resp =
+		(const ra_val_resp_hdr_t *)((const uint8_t *)map + RA_SNES_VALCACHE_OFFSET);
+	uint32_t rid = resp->response_id;
+	if (rid == s_active_id || rid != s_snes_request_id) return;
+	memcpy(s_active_addrs, s_published_addrs, s_published_count * sizeof(uint32_t));
+	s_active_count = s_published_count;
+	s_active_id = rid;
+}
+
+// 1 when the FPGA has confirmed the latest published list revision.
+static int s_fpga_caught_up(const void *map)
+{
+	if (!map) return 0;
+	const ra_val_resp_hdr_t *resp =
+		(const ra_val_resp_hdr_t *)((const uint8_t *)map + RA_SNES_VALCACHE_OFFSET);
+	return resp->response_id == s_snes_request_id;
+}
 
 // Smart Cache dynamic-add state (see "Smart Cache" section below)
 static int s_dynamic_pending = 0;   // 1 if new addresses added since last flush
@@ -342,6 +394,9 @@ void ra_snes_addrlist_init(void)
 	s_dynamic_pending = 0;
 	s_dynamic_added = 0;
 	s_snes_dyn_count = 0;
+	s_active_count = 0;
+	s_active_id = 0;
+	s_published_count = 0;
 }
 
 void ra_snes_addrlist_begin_collect(void)
@@ -383,12 +438,24 @@ int ra_snes_addrlist_end_collect(void *map)
 	}
 	if (!changed) return 0;
 
+	// A wholesale replacement while a previous revision is still in flight
+	// would leave the VALCACHE ordered by a revision we no longer have a
+	// snapshot of. Invalidate the active snapshot in that (rare) case so
+	// reads miss to rtquery/zero instead of misaligning; the next confirmed
+	// response re-promotes. When the FPGA is caught up (the normal case) the
+	// active snapshot stays valid until the new revision is confirmed.
+	if (s_active_id && !s_fpga_caught_up(map)) {
+		s_active_count = 0;
+		s_active_id = 0;
+	}
+
 	// Update local list — a full collect defines the STATIC baseline
 	memcpy(s_snes_addrs, s_collect_buf, new_count * sizeof(uint32_t));
 	memset(s_snes_addr_dyn, 0, (size_t)new_count);
 	s_snes_dyn_count = 0;
 	s_snes_addr_count = new_count;
 	s_snes_request_id++;
+	s_publish_snapshot();
 
 	// Write to DDRAM
 	if (!map) return 1;
@@ -417,17 +484,18 @@ int ra_snes_addrlist_end_collect(void *map)
 
 uint8_t ra_snes_addrlist_read_cached(const void *map, uint32_t addr)
 {
-	if (!map || s_snes_addr_count == 0) return 0;
+	if (!map || s_active_count == 0) return 0;
 
-	// Binary search
-	int lo = 0, hi = s_snes_addr_count - 1;
+	// Binary search over the ACTIVE snapshot — the ordering the VALCACHE
+	// actually follows (see s_sync_active).
+	int lo = 0, hi = s_active_count - 1;
 	while (lo <= hi) {
 		int mid = (lo + hi) / 2;
-		if (s_snes_addrs[mid] == addr) {
+		if (s_active_addrs[mid] == addr) {
 			const uint8_t *vals = (const uint8_t *)map + RA_SNES_VALCACHE_OFFSET + 8;
 			return vals[mid];
 		}
-		if (s_snes_addrs[mid] < addr) lo = mid + 1;
+		if (s_active_addrs[mid] < addr) lo = mid + 1;
 		else hi = mid - 1;
 	}
 	return 0;
@@ -436,9 +504,8 @@ uint8_t ra_snes_addrlist_read_cached(const void *map, uint32_t addr)
 int ra_snes_addrlist_is_ready(const void *map)
 {
 	if (!map || s_snes_addr_count == 0 || s_snes_request_id == 0) return 0;
-	const uint8_t *base = (const uint8_t *)map;
-	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
-	return resp->response_id == s_snes_request_id;
+	s_sync_active(map);
+	return s_fpga_caught_up(map);
 }
 
 int ra_snes_addrlist_count(void)
@@ -451,6 +518,19 @@ const uint32_t *ra_snes_addrlist_addrs(void)
 	return s_snes_addrs;
 }
 
+// Active (FPGA-confirmed) snapshot — the ordering the VALCACHE follows.
+// Use these when pairing addresses with VALCACHE values by index; the
+// pending accessors above may already contain unpublished insertions.
+int ra_snes_addrlist_active_count(void)
+{
+	return s_active_count;
+}
+
+const uint32_t *ra_snes_addrlist_active_addrs(void)
+{
+	return s_active_addrs;
+}
+
 uint32_t ra_snes_addrlist_request_id(void)
 {
 	return s_snes_request_id;
@@ -459,6 +539,9 @@ uint32_t ra_snes_addrlist_request_id(void)
 uint32_t ra_snes_addrlist_response_frame(const void *map)
 {
 	if (!map) return 0;
+	// Called once per poll by every Selective Address console — piggyback the
+	// pending→active promotion check here so no per-console change is needed.
+	s_sync_active(map);
 	const uint8_t *base = (const uint8_t *)map;
 	const ra_val_resp_hdr_t *resp = (const ra_val_resp_hdr_t *)(base + RA_SNES_VALCACHE_OFFSET);
 	return resp->response_frame;
@@ -504,14 +587,17 @@ void ra_snes_addrlist_diag_dump(const void *map)
 //  state above so ra_snes_addrlist_init can clear them.)
 // ======================================================================
 
+// "Servable from cache" check — searches the ACTIVE snapshot, not the pending
+// list: an address inserted by add_dynamic must keep missing (and thus be
+// served by rtquery) until the FPGA confirms the revision that contains it.
 int ra_snes_addrlist_contains(uint32_t addr)
 {
-	if (s_snes_addr_count == 0) return -1;
-	int lo = 0, hi = s_snes_addr_count - 1;
+	if (s_active_count == 0) return -1;
+	int lo = 0, hi = s_active_count - 1;
 	while (lo <= hi) {
 		int mid = (lo + hi) / 2;
-		if (s_snes_addrs[mid] == addr) return mid;
-		if (s_snes_addrs[mid] < addr) lo = mid + 1;
+		if (s_active_addrs[mid] == addr) return mid;
+		if (s_active_addrs[mid] < addr) lo = mid + 1;
 		else hi = mid - 1;
 	}
 	return -1;
@@ -523,19 +609,19 @@ int ra_snes_addrlist_contains(uint32_t addr)
 // threshold that starves CD-ROM XA streaming and causes audio glitches).
 uint8_t ra_snes_addrlist_lookup_byte(const void *map, uint32_t addr, int *hit)
 {
-	if (!map || s_snes_addr_count == 0) {
+	if (!map || s_active_count == 0) {
 		if (hit) *hit = 0;
 		return 0;
 	}
-	int lo = 0, hi = s_snes_addr_count - 1;
+	int lo = 0, hi = s_active_count - 1;
 	while (lo <= hi) {
 		int mid = (lo + hi) / 2;
-		if (s_snes_addrs[mid] == addr) {
+		if (s_active_addrs[mid] == addr) {
 			const uint8_t *vals = (const uint8_t *)map + RA_SNES_VALCACHE_OFFSET + 8;
 			if (hit) *hit = 1;
 			return vals[mid];
 		}
-		if (s_snes_addrs[mid] < addr) lo = mid + 1;
+		if (s_active_addrs[mid] < addr) lo = mid + 1;
 		else hi = mid - 1;
 	}
 	if (hit) *hit = 0;
@@ -589,12 +675,19 @@ int ra_snes_addrlist_has_pending(void)
 int ra_snes_addrlist_flush_dynamic(void *map)
 {
 	if (!s_dynamic_pending || !map) return 0;
+	// Serialize revisions: publish only when the FPGA has confirmed the
+	// current one. This guarantees the VALCACHE ordering is always either
+	// the active snapshot or the (single) revision in flight, so cached
+	// reads never misalign. Deferred flushes keep s_dynamic_pending set and
+	// retry next frame; the pending addresses are served by rtquery meanwhile.
+	if (!s_fpga_caught_up(map)) return 0;
 	s_dynamic_pending = 0;
 	int flushed = s_dynamic_added;
 	s_dynamic_added = 0;
 
 	// Bump request ID and write entire list to DDRAM
 	s_snes_request_id++;
+	s_publish_snapshot();
 	uint8_t *base = (uint8_t *)map;
 
 	// Write addresses first
@@ -636,6 +729,10 @@ int ra_snes_addrlist_prune_dynamic(void *map)
 	// Never prune down to an empty list (all-dynamic lists would break the
 	// is_ready/reindex handshake); keep everything instead.
 	if (s_snes_dyn_count >= s_snes_addr_count) return 0;
+	// Same revision serialization as flush_dynamic: defer until the FPGA
+	// confirmed the current list, so the active snapshot stays the only
+	// other ordering in play. Callers retry on a later cleanup tick.
+	if (map && !s_fpga_caught_up(map)) return 0;
 
 	int w = 0;
 	for (int i = 0; i < s_snes_addr_count; i++) {
@@ -653,6 +750,7 @@ int ra_snes_addrlist_prune_dynamic(void *map)
 
 	// Publish the shrunk list (same commit order as flush_dynamic)
 	s_snes_request_id++;
+	s_publish_snapshot();
 	if (map) {
 		uint8_t *base = (uint8_t *)map;
 		uint32_t *addrs = (uint32_t *)(base + RA_SNES_ADDRLIST_OFFSET + 8);
@@ -671,7 +769,7 @@ int ra_snes_addrlist_prune_dynamic(void *map)
 }
 
 // ======================================================================
-// Realtime Query Mailbox (Option C "on steroids")
+// Realtime Query Mailbox (Selective Address "on steroids")
 // ======================================================================
 
 static uint8_t s_rtquery_seq = 0;

--- a/ra_ramread.h
+++ b/ra_ramread.h
@@ -79,13 +79,13 @@ typedef struct __attribute__((packed)) {
 #define RA_SNES_WRAM_SIZE     0x20000   // 128KB
 #define RA_SNES_BSRAM_OFFSET  0x20100   // BSRAM data starts after WRAM
 
-// Option C: Selective address reading (SNES)
+// Selective Address reading (shared addrlist, SNES layout)
 #define RA_SNES_ADDRLIST_OFFSET  0x40000   // ARM → FPGA: address request table
 #define RA_SNES_VALCACHE_OFFSET  0x48000   // FPGA → ARM: value response table
 #define RA_SNES_MAX_ADDRS        4096      // Max tracked addresses
 
 // ======================================================================
-// Realtime Query Mailbox (Option C "on steroids")
+// Realtime Query Mailbox (Selective Address "on steroids")
 // ARM writes query addresses, FPGA reads SDRAM, writes values back.
 // Used for AddAddress pointer resolution during rc_client_do_frame().
 // ======================================================================
@@ -129,7 +129,7 @@ typedef struct __attribute__((packed)) {
         uint32_t reserved;
 } ra_query_resp_t;
 
-// Realtime query API — generic, works with any Option C core
+// Realtime query API — generic, works with any Selective Address core
 void     ra_rtquery_init(void *map);
 void     ra_rtquery_disable(void *map);  // clears RA_ARM_CFG_RTQUERY so FPGA stops polling
 void     ra_clear_en_set(void *map);     // sets   RA_ARM_CFG_CLEAR_EN (FPGA clears IWRAM on game load)
@@ -196,7 +196,7 @@ uint32_t ra_ramread_atari2600_read(const void *map, uint32_t address, uint8_t *b
 uint8_t  ra_ramread_atari7800_byte(const void *map, uint16_t addr);
 uint32_t ra_ramread_atari7800_read(const void *map, uint32_t address, uint8_t *buffer, uint32_t num_bytes);
 
-// Option C: Selective address reading (SNES)
+// Selective Address reading (shared addrlist, SNES layout)
 // ARM collects needed addresses from rcheevos, writes list to DDRAM.
 // FPGA reads only those addresses each VBlank. ARM reads cached values.
 void     ra_snes_addrlist_init(void);
@@ -207,6 +207,11 @@ uint8_t  ra_snes_addrlist_read_cached(const void *map, uint32_t addr);
 int      ra_snes_addrlist_is_ready(const void *map);
 int      ra_snes_addrlist_count(void);
 const uint32_t *ra_snes_addrlist_addrs(void);  // Returns pointer to sorted address array
+// Active (FPGA-confirmed) snapshot: the ordering the VALCACHE follows. Use
+// these when pairing addresses with VALCACHE values by index — the pending
+// accessors above may already contain unpublished insertions.
+int      ra_snes_addrlist_active_count(void);
+const uint32_t *ra_snes_addrlist_active_addrs(void);
 uint32_t ra_snes_addrlist_request_id(void);     // Current expected request ID
 uint32_t ra_snes_addrlist_response_frame(const void *map);
 void     ra_snes_addrlist_diag_dump(const void *map);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -3307,7 +3307,14 @@ void user_io_poll()
 			{
 				//printf("SD WR %llu on %d\n", lba, disk);
 
-				if (use_save) menu_process_save();
+				if (use_save)
+				{
+					menu_process_save();
+					// Suspend RA evaluation: on cores that share the save
+					// port with the RA read path this transfer corrupts
+					// RA-visible save-RAM reads (see achievements_notify_save_io).
+					achievements_notify_save_io();
+				}
 
 				buffer_lba[disk] = -1;
 
@@ -3355,6 +3362,12 @@ void user_io_poll()
 			}
 			else if (op & 1)
 			{
+				// Save-slot reads (load backup / restore): same port-sharing
+				// corruption as writes. Strict disk check so CD-image reads on
+				// other slots never arm the guard.
+				if (use_save && (disk == 0 || (is_saturn() && disk == 1)))
+					achievements_notify_save_io();
+
 				uint32_t buf_n = sizeof(buffer[0]) / blksz;
 				if (is_psx() && blksz == 2352)
 				{


### PR DESCRIPTION
- MegaCD support: wires up detection and Smart Cache handling for the new MegaCD RAM mirror.
- Smart Cache retrofit for S32X and TurboGrafx16: both consoles previously lacked the realtime-query path present in newer cores; now brought in line.
- Active-snapshot consistency fix (ra_ramread.cpp): the shared DDRAM mailbox client now tracks pending/published/active address-list snapshots separately and indexes cached reads against the FPGA-confirmed active snapshot instead of the live pending list. This fixes an index-misalignment bug that could cause spurious achievement triggers when a dynamic cache insert/prune shifted list positions before the FPGA caught up.
- Save I/O guard: achievement evaluation is now suspended for 700ms after any save I/O (achievements_notify_save_io), preventing false triggers on consoles where the save path shares hardware with the RA read path (e.g. SNES BSRAM Port B - Super Mario RPG bugfix).
- Per-console re-prime tuning: most consoles call rc_client_reset() around bootstrap/cache-activation collection to avoid 0→real-value false triggers; NeoGeo and PSX use a boot_zero flag instead, since their multi-pass pointer-resolution re-activations run on real values and a reset would discard legitimate hit-count progress.
- TurboGrafx16: also adds a proper hardcore FPGA signal (status[39]) alongside the legacy cheats toggle. 
- README: documents all of the above, adds a Hardcore support column and Saturn/Atari 7800 rows to the console table, and fixes a stale Famicom Disk System console ID (91→81).