### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This is a fork of the official [MiSTer Main binary](https://github.com/MiSTer-de
 
 | Core | Console ID | Hardcore | Modified Core Repo |
 |------|-----------|----------|--------------------|
-| NES | 7 | ✅ Officially Supported | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
-| Famicom Disk System (via NES core) | 81 | ✅ Officially Supported | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
-| SNES (incl. SA-1 / SuperFX) | 3 | ✅ Officially Supported | [odelot/SNES_MiSTer](https://github.com/odelot/SNES_MiSTer) |
-| Genesis / Mega Drive | 1 | ✅ Officially Supported | [odelot/MegaDrive_MiSTer](https://github.com/odelot/MegaDrive_MiSTer) |
-| N64 | 2 | ✅ Officially Supported | [odelot/N64_MiSTer](https://github.com/odelot/N64_MiSTer) |
-| PSX | 12 | ✅ Officially Supported | [odelot/PSX_MiSTer](https://github.com/odelot/PSX_MiSTer) |
+| NES | 7 | ✅ Supported | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
+| Famicom Disk System (via NES core) | 81 | ✅ Supported | [odelot/NES_MiSTer](https://github.com/odelot/NES_MiSTer) |
+| SNES (incl. SA-1 / SuperFX) | 3 | ✅ Supported | [odelot/SNES_MiSTer](https://github.com/odelot/SNES_MiSTer) |
+| Genesis / Mega Drive | 1 | ✅ Supported | [odelot/MegaDrive_MiSTer](https://github.com/odelot/MegaDrive_MiSTer) |
+| N64 | 2 | ✅ Supported | [odelot/N64_MiSTer](https://github.com/odelot/N64_MiSTer) |
+| PSX | 12 | ✅ Supported | [odelot/PSX_MiSTer](https://github.com/odelot/PSX_MiSTer) |
+| Gameboy / Gameboy Color | 4 / 6 | ✅ Supported | [odelot/Gameboy_MiSTer](https://github.com/odelot/Gameboy_MiSTer) |
 | Master System / Game Gear | 11 / 15 | 🔧 wired, in validation | [odelot/SMS_MiSTer](https://github.com/odelot/SMS_MiSTer) |
-| Gameboy / Gameboy Color | 4 / 6 | 🔧 wired, in validation | [odelot/Gameboy_MiSTer](https://github.com/odelot/Gameboy_MiSTer) |
 | GBA (Game Boy Advance) | 5 | 🔧 wired, in validation | [odelot/GBA_MiSTer](https://github.com/odelot/GBA_MiSTer) |
 | Mega CD / Sega CD | 9 | 🔧 wired, in validation | [odelot/MegaCD_MiSTer](https://github.com/odelot/MegaCD_MiSTer) |
 | TurboGrafx-16 / PC Engine (incl. CD) | 8 / 76 | 🔧 wired, in validation | [odelot/TurboGrafx16_MiSTer](https://github.com/odelot/TurboGrafx16_MiSTer) |


### PR DESCRIPTION
- Added “Gameboy / Gameboy Color” to Hardcore Supported
- Re-ordered “Gameboy / Gameboy Color” in-line with Hardcore Supported cores
- Clarified less verbose “Supported” for Hardcore column